### PR TITLE
fix!(std-wrap): refactor std.wrap() and linker proxy

### DIFF
--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=3887c332960840a5243ffc825b1c4446c47ad211#3887c332960840a5243ffc825b1c4446c47ad211"
+source = "git+https://github.com/tangramdotdev/tangram?rev=9cebbf75e1ce966c555fcef565b822e3b85b4a68#9cebbf75e1ce966c555fcef565b822e3b85b4a68"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -1659,7 +1659,7 @@ dependencies = [
 [[package]]
 name = "tangram_error"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=3887c332960840a5243ffc825b1c4446c47ad211#3887c332960840a5243ffc825b1c4446c47ad211"
+source = "git+https://github.com/tangramdotdev/tangram?rev=9cebbf75e1ce966c555fcef565b822e3b85b4a68#9cebbf75e1ce966c555fcef565b822e3b85b4a68"
 dependencies = [
  "serde",
  "thiserror",

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -808,9 +808,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f9214f3e703236b221f1a9cd88ec8b4adfa5296de01ab96216361f4692f56"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1547,6 +1547,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,7 +1659,6 @@ name = "tangram_env"
 version = "0.0.0"
 dependencies = [
  "clap",
- "heck",
  "serde",
 ]
 
@@ -1676,11 +1681,12 @@ dependencies = [
  "serde",
  "serde_json",
  "tangram_client",
+ "tangram_error",
  "tangram_wrapper",
- "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "twox-hash",
  "xattr",
 ]
 
@@ -1689,17 +1695,14 @@ name = "tangram_wrapper"
 version = "0.0.0"
 dependencies = [
  "byteorder",
- "fnv",
- "heck",
  "itertools",
  "libc",
- "num",
  "serde",
  "serde_json",
  "tangram_client",
- "tempfile",
  "tracing",
  "tracing-subscriber",
+ "twox-hash",
  "xattr",
 ]
 
@@ -1729,18 +1732,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1969,6 +1972,17 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "rand",
+ "static_assertions",
+]
 
 [[package]]
 name = "typenum"

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -1547,12 +1547,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +1669,7 @@ dependencies = [
 name = "tangram_linker"
 version = "0.0.0"
 dependencies = [
+ "fnv",
  "futures",
  "goblin",
  "itertools",
@@ -1686,7 +1681,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "twox-hash",
  "xattr",
 ]
 
@@ -1695,6 +1689,7 @@ name = "tangram_wrapper"
 version = "0.0.0"
 dependencies = [
  "byteorder",
+ "fnv",
  "itertools",
  "libc",
  "serde",
@@ -1702,7 +1697,6 @@ dependencies = [
  "tangram_client",
  "tracing",
  "tracing-subscriber",
- "twox-hash",
  "xattr",
 ]
 
@@ -1972,17 +1966,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "rand",
- "static_assertions",
-]
 
 [[package]]
 name = "typenum"

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=9cebbf75e1ce966c555fcef565b822e3b85b4a68#9cebbf75e1ce966c555fcef565b822e3b85b4a68"
+source = "git+https://github.com/tangramdotdev/tangram?rev=3cac07e49d80d0a571184be17b17f4daec32d566#3cac07e49d80d0a571184be17b17f4daec32d566"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -1659,7 +1659,7 @@ dependencies = [
 [[package]]
 name = "tangram_error"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=9cebbf75e1ce966c555fcef565b822e3b85b4a68#9cebbf75e1ce966c555fcef565b822e3b85b4a68"
+source = "git+https://github.com/tangramdotdev/tangram?rev=3cac07e49d80d0a571184be17b17f4daec32d566#3cac07e49d80d0a571184be17b17f4daec32d566"
 dependencies = [
  "serde",
  "thiserror",

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=e37efd58faedfb5f012aad932907ab26a2a5dcbb#e37efd58faedfb5f012aad932907ab26a2a5dcbb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=3887c332960840a5243ffc825b1c4446c47ad211#3887c332960840a5243ffc825b1c4446c47ad211"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -1659,7 +1659,7 @@ dependencies = [
 [[package]]
 name = "tangram_error"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=e37efd58faedfb5f012aad932907ab26a2a5dcbb#e37efd58faedfb5f012aad932907ab26a2a5dcbb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=3887c332960840a5243ffc825b1c4446c47ad211#3887c332960840a5243ffc825b1c4446c47ad211"
 dependencies = [
  "serde",
  "thiserror",

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=e0a36420ea2529904795e4b42250036cd26f71dc#e0a36420ea2529904795e4b42250036cd26f71dc"
+source = "git+https://github.com/tangramdotdev/tangram?rev=e37efd58faedfb5f012aad932907ab26a2a5dcbb#e37efd58faedfb5f012aad932907ab26a2a5dcbb"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -1659,7 +1659,7 @@ dependencies = [
 [[package]]
 name = "tangram_error"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=e0a36420ea2529904795e4b42250036cd26f71dc#e0a36420ea2529904795e4b42250036cd26f71dc"
+source = "git+https://github.com/tangramdotdev/tangram?rev=e37efd58faedfb5f012aad932907ab26a2a5dcbb#e37efd58faedfb5f012aad932907ab26a2a5dcbb"
 dependencies = [
  "serde",
  "thiserror",

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -23,8 +23,8 @@ itertools = "0.12"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "e37efd58faedfb5f012aad932907ab26a2a5dcbb" }
-tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "e37efd58faedfb5f012aad932907ab26a2a5dcbb" }
+tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "3887c332960840a5243ffc825b1c4446c47ad211" }
+tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "3887c332960840a5243ffc825b1c4446c47ad211" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -23,8 +23,8 @@ itertools = "0.12"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "9cebbf75e1ce966c555fcef565b822e3b85b4a68" }
-tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "9cebbf75e1ce966c555fcef565b822e3b85b4a68" }
+tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "3cac07e49d80d0a571184be17b17f4daec32d566" }
+tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "3cac07e49d80d0a571184be17b17f4daec32d566" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -23,8 +23,8 @@ itertools = "0.12"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "3887c332960840a5243ffc825b1c4446c47ad211" }
-tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "3887c332960840a5243ffc825b1c4446c47ad211" }
+tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "9cebbf75e1ce966c555fcef565b822e3b85b4a68" }
+tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "9cebbf75e1ce966c555fcef565b822e3b85b4a68" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -16,6 +16,7 @@ missing_safety_doc = "allow"
 [workspace.dependencies]
 byteorder = "1"
 clap = { version = "4.2.1", features = ["derive"] }
+fnv = "1"
 futures = "0.3"
 goblin = "0.7"
 itertools = "0.12"
@@ -28,7 +29,6 @@ tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "e0a36
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-twox-hash = "1"
 xattr = "1"
 
 tangram_env = { path = "packages/env" }

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -21,7 +21,6 @@ futures = "0.3"
 goblin = "0.7"
 itertools = "0.12"
 libc = "0.2"
-num = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "e0a36420ea2529904795e4b42250036cd26f71dc" }

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -15,25 +15,20 @@ missing_safety_doc = "allow"
 
 [workspace.dependencies]
 byteorder = "1"
-bytes = "1"
 clap = { version = "4.2.1", features = ["derive"] }
-fnv = "1"
 futures = "0.3"
 goblin = "0.7"
-heck = "0.4"
-hex = { version = "0.4", features = ["serde"] }
 itertools = "0.12"
 libc = "0.2"
 num = "0.4"
-regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "e0a36420ea2529904795e4b42250036cd26f71dc" }
 tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "e0a36420ea2529904795e4b42250036cd26f71dc" }
-tempfile = "3"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+twox-hash = "1"
 xattr = "1"
 
 tangram_env = { path = "packages/env" }

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -23,8 +23,8 @@ itertools = "0.12"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "e0a36420ea2529904795e4b42250036cd26f71dc" }
-tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "e0a36420ea2529904795e4b42250036cd26f71dc" }
+tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "e37efd58faedfb5f012aad932907ab26a2a5dcbb" }
+tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "e37efd58faedfb5f012aad932907ab26a2a5dcbb" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/packages/std/autotools.tg
+++ b/packages/std/autotools.tg
@@ -71,48 +71,48 @@ export let target = async (...args: tg.Args<Arg>) => {
 		} else if (typeof arg === "object") {
 			let object: tg.MutationMap<Apply> = {};
 			let phasesArgs: Array<std.phases.Arg> = [];
-			if ("doCheck" in arg) {
+			if (arg.doCheck !== undefined) {
 				object.doCheck = arg.doCheck;
 			}
-			if ("env" in arg && arg.env !== undefined) {
+			if (arg.env !== undefined) {
 				phasesArgs.push({ env: arg.env });
 			}
-			if ("host" in arg) {
+			if (arg.host !== undefined) {
 				object.host = tg.Mutation.is(arg.host)
 					? arg.host
 					: std.triple(arg.host);
 			}
-			if ("opt" in arg) {
+			if (arg.opt !== undefined) {
 				object.opt = arg.opt;
 			}
-			if ("parallel" in arg) {
+			if (arg.parallel !== undefined) {
 				object.parallel = arg.parallel;
 			}
-			if ("prefixArg" in arg) {
+			if (arg.prefixArg !== undefined) {
 				object.prefixArg = arg.prefixArg;
 			}
-			if ("prefixPath" in arg) {
+			if (arg.prefixPath !== undefined) {
 				object.prefixPath = arg.prefixPath;
 			}
-			if ("source" in arg) {
+			if (arg.source !== undefined) {
 				object.source = arg.source;
 			}
-			if ("phases" in arg && arg.phases !== undefined) {
+			if (arg.phases !== undefined) {
 				if (tg.Mutation.is(arg.phases)) {
 					object.phases = arg.phases;
 				} else {
 					phasesArgs.push(arg.phases);
 				}
 			}
-			if ("sdk" in arg) {
+			if (arg.sdk !== undefined) {
 				object.sdkArgs = tg.Mutation.is(arg.sdk)
 					? arg.sdk
 					: await tg.Mutation.arrayAppend<std.sdk.Arg>(arg.sdk);
 			}
-			if ("stripExecutables" in arg) {
+			if (arg.stripExecutables !== undefined) {
 				object.stripExecutables = arg.stripExecutables;
 			}
-			if ("target" in arg) {
+			if (arg.target !== undefined) {
 				object.target = tg.Mutation.is(arg.target)
 					? arg.target
 					: std.triple(arg.target);

--- a/packages/std/bootstrap.tg
+++ b/packages/std/bootstrap.tg
@@ -13,7 +13,7 @@ export type Arg = {
 	host?: Triple.Arg;
 };
 
-export let bootstrap = tg.target(async (arg?: Arg) => {
+export let bootstrap = async (arg?: Arg) => {
 	let { component, host } = await configure(arg);
 	let hostString = host.toString();
 	if (tg.System.os(host) === "darwin") {
@@ -35,7 +35,7 @@ export let bootstrap = tg.target(async (arg?: Arg) => {
 		return tg.directory(dirObject);
 	}
 	return remoteComponent(requestedComponentName);
-});
+};
 
 export default bootstrap;
 
@@ -209,9 +209,9 @@ export let remoteComponent = tg.target(async (componentName: string) => {
 });
 
 /** "Polyfill" for `std.Triple.hostSystem` without depending on `std`. */
-export let hostSystem = tg.target(async () => {
+export let hostSystem = async () => {
 	return (await tg.current.env())["TANGRAM_HOST"] as tg.System;
-});
+};
 
 /** Enumerate the full set of components for a host. */
 export let componentList = async (arg?: Arg) => {
@@ -244,7 +244,7 @@ export let componentList = async (arg?: Arg) => {
 };
 
 /** A build environment providing the bootstrap tools, with no proxying supported. */
-export let toolchainEnv = tg.target(async (arg?: Triple.HostArg) => {
+export let toolchainEnv = async (arg?: Triple.HostArg) => {
 	let host = await Triple.host(arg);
 	let os = host.os;
 	let shell = await dash({ host });
@@ -266,12 +266,12 @@ export let toolchainEnv = tg.target(async (arg?: Triple.HostArg) => {
 		};
 	}
 	return env;
-});
+};
 
 /** The `toolchainEnv` combined with a statically-linked `make` binary. */
-export let buildEnv = tg.target(async (arg?: Triple.HostArg) => {
+export let buildEnv = async (arg?: Triple.HostArg) => {
 	return env.object(toolchainEnv(arg), make(arg));
-});
+};
 
 export let test = tg.target(async () => {
 	let host = await hostSystem();

--- a/packages/std/bootstrap/rust.tg
+++ b/packages/std/bootstrap/rust.tg
@@ -1,6 +1,6 @@
 import * as bootstrap from "../bootstrap.tg";
 import { caCertificates } from "../certificates.tg";
-import { env } from "../env.tg";
+import { env as stdEnv } from "../env.tg";
 import * as phases from "../phases.tg";
 import { download } from "../tangram.tg";
 import { Triple, triple } from "../triple.tg";
@@ -159,7 +159,7 @@ export let build = tg.target(async (arg: Arg) => {
 
 	// Set up common environemnt.
 	let certFile = await tg`${caCertificates()}/cacert.pem`;
-	let env: tg.Unresolved<env.Arg> = [
+	let env: tg.Unresolved<stdEnv.Arg> = [
 		bootstrap.toolchainEnv(host),
 		rustToolchain,
 		{
@@ -232,14 +232,20 @@ export let build = tg.target(async (arg: Arg) => {
 	};
 
 	// Build and return.
-	return tg.Directory.expect(
-		await phases.build({
-			env,
-			phases: { prepare, build, install },
-			target: {
-				host: system,
-				checksum: "unsafe",
-			},
-		}),
-	);
+	let envObj = await stdEnv.object(env);
+	console.log("envObj", envObj);
+	for (let [key, val] of Object.entries(envObj as Record<string, unknown>)) {
+		console.log(`${key}=${val}`);
+	}
+
+		return tg.Directory.expect(
+			await phases.build({
+				env,
+				phases: { prepare, build, install },
+				target: {
+					host: system,
+					checksum: "unsafe",
+				},
+			}),
+		);
 });

--- a/packages/std/bootstrap/rust.tg
+++ b/packages/std/bootstrap/rust.tg
@@ -232,20 +232,14 @@ export let build = tg.target(async (arg: Arg) => {
 	};
 
 	// Build and return.
-	let envObj = await stdEnv.object(env);
-	console.log("envObj", envObj);
-	for (let [key, val] of Object.entries(envObj as Record<string, unknown>)) {
-		console.log(`${key}=${val}`);
-	}
-
-		return tg.Directory.expect(
-			await phases.build({
-				env,
-				phases: { prepare, build, install },
-				target: {
-					host: system,
-					checksum: "unsafe",
-				},
-			}),
-		);
+	return tg.Directory.expect(
+		await phases.build({
+			env,
+			phases: { prepare, build, install },
+			target: {
+				host: system,
+				checksum: "unsafe",
+			},
+		}),
+	);
 });

--- a/packages/std/container.tg
+++ b/packages/std/container.tg
@@ -223,38 +223,38 @@ export let layer = tg.target(
 
 /** The JSON configuration schema for a container image. This format is shared by both the OCI container image spec and the Docker image spec. */
 export type ImageConfigV1 = Platform & {
-	config?: ImageExecutionConfig | null;
+	config?: ImageExecutionConfig;
 	rootfs: {
 		type: "layers";
 		diff_ids: Array<string>;
 	};
-	history?: Array<ImageHistory> | null;
+	history?: Array<ImageHistory>;
 };
 
 /** The execution configuration. */
 export type ImageExecutionConfig = {
-	User?: string | null;
-	ExposedPorts?: Record<string, {}> | null;
-	Env?: Array<string> | null;
-	Entrypoint?: Array<string> | null;
-	Cmd?: Array<string> | null;
-	Volumes?: Record<string, {}> | null;
-	WorkingDir?: string | null;
-	Labels?: Record<string, string> | null;
-	StopSignal?: string | null;
-	ArgsEscaped?: boolean | null;
-	Memory?: number | null;
-	MemorySwap?: number | null;
-	CpuShares?: number | null;
-	Healthcheck?: Record<string, unknown> | null;
+	User?: string;
+	ExposedPorts?: Record<string, {}>;
+	Env?: Array<string>;
+	Entrypoint?: Array<string>;
+	Cmd?: Array<string>;
+	Volumes?: Record<string, {}>;
+	WorkingDir?: string;
+	Labels?: Record<string, string>;
+	StopSignal?: string;
+	ArgsEscaped?: boolean;
+	Memory?: number;
+	MemorySwap?: number;
+	CpuShares?: number;
+	Healthcheck?: Record<string, unknown>;
 };
 
 export type ImageHistory = {
-	created?: string | null;
-	author?: string | null;
-	created_by?: string | null;
-	comment?: string | null;
-	empty_layer?: boolean | null;
+	created?: string;
+	author?: string;
+	created_by?: string;
+	comment?: string;
+	empty_layer?: boolean;
 };
 
 export default container;

--- a/packages/std/env.tg
+++ b/packages/std/env.tg
@@ -116,10 +116,12 @@ export namespace env {
 				}
 			},
 		);
+		console.log("env", env_);
 		let manifestEnv = await wrap.mergeEnvs(...(env_ ?? []));
 		if (!manifestEnv) {
 			return undefined;
 		}
+		console.log("manifestEnv", manifestEnv);
 		let ret: Record<string, tg.MaybeMutation<tg.Template.Arg>> = {};
 		for await (let [key, value] of wrap.envVars(manifestEnv)) {
 			ret[key] = value;

--- a/packages/std/env.tg
+++ b/packages/std/env.tg
@@ -83,7 +83,7 @@ export namespace env {
 					// Try to read the manifest from it.
 					let existingManifest = await wrap.Manifest.read(file);
 					if (existingManifest && existingManifest.env) {
-						if (existingManifest.env.kind === "map") {
+						if (existingManifest.env.kind === "set") {
 							return {
 								env: await tg.Mutation.arrayAppend<wrap.Manifest.Env>(
 									existingManifest.env,
@@ -108,15 +108,15 @@ export namespace env {
 					return {
 						env: await tg.Mutation.arrayAppend<wrap.Manifest.Env>(
 							(await wrap.manifestEnvFromArg(arg)) ?? {
-								kind: "map",
-								value: {},
+								kind: "set",
+								value: { kind: "map", value: {} },
 							},
 						),
 					};
 				}
 			},
 		);
-		let manifestEnv = wrap.mergeEnvs(...(env_ ?? []));
+		let manifestEnv = await wrap.mergeEnvs(...(env_ ?? []));
 		if (!manifestEnv) {
 			return undefined;
 		}

--- a/packages/std/env.tg
+++ b/packages/std/env.tg
@@ -118,9 +118,7 @@ export namespace env {
 				}
 			},
 		);
-		console.log("pre-merge", env_);
 		let env = await wrap.mergeEnvs(...(env_ ?? []));
-		console.log("post-merge", env);
 		if (env === undefined) {
 			return undefined;
 		} else if (env.kind === "unset") {
@@ -128,9 +126,7 @@ export namespace env {
 		} else {
 			let ret: tg.MutationMap<Record<string, tg.Template.Arg>> = {};
 			let map = await wrap.envMapFromManifestEnv(env);
-			console.log("map", map);
 			for await (let [key, value] of wrap.envVars(map)) {
-				console.log("key", key, "value", value);
 				ret[key] = value;
 			}
 			return ret;

--- a/packages/std/env.tg
+++ b/packages/std/env.tg
@@ -203,76 +203,76 @@ export namespace env {
 	};
 
 	/** Retrieve the artifact a key's template value refers to. Throws if cannot be found. */
-	export let getArtifactByKey = tg.target(
-		async (arg: ArtifactByKeyArg): Promise<tg.Artifact> => {
-			let template = await tryGetKey(arg);
-			tg.assert(template, `Unable to find key ${arg.key} in this env.`);
-			// There are two options. Either the template points directly to an artifact with a single reference, or it points to a directory with a subpath. Anything else, we reject.
-			let components = template.components;
-			switch (components.length) {
-				case 1: {
-					let [artifact] = components;
-					if (artifact && typeof artifact !== "string") {
-						return artifact;
-					}
-				}
-				case 2: {
-					let [directory, subpath] = components;
-					if (
-						directory &&
-						typeof directory !== "string" &&
-						tg.Directory.is(directory) &&
-						subpath &&
-						typeof subpath === "string"
-					) {
-						// Slice off the leading `/`.
-						return await directory.get(subpath.slice(1));
-					}
-				}
-				default: {
-					throw new Error(
-						`Could not resolve artifact from key ${arg.key}. Value: ${template}.`,
-					);
+	export let getArtifactByKey = async (
+		arg: ArtifactByKeyArg,
+	): Promise<tg.Artifact> => {
+		let template = await tryGetKey(arg);
+		tg.assert(template, `Unable to find key ${arg.key} in this env.`);
+		// There are two options. Either the template points directly to an artifact with a single reference, or it points to a directory with a subpath. Anything else, we reject.
+		let components = template.components;
+		switch (components.length) {
+			case 1: {
+				let [artifact] = components;
+				if (artifact && typeof artifact !== "string") {
+					return artifact;
 				}
 			}
-		},
-	);
+			case 2: {
+				let [directory, subpath] = components;
+				if (
+					directory &&
+					typeof directory !== "string" &&
+					tg.Directory.is(directory) &&
+					subpath &&
+					typeof subpath === "string"
+				) {
+					// Slice off the leading `/`.
+					return await directory.get(subpath.slice(1));
+				}
+			}
+			default: {
+				throw new Error(
+					`Could not resolve artifact from key ${arg.key}. Value: ${template}.`,
+				);
+			}
+		}
+	};
 
 	/** Retrieve the artifact a key's template value refers to. Returns undefined if cannot be found. */
-	export let tryGetArtifactByKey = tg.target(
-		async (arg: ArtifactByKeyArg): Promise<tg.Artifact | undefined> => {
-			let template = await tryGetKey(arg);
-			if (!template) {
+	export let tryGetArtifactByKey = async (
+		arg: ArtifactByKeyArg,
+	): Promise<tg.Artifact | undefined> => {
+		let template = await tryGetKey(arg);
+		if (!template) {
+			return undefined;
+		}
+		// There are two options. Either the template points directly to an artifact with a single reference, or it points to a directory with a subpath. Anything else, we reject.
+		let components = template.components;
+		switch (components.length) {
+			case 1: {
+				let [artifact] = components;
+				if (artifact && typeof artifact !== "string") {
+					return artifact;
+				}
+			}
+			case 2: {
+				let [directory, subpath] = components;
+				if (
+					directory &&
+					typeof directory !== "string" &&
+					tg.Directory.is(directory) &&
+					subpath &&
+					typeof subpath === "string"
+				) {
+					// Slice off the leading `/`.
+					return await directory.get(subpath.slice(1));
+				}
+			}
+			default: {
 				return undefined;
 			}
-			// There are two options. Either the template points directly to an artifact with a single reference, or it points to a directory with a subpath. Anything else, we reject.
-			let components = template.components;
-			switch (components.length) {
-				case 1: {
-					let [artifact] = components;
-					if (artifact && typeof artifact !== "string") {
-						return artifact;
-					}
-				}
-				case 2: {
-					let [directory, subpath] = components;
-					if (
-						directory &&
-						typeof directory !== "string" &&
-						tg.Directory.is(directory) &&
-						subpath &&
-						typeof subpath === "string"
-					) {
-						// Slice off the leading `/`.
-						return await directory.get(subpath.slice(1));
-					}
-				}
-				default: {
-					return undefined;
-				}
-			}
-		},
-	);
+		}
+	};
 
 	type GetKeyArg = {
 		env: env.Arg;
@@ -280,22 +280,20 @@ export namespace env {
 	};
 
 	/** Retrieve the value of a key. If not present, throw an error. */
-	export let getKey = tg.target(
-		async (arg: GetKeyArg): Promise<tg.Template> => {
-			let { env, key } = arg;
-			let manifest = await wrap.manifestEnvFromArg(env);
-			if (!manifest) {
-				throw new Error(`This env does not provide a manifest.`);
+	export let getKey = async (arg: GetKeyArg): Promise<tg.Template> => {
+		let { env, key } = arg;
+		let manifest = await wrap.manifestEnvFromArg(env);
+		if (!manifest) {
+			throw new Error(`This env does not provide a manifest.`);
+		}
+		for await (let [foundKey, value] of wrap.envVars(manifest)) {
+			if (foundKey === key) {
+				tg.assert(value, `Found key ${key} but it was undefined.`);
+				return value;
 			}
-			for await (let [foundKey, value] of wrap.envVars(manifest)) {
-				if (foundKey === key) {
-					tg.assert(value, `Found key ${key} but it was undefined.`);
-					return value;
-				}
-			}
-			throw new Error(`Could not find key ${key} in this env.`);
-		},
-	);
+		}
+		throw new Error(`Could not find key ${key} in this env.`);
+	};
 
 	/** Retrieve the value of a key. If not present, return `undefined`. */
 	export async function tryGetKey(
@@ -328,58 +326,58 @@ export namespace env {
 	}
 
 	/** Return the value of `SHELL` if present. If not present, return the file providing `sh` in `PATH`. If not present, throw an error. */
-	export let getShellExecutable = tg.target(
-		async (envArg: env.Arg): Promise<tg.File | tg.Symlink> => {
-			// First, check if "SHELL" is set and points to an executable.
-			let shellArtifact = await env.tryGetArtifactByKey({
-				env: envArg,
-				key: "SHELL",
-			});
-			if (shellArtifact) {
-				tg.assert(
-					tg.File.is(shellArtifact) || tg.Symlink.is(shellArtifact),
-					`Template for shell did not point to a file or symlink.`,
-				);
-				return shellArtifact;
-			}
+	export let getShellExecutable = async (
+		envArg: env.Arg,
+	): Promise<tg.File | tg.Symlink> => {
+		// First, check if "SHELL" is set and points to an executable.
+		let shellArtifact = await env.tryGetArtifactByKey({
+			env: envArg,
+			key: "SHELL",
+		});
+		if (shellArtifact) {
+			tg.assert(
+				tg.File.is(shellArtifact) || tg.Symlink.is(shellArtifact),
+				`Template for shell did not point to a file or symlink.`,
+			);
+			return shellArtifact;
+		}
 
-			// If SHELL isn't set, see if `sh` is in path. Return that file if so.
-			let shExecutable = await tryWhich({ env: envArg, name: "sh" });
-			if (shExecutable) {
-				return shExecutable;
-			}
+		// If SHELL isn't set, see if `sh` is in path. Return that file if so.
+		let shExecutable = await tryWhich({ env: envArg, name: "sh" });
+		if (shExecutable) {
+			return shExecutable;
+		}
 
-			// If not, we failed to find a shell.
-			throw new Error(`This env does not provide a shell.`);
-		},
-	);
+		// If not, we failed to find a shell.
+		throw new Error(`This env does not provide a shell.`);
+	};
 
 	/** Return the value of `SHELL` if present. If not present, return the file providing `sh` in `PATH`. If not present, return `undefined`. */
-	export let tryGetShellExecutable = tg.target(
-		async (envArg: env.Arg): Promise<tg.File | tg.Symlink | undefined> => {
-			// First, check if "SHELL" is set and points to an executable.
-			let shellArtifact = await tryGetArtifactByKey({
-				env: envArg,
-				key: "SHELL",
-			});
-			if (shellArtifact) {
-				tg.assert(
-					tg.File.is(shellArtifact) || tg.Symlink.is(shellArtifact),
-					`Template for shell did not point to a file or symlink.`,
-				);
-				return shellArtifact;
-			}
+	export let tryGetShellExecutable = async (
+		envArg: env.Arg,
+	): Promise<tg.File | tg.Symlink | undefined> => {
+		// First, check if "SHELL" is set and points to an executable.
+		let shellArtifact = await tryGetArtifactByKey({
+			env: envArg,
+			key: "SHELL",
+		});
+		if (shellArtifact) {
+			tg.assert(
+				tg.File.is(shellArtifact) || tg.Symlink.is(shellArtifact),
+				`Template for shell did not point to a file or symlink.`,
+			);
+			return shellArtifact;
+		}
 
-			// If SHELL isn't set, see if `sh` is in path. Return that file if so.
-			let shExecutable = await tryWhich({ env: envArg, name: "sh" });
-			if (shExecutable) {
-				return shExecutable;
-			}
+		// If SHELL isn't set, see if `sh` is in path. Return that file if so.
+		let shExecutable = await tryWhich({ env: envArg, name: "sh" });
+		if (shExecutable) {
+			return shExecutable;
+		}
 
-			// If not, we failed to find a shell.
-			return undefined;
-		},
-	);
+		// If not, we failed to find a shell.
+		return undefined;
+	};
 
 	type ProvidesArg = {
 		env: env.Arg;
@@ -388,7 +386,7 @@ export namespace env {
 	};
 
 	/** Assert the env provides a specific executable in PATH. */
-	export let assertProvides = tg.target(async (arg: ProvidesArg) => {
+	export let assertProvides = async (arg: ProvidesArg) => {
 		let { name, names: names_ } = arg;
 		let names = names_ ?? [];
 		if (name) {
@@ -406,73 +404,68 @@ export namespace env {
 			}),
 		);
 		return true;
-	});
+	};
 
 	/** Check if the env provides a specific executable in PATH. */
-	export let provides = tg.target(
-		async (arg: ProvidesArg): Promise<boolean> => {
-			let { name, names: names_ } = arg;
-			let names = names_ ?? [];
-			if (name) {
-				names.push(name);
-			}
+	export let provides = async (arg: ProvidesArg): Promise<boolean> => {
+		let { name, names: names_ } = arg;
+		let names = names_ ?? [];
+		if (name) {
+			names.push(name);
+		}
 
-			let results = await Promise.all(
-				names.map(async (name) => {
-					for await (let [binName, _file] of env.binsInPath(arg)) {
-						if (binName === name) {
-							return true;
-						}
+		let results = await Promise.all(
+			names.map(async (name) => {
+				for await (let [binName, _file] of env.binsInPath(arg)) {
+					if (binName === name) {
+						return true;
 					}
-					return false;
-				}),
-			);
-			return results.every((el) => el);
-		},
-	);
-
+				}
+				return false;
+			}),
+		);
+		return results.every((el) => el);
+	};
 	type WhichArg = {
 		env: env.Arg;
 		name: string;
 	};
 
 	/** Return the file for a given executable in an env's PATH. Throws an error if not present. */
-	export let which = tg.target(
-		async (arg: WhichArg): Promise<tg.File | tg.Symlink> => {
-			let file = await tryWhich(arg);
-			tg.assert(file, `This env does not provide ${arg.name} in $PATH`);
-			return file;
-		},
-	);
+	export let which = async (arg: WhichArg): Promise<tg.File | tg.Symlink> => {
+		let file = await tryWhich(arg);
+		tg.assert(file, `This env does not provide ${arg.name} in $PATH`);
+		return file;
+	};
 
 	/** Return the artifact providing a given binary by name. */
-	export let whichArtifact = tg.target(
-		async (arg: WhichArg): Promise<tg.Directory | undefined> => {
-			for await (let [parentDir, binDir] of env.dirsInVar({
-				env: arg.env,
-				key: "PATH",
-			})) {
-				let artifact = await binDir.tryGet(arg.name);
-				if (artifact) {
-					return parentDir;
-				}
+	export let whichArtifact = async (
+		arg: WhichArg,
+	): Promise<tg.Directory | undefined> => {
+		for await (let [parentDir, binDir] of env.dirsInVar({
+			env: arg.env,
+			key: "PATH",
+		})) {
+			let artifact = await binDir.tryGet(arg.name);
+			if (artifact) {
+				return parentDir;
 			}
-		},
-	);
+		}
+	};
 
 	/** Return the file for a given executable in an env's PATH. Returns undefined if not present. */
-	export let tryWhich = tg.target(
-		async (arg: WhichArg): Promise<tg.File | tg.Symlink | undefined> => {
-			for await (let [name, executable] of env.binsInPath(arg)) {
-				if (name === arg.name) {
-					if (tg.Symlink.is(executable) || tg.File.is(executable)) {
-						return executable;
-					}
+	export let tryWhich = async (
+		arg: WhichArg,
+	): Promise<tg.File | tg.Symlink | undefined> => {
+		for await (let [name, executable] of env.binsInPath(arg)) {
+			if (name === arg.name) {
+				if (tg.Symlink.is(executable) || tg.File.is(executable)) {
+					return executable;
 				}
 			}
-			return undefined;
-		},
-	);
+		}
+		return undefined;
+	};
 }
 
 let isBootstrapModeArg = (arg: unknown): arg is { bootstrapMode: boolean } => {

--- a/packages/std/env.tg
+++ b/packages/std/env.tg
@@ -105,6 +105,7 @@ export namespace env {
 						return {};
 					}
 				} else {
+					console.log("pre-manifest-env", arg);
 					let manifestEnv = await wrap.manifestEnvFromArg(arg);
 					if (manifestEnv) {
 						return {
@@ -118,7 +119,9 @@ export namespace env {
 				}
 			},
 		);
+		console.log("env pre-merge", env_);
 		let env = await wrap.mergeEnvs(...(env_ ?? []));
+		console.log("env post-merge", env);
 		if (env === undefined) {
 			return undefined;
 		} else if (env.kind === "unset") {

--- a/packages/std/env.tg
+++ b/packages/std/env.tg
@@ -105,7 +105,6 @@ export namespace env {
 						return {};
 					}
 				} else {
-					console.log("pre-manifest-env", arg);
 					let manifestEnv = await wrap.manifestEnvFromArg(arg);
 					if (manifestEnv) {
 						return {
@@ -119,9 +118,9 @@ export namespace env {
 				}
 			},
 		);
-		console.log("env pre-merge", env_);
+		console.log("pre-merge", env_);
 		let env = await wrap.mergeEnvs(...(env_ ?? []));
-		console.log("env post-merge", env);
+		console.log("post-merge", env);
 		if (env === undefined) {
 			return undefined;
 		} else if (env.kind === "unset") {
@@ -129,7 +128,9 @@ export namespace env {
 		} else {
 			let ret: tg.MutationMap<Record<string, tg.Template.Arg>> = {};
 			let map = await wrap.envMapFromManifestEnv(env);
+			console.log("map", map);
 			for await (let [key, value] of wrap.envVars(map)) {
+				console.log("key", key, "value", value);
 				ret[key] = value;
 			}
 			return ret;

--- a/packages/std/env.tg
+++ b/packages/std/env.tg
@@ -61,7 +61,7 @@ export namespace env {
 		>
 	> => {
 		type Apply = {
-			env: Array<wrap.Manifest.Env>;
+			env: Array<wrap.Manifest.Mutation>;
 		};
 		let { env: env_ } = await tg.Args.apply<env.Arg, Apply>(
 			args,
@@ -85,7 +85,7 @@ export namespace env {
 					if (existingManifest && existingManifest.env) {
 						if (existingManifest.env.kind === "set") {
 							return {
-								env: await tg.Mutation.arrayAppend<wrap.Manifest.Env>(
+								env: await tg.Mutation.arrayAppend<wrap.Manifest.Mutation>(
 									existingManifest.env,
 								),
 							};
@@ -105,28 +105,32 @@ export namespace env {
 						return {};
 					}
 				} else {
-					return {
-						env: await tg.Mutation.arrayAppend<wrap.Manifest.Env>(
-							(await wrap.manifestEnvFromArg(arg)) ?? {
-								kind: "set",
-								value: { kind: "map", value: {} },
-							},
-						),
-					};
+					let manifestEnv = await wrap.manifestEnvFromArg(arg);
+					if (manifestEnv) {
+						return {
+							env: await tg.Mutation.arrayAppend<wrap.Manifest.Mutation>(
+								manifestEnv,
+							),
+						};
+					} else {
+						return {};
+					}
 				}
 			},
 		);
-		console.log("env", env_);
-		let manifestEnv = await wrap.mergeEnvs(...(env_ ?? []));
-		if (!manifestEnv) {
+		let env = await wrap.mergeEnvs(...(env_ ?? []));
+		if (env === undefined) {
 			return undefined;
+		} else if (env.kind === "unset") {
+			return tg.Mutation.unset();
+		} else {
+			let ret: tg.MutationMap<Record<string, tg.Template.Arg>> = {};
+			let map = await wrap.envMapFromManifestEnv(env);
+			for await (let [key, value] of wrap.envVars(map)) {
+				ret[key] = value;
+			}
+			return ret;
 		}
-		console.log("manifestEnv", manifestEnv);
-		let ret: Record<string, tg.MaybeMutation<tg.Template.Arg>> = {};
-		for await (let [key, value] of wrap.envVars(manifestEnv)) {
-			ret[key] = value;
-		}
-		return ret;
 	};
 
 	/////// Queries
@@ -288,7 +292,8 @@ export namespace env {
 		if (!manifest) {
 			throw new Error(`This env does not provide a manifest.`);
 		}
-		for await (let [foundKey, value] of wrap.envVars(manifest)) {
+		let map = await wrap.envMapFromManifestEnv(manifest);
+		for await (let [foundKey, value] of wrap.envVars(map)) {
 			if (foundKey === key) {
 				tg.assert(value, `Found key ${key} but it was undefined.`);
 				return value;
@@ -306,7 +311,8 @@ export namespace env {
 		if (!manifest) {
 			return undefined;
 		}
-		for await (let [foundKey, value] of wrap.envVars(manifest)) {
+		let map = await wrap.envMapFromManifestEnv(manifest);
+		for await (let [foundKey, value] of wrap.envVars(map)) {
 			if (foundKey === key) {
 				return value;
 			}
@@ -322,7 +328,8 @@ export namespace env {
 		if (!manifest) {
 			return undefined;
 		}
-		for await (let [key, value] of wrap.envVars(manifest)) {
+		let map = await wrap.envMapFromManifestEnv(manifest);
+		for await (let [key, value] of wrap.envVars(map)) {
 			yield [key, value];
 		}
 	}

--- a/packages/std/packages/env/Cargo.toml
+++ b/packages/std/packages/env/Cargo.toml
@@ -8,5 +8,4 @@ workspace = true
 
 [dependencies]
 clap = { workspace = true }
-heck = { workspace = true }
 serde = { workspace = true }

--- a/packages/std/packages/tgld/Cargo.toml
+++ b/packages/std/packages/tgld/Cargo.toml
@@ -13,9 +13,10 @@ itertools = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tangram_client = { workspace = true }
+tangram_error = { workspace = true }
 tangram_wrapper = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+twox-hash = { workspace = true }
 xattr = { workspace = true }

--- a/packages/std/packages/tgld/Cargo.toml
+++ b/packages/std/packages/tgld/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+fnv = { workspace = true }
 futures = { workspace = true }
 goblin = { workspace = true }
 itertools = { workspace = true }
@@ -18,5 +19,4 @@ tangram_wrapper = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-twox-hash = { workspace = true }
 xattr = { workspace = true }

--- a/packages/std/packages/tgld/src/main.rs
+++ b/packages/std/packages/tgld/src/main.rs
@@ -600,6 +600,7 @@ async fn template_to_resolved_symlink<F>(tg: &dyn tg::Handle, template: F) -> tg
 where
 	F: futures::Future<Output = tg::template::Data>,
 {
+	// FIXME - re-implement tryGet from the global, you need to walk the path.
 	match template.await.components.as_slice() {
 		[tg::template::component::Data::Artifact(id)] => tg::symlink::Data {
 			artifact: Some(id.clone()),

--- a/packages/std/packages/tgld/src/main.rs
+++ b/packages/std/packages/tgld/src/main.rs
@@ -8,7 +8,6 @@ use std::{
 use tangram_client as tg;
 use tangram_error::{return_error, Result, WrapErr};
 use tangram_wrapper::manifest::{self, Manifest};
-use tg::artifact;
 use tracing_subscriber::prelude::*;
 
 type Hasher = fnv::FnvBuildHasher;

--- a/packages/std/packages/wrapper/Cargo.toml
+++ b/packages/std/packages/wrapper/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 byteorder = { workspace = true }
+fnv = { workspace = true }
 itertools = { workspace = true }
 libc = { workspace = true }
 serde = { workspace = true }
@@ -15,5 +16,4 @@ serde_json = { workspace = true }
 tangram_client = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-twox-hash = { workspace = true }
 xattr = { workspace = true }

--- a/packages/std/packages/wrapper/Cargo.toml
+++ b/packages/std/packages/wrapper/Cargo.toml
@@ -8,15 +8,12 @@ workspace = true
 
 [dependencies]
 byteorder = { workspace = true }
-fnv = { workspace = true }
-heck = { workspace = true }
 itertools = { workspace = true }
 libc = { workspace = true }
-num = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tangram_client = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-tempfile = { workspace = true }
+twox-hash = { workspace = true }
 xattr = { workspace = true }

--- a/packages/std/packages/wrapper/src/main.rs
+++ b/packages/std/packages/wrapper/src/main.rs
@@ -370,8 +370,12 @@ fn apply_value_to_key(
 	value: &tg::value::Data,
 	artifacts_directories: &[impl AsRef<std::path::Path>],
 ) {
-	if let tg::value::Data::Mutation(mutation) = value {
-		apply_mutation_to_key(key, mutation, artifacts_directories);
+	if let tg::value::Data::Array(mutations) = value {
+		for mutation in mutations {
+			if let tg::value::Data::Mutation(mutation) = mutation {
+				apply_mutation_to_key(key, mutation, artifacts_directories);
+			}
+		}
 	} else {
 		std::env::set_var(key, render_value(value, artifacts_directories));
 	}

--- a/packages/std/packages/wrapper/src/main.rs
+++ b/packages/std/packages/wrapper/src/main.rs
@@ -376,6 +376,8 @@ fn apply_value_to_key(
 				apply_mutation_to_key(key, mutation, artifacts_directories);
 			}
 		}
+	} else if let tg::value::Data::Mutation(mutation) = value {
+		apply_mutation_to_key(key, mutation, artifacts_directories);
 	} else {
 		std::env::set_var(key, render_value(value, artifacts_directories));
 	}

--- a/packages/std/packages/wrapper/src/manifest.rs
+++ b/packages/std/packages/wrapper/src/manifest.rs
@@ -1,7 +1,7 @@
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use num::ToPrimitive;
 use std::{
-	collections::{BTreeMap, HashSet},
+	collections::HashSet,
 	io::{Read, Seek, Write},
 	os::unix::fs::PermissionsExt,
 	path::Path,
@@ -21,6 +21,7 @@ pub struct Manifest {
 	pub identity: Identity,
 
 	/// The interpreter for the executable.
+	#[serde(skip_serializing_if = "Option::is_none")]
 	pub interpreter: Option<Interpreter>,
 
 	/// The executable to run.
@@ -28,32 +29,11 @@ pub struct Manifest {
 
 	/// The environment variable mutations to apply.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub env: Option<Env>,
+	pub env: Option<tg::mutation::Data>,
 
 	/// The command line arguments to pass to the executable.
-	pub args: Vec<tg::template::Data>,
-}
-
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "kind", content = "value", rename_all = "camelCase")]
-pub enum MaybeMutation {
-	Mutation(Mutation),
-	Template(tg::template::Data),
-}
-
-/// An Env can be either a single mutation or a map of mutations.
-/// In the mutation case, only Unset and Set are allowed.
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "kind", content = "value", rename_all = "camelCase")]
-pub enum Env {
-	Unset,
-	Map(BTreeMap<String, Vec<MaybeMutation>>),
-}
-
-impl Default for Env {
-	fn default() -> Self {
-		Env::Map(BTreeMap::new())
-	}
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub args: Option<Vec<tg::template::Data>>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -88,7 +68,7 @@ pub enum Interpreter {
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct NormalInterpreter {
 	/// The path to the file to exec.
-	pub path: tg::template::Data,
+	pub path: tg::symlink::Data,
 
 	/// Arguments for the interpreter.
 	pub args: Vec<tg::template::Data>,
@@ -98,15 +78,15 @@ pub struct NormalInterpreter {
 #[serde(rename_all = "camelCase")]
 pub struct LdLinuxInterpreter {
 	/// The path to ld-linux.so.
-	pub path: tg::template::Data,
+	pub path: tg::symlink::Data,
 
 	/// The paths for the `--library-path` argument.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub library_paths: Option<Vec<tg::template::Data>>,
+	pub library_paths: Option<Vec<tg::symlink::Data>>,
 
 	/// The paths for the `--preload` argument.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub preloads: Option<Vec<tg::template::Data>>,
+	pub preloads: Option<Vec<tg::symlink::Data>>,
 
 	/// Any additional arguments.
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -117,15 +97,15 @@ pub struct LdLinuxInterpreter {
 #[serde(rename_all = "camelCase")]
 pub struct LdMuslInterpreter {
 	/// The path to ld-linux.so.
-	pub path: tg::template::Data,
+	pub path: tg::symlink::Data,
 
 	/// The paths for the `--library-path` argument.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub library_paths: Option<Vec<tg::template::Data>>,
+	pub library_paths: Option<Vec<tg::symlink::Data>>,
 
 	/// The paths for the `--preload` argument.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub preloads: Option<Vec<tg::template::Data>>,
+	pub preloads: Option<Vec<tg::symlink::Data>>,
 
 	/// Any additional arguments.
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -137,11 +117,11 @@ pub struct LdMuslInterpreter {
 pub struct DyLdInterpreter {
 	/// The paths for the `DYLD_LIBRARY_PATH` environment variable.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub library_paths: Option<Vec<tg::template::Data>>,
+	pub library_paths: Option<Vec<tg::symlink::Data>>,
 
 	/// The paths for the `DYLD_INSERT_LIBRARIES` environment variable.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub preloads: Option<Vec<tg::template::Data>>,
+	pub preloads: Option<Vec<tg::symlink::Data>>,
 }
 
 /// An executable launched by the entrypoint.
@@ -149,28 +129,10 @@ pub struct DyLdInterpreter {
 #[serde(rename_all = "snake_case", tag = "kind", content = "value")]
 pub enum Executable {
 	/// A path to an executable file.
-	Path(tg::template::Data),
+	Path(tg::symlink::Data),
 
 	/// A script which will be rendered to a file and interpreted.
 	Content(tg::template::Data),
-}
-
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
-pub enum Mutation {
-	Unset,
-	Set(tg::template::Data),
-	SetIfUnset(tg::template::Data),
-	ArrayPrepend(Vec<tg::template::Data>),
-	ArrayAppend(Vec<tg::template::Data>),
-	TemplatePrepend(TemplateMutationValue),
-	TemplateAppend(TemplateMutationValue),
-}
-
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub struct TemplateMutationValue {
-	pub template: tg::template::Data,
-	pub separator: Option<String>,
 }
 
 impl Manifest {
@@ -256,46 +218,46 @@ impl Manifest {
 		// Collect the references from the interpreter.
 		match &self.interpreter {
 			Some(Interpreter::Normal(interpreter)) => {
-				collect_references_from_template_data(&interpreter.path, &mut references);
+				collect_references_from_symlink_data(&interpreter.path, &mut references);
 				for arg in &interpreter.args {
 					collect_references_from_template_data(arg, &mut references);
 				}
 			},
 			Some(Interpreter::LdLinux(interpreter)) => {
-				collect_references_from_template_data(&interpreter.path, &mut references);
+				collect_references_from_symlink_data(&interpreter.path, &mut references);
 				if let Some(library_paths) = &interpreter.library_paths {
 					for library_path in library_paths {
-						collect_references_from_template_data(library_path, &mut references);
+						collect_references_from_symlink_data(library_path, &mut references);
 					}
 				}
 				if let Some(preloads) = &interpreter.preloads {
 					for preload in preloads {
-						collect_references_from_template_data(preload, &mut references);
+						collect_references_from_symlink_data(preload, &mut references);
 					}
 				}
 			},
 			Some(Interpreter::LdMusl(interpreter)) => {
-				collect_references_from_template_data(&interpreter.path, &mut references);
+				collect_references_from_symlink_data(&interpreter.path, &mut references);
 				if let Some(library_paths) = &interpreter.library_paths {
 					for library_path in library_paths {
-						collect_references_from_template_data(library_path, &mut references);
+						collect_references_from_symlink_data(library_path, &mut references);
 					}
 				}
 				if let Some(preloads) = &interpreter.preloads {
 					for preload in preloads {
-						collect_references_from_template_data(preload, &mut references);
+						collect_references_from_symlink_data(preload, &mut references);
 					}
 				}
 			},
 			Some(Interpreter::DyLd(interpreter)) => {
 				if let Some(library_paths) = &interpreter.library_paths {
 					for library_path in library_paths {
-						collect_references_from_template_data(library_path, &mut references);
+						collect_references_from_symlink_data(library_path, &mut references);
 					}
 				}
 				if let Some(preloads) = &interpreter.preloads {
 					for preload in preloads {
-						collect_references_from_template_data(preload, &mut references);
+						collect_references_from_symlink_data(preload, &mut references);
 					}
 				}
 			},
@@ -304,34 +266,89 @@ impl Manifest {
 
 		// Collect the references from the executable.
 		match &self.executable {
-			Executable::Path(path) => collect_references_from_template_data(path, &mut references),
+			Executable::Path(path) => collect_references_from_symlink_data(path, &mut references),
 			Executable::Content(template) => {
 				collect_references_from_template_data(template, &mut references);
 			},
 		};
 
 		// Collect the references from the env.
-		if let Some(Env::Map(env)) = &self.env {
-			for mutations in env.values() {
-				for maybe_mutation in mutations {
-					match maybe_mutation {
-						MaybeMutation::Mutation(mutation) => {
-							collect_references_from_mutation(mutation, &mut references);
-						},
-						MaybeMutation::Template(template) => {
-							collect_references_from_template_data(template, &mut references);
-						},
-					}
-				}
-			}
+		if let Some(env) = &self.env {
+			collect_references_from_mutation_data(env, &mut references);
 		}
 
 		// Collect the references from the args.
-		for arg in &self.args {
-			collect_references_from_template_data(arg, &mut references);
+		if let Some(args) = &self.args {
+			for arg in args {
+				collect_references_from_template_data(arg, &mut references);
+			}
 		}
 
 		references
+	}
+}
+
+pub fn collect_references_from_value_data(
+	value: &tg::value::Data,
+	references: &mut HashSet<tg::artifact::Id, fnv::FnvBuildHasher>,
+) {
+	match value {
+		tg::value::Data::Directory(id) => {
+			references.insert(id.clone().try_into().unwrap());
+		},
+		tg::value::Data::File(id) => {
+			references.insert(id.clone().try_into().unwrap());
+		},
+		tg::value::Data::Symlink(id) => {
+			references.insert(id.clone().try_into().unwrap());
+		},
+		tg::value::Data::Mutation(data) => {
+			collect_references_from_mutation_data(data, references);
+		},
+		tg::value::Data::Template(data) => {
+			collect_references_from_template_data(data, references);
+		},
+		tg::value::Data::Array(arr) => {
+			for value in arr {
+				collect_references_from_value_data(value, references);
+			}
+		},
+		tg::value::Data::Map(map) => {
+			for value in map.values() {
+				collect_references_from_value_data(value, references);
+			}
+		},
+		_ => {},
+	}
+}
+
+pub fn collect_references_from_artifact_data(
+	value: &tg::artifact::Data,
+	references: &mut HashSet<tg::artifact::Id, fnv::FnvBuildHasher>,
+) {
+	match value {
+		tg::artifact::Data::Directory(data) => {
+			for id in data.entries.values() {
+				references.insert(id.clone());
+			}
+		},
+		tg::artifact::Data::File(data) => {
+			for id in &data.references {
+				references.insert(id.clone());
+			}
+		},
+		tg::artifact::Data::Symlink(data) => {
+			collect_references_from_symlink_data(data, references);
+		},
+	}
+}
+
+pub fn collect_references_from_symlink_data(
+	value: &tg::symlink::Data,
+	references: &mut HashSet<tg::artifact::Id, fnv::FnvBuildHasher>,
+) {
+	if let Some(id) = &value.artifact {
+		references.insert(id.clone());
 	}
 }
 
@@ -346,23 +363,24 @@ pub fn collect_references_from_template_data(
 	}
 }
 
-pub fn collect_references_from_mutation(
-	value: &Mutation,
+pub fn collect_references_from_mutation_data(
+	value: &tg::mutation::Data,
 	references: &mut HashSet<tg::artifact::Id, fnv::FnvBuildHasher>,
 ) {
 	match value {
-		Mutation::Unset => {},
-		Mutation::Set(value) | Mutation::SetIfUnset(value) => {
-			collect_references_from_template_data(value, references);
+		tg::mutation::Data::Unset => {},
+		tg::mutation::Data::Set { value } | tg::mutation::Data::SetIfUnset { value } => {
+			collect_references_from_value_data(value, references);
 		},
-		Mutation::ArrayPrepend(values) | Mutation::ArrayAppend(values) => {
+		tg::mutation::Data::ArrayPrepend { values }
+		| tg::mutation::Data::ArrayAppend { values } => {
 			for value in values {
-				collect_references_from_template_data(value, references);
+				collect_references_from_value_data(value, references);
 			}
 		},
-		Mutation::TemplatePrepend(template_mutation)
-		| Mutation::TemplateAppend(template_mutation) => {
-			collect_references_from_template_data(&template_mutation.template, references);
+		tg::mutation::Data::TemplatePrepend { template, .. }
+		| tg::mutation::Data::TemplateAppend { template, .. } => {
+			collect_references_from_template_data(template, references);
 		},
 	}
 }

--- a/packages/std/packages/wrapper/src/manifest.rs
+++ b/packages/std/packages/wrapper/src/manifest.rs
@@ -129,7 +129,7 @@ pub struct DyLdInterpreter {
 
 /// An executable launched by the entrypoint.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case", tag = "kind", content = "value")]
+#[serde(rename_all = "camelCase", tag = "kind", content = "value")]
 pub enum Executable {
 	/// A path to an executable file.
 	Path(tg::symlink::Data),

--- a/packages/std/packages/wrapper/src/manifest.rs
+++ b/packages/std/packages/wrapper/src/manifest.rs
@@ -1,13 +1,12 @@
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::{
 	collections::HashSet,
-	hash::{BuildHasher, BuildHasherDefault},
+	hash::BuildHasher,
 	io::{Read, Seek, Write},
 	os::unix::fs::PermissionsExt,
 	path::Path,
 };
 use tangram_client as tg;
-use twox_hash::Xxh3Hash64;
 
 /// The magic number used to indicate an executable has a manifest.
 pub const MAGIC_NUMBER: &[u8] = b"tangram\0";
@@ -16,7 +15,7 @@ pub const MAGIC_NUMBER: &[u8] = b"tangram\0";
 pub const VERSION: u64 = 0;
 
 /// Set the algorithm used to hash IDs.;
-type Hasher = BuildHasherDefault<Xxh3Hash64>;
+type Hasher = fnv::FnvBuildHasher;
 
 /// The Tangram run entrypoint manifest.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/packages/std/phases.tg
+++ b/packages/std/phases.tg
@@ -63,26 +63,22 @@ export let target = async (...args: tg.Args<Arg>) => {
 			return {};
 		} else if (isArgObject(arg)) {
 			let object: tg.MutationMap<Apply> = {};
-			if ("target" in arg) {
-				object.targetArgs = await tg.Mutation.arrayAppend<tg.Target.Arg>(
-					arg.target,
-				);
+			if (arg.target !== undefined) {
+				object.targetArgs = tg.Mutation.is(arg.target)
+					? arg.target
+					: await tg.Mutation.arrayAppend<tg.Target.Arg>(arg.target);
 			}
-			if ("env" in arg) {
+			if (arg.env !== undefined) {
 				if (tg.Mutation.is(arg.env)) {
-					if (arg.env.inner.kind === "unset") {
-						object.env = tg.Mutation.unset();
-					} else {
-						return tg.unreachable();
-					}
+					object.env = arg.env;
 				} else {
 					object.env = await tg.Mutation.arrayAppend<std.env.Arg>(arg.env);
 				}
 			}
-			if ("order" in arg) {
+			if (arg.order !== undefined) {
 				object.order = arg.order;
 			}
-			if ("phases" in arg) {
+			if (arg.phases !== undefined) {
 				if (tg.Mutation.is(arg.phases)) {
 					object.phases = arg.phases;
 				} else {
@@ -206,10 +202,11 @@ export let isPhaseArgObject = (arg: unknown): arg is PhaseArgObject => {
 	);
 };
 
-export let isPhaseObject = (arg: PhaseArg): arg is Phase => {
+export let isPhaseObject = (arg: unknown): arg is Phase => {
 	return (
 		arg !== undefined &&
 		typeof arg === "object" &&
+		arg !== null &&
 		"body" in arg &&
 		isCommand(arg.body)
 	);
@@ -253,7 +250,7 @@ export let mergeCommandArgs = async (
 						? arg.inner.value.command
 						: await tg.template(arg.inner.value.command);
 					let args = undefined;
-					if ("args" in arg.inner.value) {
+					if (arg.inner.value.args !== undefined) {
 						args = tg.Mutation.is(arg.inner.value.args)
 							? arg.inner.value.args
 							: await Promise.all(
@@ -282,7 +279,7 @@ export let mergeCommandArgs = async (
 								await tg.template(arg.inner.value.command),
 						  );
 					let args = undefined;
-					if ("args" in arg.inner.value) {
+					if (arg.inner.value.args !== undefined) {
 						args = tg.Mutation.is(arg.inner.value.args)
 							? arg.inner.value.args
 							: await tg.Mutation.setIfUnset(
@@ -310,18 +307,18 @@ export let mergeCommandArgs = async (
 			) {
 				throw new Error("Cannot apply array mutation to a command.");
 			} else {
-				return tg.unreachable();
+				throw new Error("Unexpected mutation for command.");
 			}
 		} else if (isCommandArgObject(arg)) {
 			let ret: tg.MutationMap<Apply> = {};
 			// Handle command, default mutation is `set`.
-			if ("command" in arg) {
+			if (arg.command !== undefined) {
 				ret.command = tg.Mutation.is(arg.command)
 					? arg.command
 					: await tg.template(arg.command);
 			}
 			// Handle args, detault mutation is `array_append`.
-			if ("args" in arg) {
+			if (arg.args !== undefined) {
 				ret.args = tg.Mutation.is(arg.args)
 					? arg.args
 					: await tg.mutation({
@@ -364,15 +361,11 @@ export let mergePhaseArgs = async (
 					? await tg.Mutation.arrayAppend<CommandArg>(arg.body)
 					: "",
 			};
-			if ("pre" in arg) {
-				ret.pre = arg.pre
-					? await tg.Mutation.arrayAppend<CommandArg>(arg.pre)
-					: undefined;
+			if (arg.pre !== undefined) {
+				ret.pre = await tg.Mutation.arrayAppend<CommandArg>(arg.pre);
 			}
-			if ("post" in arg) {
-				ret.post = arg.post
-					? await tg.Mutation.arrayAppend<CommandArg>(arg.post)
-					: undefined;
+			if (arg.post !== undefined) {
+				ret.post = await tg.Mutation.arrayAppend<CommandArg>(arg.post);
 			}
 			return ret;
 		} else if (tg.Mutation.is(arg)) {
@@ -399,7 +392,7 @@ export let mergePhaseArgs = async (
 				body: await tg.Mutation.arrayAppend<CommandArg>(arg),
 			};
 		} else {
-			return tg.unreachable();
+			throw new Error("Unexpected phase arg type.");
 		}
 	});
 
@@ -444,7 +437,7 @@ export let isCommandArgObject = (arg: unknown): arg is CommandArgObject => {
 	);
 };
 
-export let isCommand = (arg: PhaseArg): arg is Command => {
+export let isCommand = (arg: unknown): arg is Command => {
 	return isCommandArgObject(arg) && tg.Template.is(arg.command);
 };
 

--- a/packages/std/sdk.tg
+++ b/packages/std/sdk.tg
@@ -158,7 +158,12 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 	} else if (toolchain === "gcc") {
 		let hostToolchain = await canadianCross.toolchain({ host });
 		let proxyEnv = await proxy({ env: hostToolchain });
-		let dependenciesEnv = await dependencies.env({ build: host, host });
+		let dependenciesEnv = await dependencies.env({
+			build: host,
+			host,
+			env: [hostToolchain, proxyEnv],
+			sdk: { bootstrapMode: true },
+		});
 		return std.env(hostToolchain, proxyEnv, dependenciesEnv, {
 			bootstrapMode: true, // Prevent the utils from getting added twice, the dependencies already add them.
 		});
@@ -337,8 +342,8 @@ export namespace sdk {
 			os === "darwin"
 				? "ld"
 				: flavor === "gcc"
-				  ? `${targetPrefix}ld`
-				  : "ld.lld";
+					? `${targetPrefix}ld`
+					: "ld.lld";
 		let foundLd = await directory.tryGet(`bin/${linkerName}`);
 		tg.assert(foundLd, `Unable to find ${linkerName}.`);
 		let ld = await tg.symlink(tg`${directory}/bin/${linkerName}`);

--- a/packages/std/sdk.tg
+++ b/packages/std/sdk.tg
@@ -9,7 +9,6 @@ import proxy from "./sdk/proxy.tg";
 import * as std from "./tangram.tg";
 
 /** An SDK combines a compiler, a linker, a libc, and a set of basic utilities. */
-// FIXME - the outer function should resolve the args, then pass to an inner target. Improve caching!
 export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 	type Apply = {
 		bootstrapMode: Array<boolean>;

--- a/packages/std/sdk.tg
+++ b/packages/std/sdk.tg
@@ -228,155 +228,147 @@ export namespace sdk {
 	] as const;
 
 	/** Assert that an env provides an toolchain. */
-	export let assertProvidesToolchain = tg.target(
-		async (arg: ProvidesToolchainArg) => {
-			let { env, target } = arg;
-			// Provides binutils, cc/c++.
-			let targetPrefix = ``;
-			if (target) {
-				let os = std.triple(target).os;
-				if (os !== "darwin") {
-					targetPrefix = `${std.Triple.toString(std.triple(target))}-`;
-				}
+	export let assertProvidesToolchain = async (arg: ProvidesToolchainArg) => {
+		let { env, target } = arg;
+		// Provides binutils, cc/c++.
+		let targetPrefix = ``;
+		if (target) {
+			let os = std.triple(target).os;
+			if (os !== "darwin") {
+				targetPrefix = `${std.Triple.toString(std.triple(target))}-`;
 			}
-			await std.env.assertProvides({
-				env,
-				names: requiredComponents.map((name) => `${targetPrefix}${name}`),
-			});
-			return true;
-		},
-	);
+		}
+		await std.env.assertProvides({
+			env,
+			names: requiredComponents.map((name) => `${targetPrefix}${name}`),
+		});
+		return true;
+	};
 
 	/** Determine whether an env provides an toolchain. */
-	export let providesToolchain = tg.target(
-		(arg: ProvidesToolchainArg): Promise<boolean> => {
-			let { env, target } = arg;
-			// Provides binutils, cc/c++.
-			let targetPrefix = ``;
-			if (target) {
-				let os = std.triple(target).os;
-				if (os !== "darwin") {
-					targetPrefix = `${std.Triple.toString(std.triple(target))}-`;
-				}
+	export let providesToolchain = (
+		arg: ProvidesToolchainArg,
+	): Promise<boolean> => {
+		let { env, target } = arg;
+		// Provides binutils, cc/c++.
+		let targetPrefix = ``;
+		if (target) {
+			let os = std.triple(target).os;
+			if (os !== "darwin") {
+				targetPrefix = `${std.Triple.toString(std.triple(target))}-`;
 			}
-			return std.env.provides({
-				env,
-				names: requiredComponents.map((name) => `${targetPrefix}${name}`),
-			});
-		},
-	);
+		}
+		return std.env.provides({
+			env,
+			names: requiredComponents.map((name) => `${targetPrefix}${name}`),
+		});
+	};
 
 	/** Locate the C and C++ compilers, linker, and ld.so from a toolchain. */
-	export let toolchainComponents = tg.target(
-		async (arg?: ToolchainEnvArg): Promise<ToolchainComponents> => {
-			let { env, target: targetTriple } = arg ?? {};
-			// Make sure we have a toolchain.
-			await sdk.assertProvidesToolchain({ env, target: targetTriple });
-			let host = await getHost({ env });
-			let os = host.os;
-			let target = targetTriple ? std.triple(targetTriple) : host;
-			let isCross = !std.Triple.eq(host, target);
-			let targetString = std.Triple.toString(target);
-			let targetPrefix = isCross ? `${targetString}-` : ``;
+	export let toolchainComponents = async (
+		arg?: ToolchainEnvArg,
+	): Promise<ToolchainComponents> => {
+		let { env, target: targetTriple } = arg ?? {};
+		// Make sure we have a toolchain.
+		await sdk.assertProvidesToolchain({ env, target: targetTriple });
+		let host = await getHost({ env });
+		let os = host.os;
+		let target = targetTriple ? std.triple(targetTriple) : host;
+		let isCross = !std.Triple.eq(host, target);
+		let targetString = std.Triple.toString(target);
+		let targetPrefix = isCross ? `${targetString}-` : ``;
 
-			// Set the default flavor for the os at first, to confirm later.
-			let flavor: "gcc" | "llvm" = os === "linux" ? "gcc" : "llvm";
+		// Set the default flavor for the os at first, to confirm later.
+		let flavor: "gcc" | "llvm" = os === "linux" ? "gcc" : "llvm";
 
-			// Determine actual flavor and locate cc and c++.
-			let cc;
-			let cxx;
-			if (flavor === "gcc") {
-				// Check if `gcc` is available.
-				let gcc = await std.env.tryWhich({ env, name: `${targetPrefix}gcc` });
-				if (gcc) {
-					// If so, try to find `g++`.
-					let gxx = await std.env.tryWhich({ env, name: `${targetPrefix}g++` });
-					tg.assert(
-						gxx,
-						`Found ${targetPrefix}gcc but not ${targetPrefix}g++.`,
-					);
-					cc = gcc;
-					cxx = gxx;
-				} else {
-					// Try to find clang, which needs no prefix.
-					let clang = await std.env.tryWhich({ env, name: "clang" });
-					tg.assert(clang, `Found neither ${targetPrefix}gcc nor clang.`);
-					// If clang is available, try to find clang++.
-					let clangxx = await std.env.tryWhich({ env, name: "clang++" });
-					tg.assert(clangxx, "Found clang but not clang++.");
-					flavor = "llvm";
-					cc = clang;
-					cxx = clangxx;
-				}
+		// Determine actual flavor and locate cc and c++.
+		let cc;
+		let cxx;
+		if (flavor === "gcc") {
+			// Check if `gcc` is available.
+			let gcc = await std.env.tryWhich({ env, name: `${targetPrefix}gcc` });
+			if (gcc) {
+				// If so, try to find `g++`.
+				let gxx = await std.env.tryWhich({ env, name: `${targetPrefix}g++` });
+				tg.assert(gxx, `Found ${targetPrefix}gcc but not ${targetPrefix}g++.`);
+				cc = gcc;
+				cxx = gxx;
 			} else {
-				// Check if `clang` is available.
+				// Try to find clang, which needs no prefix.
 				let clang = await std.env.tryWhich({ env, name: "clang" });
-				if (clang) {
-					// If so, try to find `clang++`.
-					let clangxx = await std.env.tryWhich({ env, name: "clang++" });
-					tg.assert(clangxx, "Found clang but not clang++.");
-					cc = clang;
-					cxx = clangxx;
-				} else {
-					// Try to find gcc.
-					let gcc = await std.env.tryWhich({ env, name: `${targetPrefix}gcc` });
-					tg.assert(gcc, `Found neither clang nor ${targetPrefix}gcc.`);
-					// If gcc is available, try to find g++.
-					let gxx = await std.env.tryWhich({ env, name: `${targetPrefix}g++` });
-					tg.assert(
-						gxx,
-						`Found ${targetPrefix}gcc but not ${targetPrefix}g++.`,
-					);
-					flavor = "gcc";
-					cc = gcc;
-					cxx = gxx;
-				}
+				tg.assert(clang, `Found neither ${targetPrefix}gcc nor clang.`);
+				// If clang is available, try to find clang++.
+				let clangxx = await std.env.tryWhich({ env, name: "clang++" });
+				tg.assert(clangxx, "Found clang but not clang++.");
+				flavor = "llvm";
+				cc = clang;
+				cxx = clangxx;
 			}
-
-			let compiler = flavor === "gcc" ? `${targetPrefix}${flavor}` : "clang";
-			let cxxCompiler = flavor === "gcc" ? `${targetPrefix}g++` : `clang++`;
-			let directory = await std.env.whichArtifact({ name: compiler, env });
-			tg.assert(directory, "Unable to find toolchain directory.");
-			cc = await tg.symlink(tg`${directory}/bin/${compiler}`);
-			cxx = await tg.symlink(tg`${directory}/bin/${cxxCompiler}`);
-
-			// Grab the linker from the same directory as the compiler, not just by using `Env.which`.
-			let linkerName =
-				os === "darwin"
-					? "ld"
-					: flavor === "gcc"
-					  ? `${targetPrefix}ld`
-					  : "ld.lld";
-			let foundLd = await directory.tryGet(`bin/${linkerName}`);
-			tg.assert(foundLd, `Unable to find ${linkerName}.`);
-			let ld = await tg.symlink(tg`${directory}/bin/${linkerName}`);
-
-			// Locate the dynamic interpreter.
-			let ldso;
-			let libDir;
-			if (os !== "darwin") {
-				let ldsoPath = isCross ? `${targetString}/lib` : "lib";
-				libDir = tg.Directory.expect(await directory.tryGet(ldsoPath));
-				let foundLdso = await libDir.tryGet(interpreterName(target));
-				tg.assert(foundLdso, "Unable to find ld.so.");
-				ldso = tg.File.expect(foundLdso);
+		} else {
+			// Check if `clang` is available.
+			let clang = await std.env.tryWhich({ env, name: "clang" });
+			if (clang) {
+				// If so, try to find `clang++`.
+				let clangxx = await std.env.tryWhich({ env, name: "clang++" });
+				tg.assert(clangxx, "Found clang but not clang++.");
+				cc = clang;
+				cxx = clangxx;
 			} else {
-				libDir = tg.Directory.expect(await directory.tryGet("lib"));
+				// Try to find gcc.
+				let gcc = await std.env.tryWhich({ env, name: `${targetPrefix}gcc` });
+				tg.assert(gcc, `Found neither clang nor ${targetPrefix}gcc.`);
+				// If gcc is available, try to find g++.
+				let gxx = await std.env.tryWhich({ env, name: `${targetPrefix}g++` });
+				tg.assert(gxx, `Found ${targetPrefix}gcc but not ${targetPrefix}g++.`);
+				flavor = "gcc";
+				cc = gcc;
+				cxx = gxx;
 			}
+		}
 
-			return {
-				cc,
-				cxx,
-				directory,
-				flavor,
-				host,
-				ld,
-				ldso,
-				libDir,
-				target,
-			};
-		},
-	);
+		let compiler = flavor === "gcc" ? `${targetPrefix}${flavor}` : "clang";
+		let cxxCompiler = flavor === "gcc" ? `${targetPrefix}g++` : `clang++`;
+		let directory = await std.env.whichArtifact({ name: compiler, env });
+		tg.assert(directory, "Unable to find toolchain directory.");
+		cc = await tg.symlink(tg`${directory}/bin/${compiler}`);
+		cxx = await tg.symlink(tg`${directory}/bin/${cxxCompiler}`);
+
+		// Grab the linker from the same directory as the compiler, not just by using `Env.which`.
+		let linkerName =
+			os === "darwin"
+				? "ld"
+				: flavor === "gcc"
+				  ? `${targetPrefix}ld`
+				  : "ld.lld";
+		let foundLd = await directory.tryGet(`bin/${linkerName}`);
+		tg.assert(foundLd, `Unable to find ${linkerName}.`);
+		let ld = await tg.symlink(tg`${directory}/bin/${linkerName}`);
+
+		// Locate the dynamic interpreter.
+		let ldso;
+		let libDir;
+		if (os !== "darwin") {
+			let ldsoPath = isCross ? `${targetString}/lib` : "lib";
+			libDir = tg.Directory.expect(await directory.tryGet(ldsoPath));
+			let foundLdso = await libDir.tryGet(interpreterName(target));
+			tg.assert(foundLdso, "Unable to find ld.so.");
+			ldso = tg.File.expect(foundLdso);
+		} else {
+			libDir = tg.Directory.expect(await directory.tryGet("lib"));
+		}
+
+		return {
+			cc,
+			cxx,
+			directory,
+			flavor,
+			host,
+			ld,
+			ldso,
+			libDir,
+			target,
+		};
+	};
 
 	type ToolchainEnvArg = {
 		/** The environment to ascertain the host from. */
@@ -398,96 +390,92 @@ export namespace sdk {
 	};
 
 	/** Determine whether an SDK supports compiling for a specific target. */
-	export let supportsTarget = tg.target(
-		async (arg: ToolchainEnvArg): Promise<boolean> => {
-			let target = arg.target
-				? std.triple(arg.target)
-				: await std.Triple.host();
-			if (
-				(await std.Triple.host()).os === "darwin" &&
-				std.triple(arg.target).os === "darwin"
-			) {
-				return true;
-			}
+	export let supportsTarget = async (
+		arg: ToolchainEnvArg,
+	): Promise<boolean> => {
+		let target = arg.target ? std.triple(arg.target) : await std.Triple.host();
+		if (
+			(await std.Triple.host()).os === "darwin" &&
+			std.triple(arg.target).os === "darwin"
+		) {
+			return true;
+		}
 
-			let allTargets = await supportedTargets(arg.env);
-			return std.Triple.arrayIncludes(allTargets, target);
-		},
-	);
+		let allTargets = await supportedTargets(arg.env);
+		return std.Triple.arrayIncludes(allTargets, target);
+	};
 
 	/** Retreive the full range of targets an SDK supports. */
-	export let supportedTargets = tg.target(
-		async (sdk: std.env.Arg): Promise<Array<std.Triple>> => {
-			// Collect all available `*cc` binaries.
-			let foundTargets: Set<std.Triple> = new Set();
+	export let supportedTargets = async (
+		sdk: std.env.Arg,
+	): Promise<Array<std.Triple>> => {
+		// Collect all available `*cc` binaries.
+		let foundTargets: Set<std.Triple> = new Set();
 
-			for await (let [name, _] of std.env.binsInPath({
-				env: sdk,
-				predicate: (name) => name.endsWith("-cc"),
-			})) {
-				let tripleString = name.slice(0, -3);
-				foundTargets.add(std.triple(tripleString));
-			}
-			return Array.from(foundTargets);
-		},
-	);
+		for await (let [name, _] of std.env.binsInPath({
+			env: sdk,
+			predicate: (name) => name.endsWith("-cc"),
+		})) {
+			let tripleString = name.slice(0, -3);
+			foundTargets.add(std.triple(tripleString));
+		}
+		return Array.from(foundTargets);
+	};
 
 	/** Obtain the host system for the compilers provided by this env. Throws an error if no compiler is found. */
-	export let getHost = tg.target(
-		async (arg: ToolchainEnvArg): Promise<std.Triple> => {
-			let { env, target } = arg;
+	export let getHost = async (arg: ToolchainEnvArg): Promise<std.Triple> => {
+		let { env, target } = arg;
 
-			let detectedHost = await std.Triple.host();
-			if (detectedHost.os === "darwin") {
-				return detectedHost;
-			}
+		let detectedHost = await std.Triple.host();
+		if (detectedHost.os === "darwin") {
+			return detectedHost;
+		}
 
-			// Locate the C compiler using the CC variable if set, falling back to "cc" in PATH if not.
-			let targetString = target ? std.Triple.toString(std.triple(target)) : "";
-			let ccEnvVar = target ? `CC_${targetString.replace(/-/g, "_")}` : "CC";
-			let cmd = `$${ccEnvVar}`;
-			let foundCC = await std.env.tryGetArtifactByKey({ env, key: ccEnvVar });
-			let targetPrefix = target ? `${targetString}-` : "";
-			if (!foundCC) {
-				foundCC = await std.env.tryWhich({ env, name: `${targetPrefix}cc` });
-				cmd = `${targetPrefix}cc`;
-			}
+		// Locate the C compiler using the CC variable if set, falling back to "cc" in PATH if not.
+		let targetString = target ? std.Triple.toString(std.triple(target)) : "";
+		let ccEnvVar = target ? `CC_${targetString.replace(/-/g, "_")}` : "CC";
+		let cmd = `$${ccEnvVar}`;
+		let foundCC = await std.env.tryGetArtifactByKey({ env, key: ccEnvVar });
+		let targetPrefix = target ? `${targetString}-` : "";
+		if (!foundCC) {
+			foundCC = await std.env.tryWhich({ env, name: `${targetPrefix}cc` });
+			cmd = `${targetPrefix}cc`;
+		}
 
-			// If we couldn't locate a file or symlink at either CC or `cc` in $PATH, we can't determine the host.
-			if (!foundCC || !(tg.File.is(foundCC) || tg.Symlink.is(foundCC))) {
-				throw new Error(
-					`Could not find a valid file or symlink via CC or looking up ${targetPrefix}cc in PATH`,
-				);
-			}
-
-			if (tg.File.is(foundCC)) {
-				// Inspect the file to see which system it should run on.
-				let metadata = await std.file.executableMetadata(foundCC);
-				if (metadata.format !== "elf" && metadata.format !== "mach-o") {
-					throw new Error(`Unexpected compiler format ${metadata.format}.`);
-				}
-				let detectedArch: tg.System.Arch | undefined;
-				if (metadata.format === "elf") {
-					detectedArch = metadata.arch;
-				} else if (metadata.format === "mach-o") {
-					detectedArch = metadata.arches[0] ?? "aarch64";
-				}
-				let os: tg.System.Os = metadata.format === "elf" ? "linux" : "darwin";
-				let system = tg.system({ arch: detectedArch ?? "x86_64", os });
-				detectedHost = std.triple(system);
-			}
-
-			// Actually run the compiler on the detected system to ask what host triple it's configured for.
-			let output = tg.File.expect(
-				await tg.build(tg`${cmd} -dumpmachine > $OUTPUT`, {
-					env: std.env.object(env),
-					host: std.Triple.system(detectedHost),
-				}),
+		// If we couldn't locate a file or symlink at either CC or `cc` in $PATH, we can't determine the host.
+		if (!foundCC || !(tg.File.is(foundCC) || tg.Symlink.is(foundCC))) {
+			throw new Error(
+				`Could not find a valid file or symlink via CC or looking up ${targetPrefix}cc in PATH`,
 			);
-			let host = (await output.text()).trim();
-			return std.triple(host);
-		},
-	);
+		}
+
+		if (tg.File.is(foundCC)) {
+			// Inspect the file to see which system it should run on.
+			let metadata = await std.file.executableMetadata(foundCC);
+			if (metadata.format !== "elf" && metadata.format !== "mach-o") {
+				throw new Error(`Unexpected compiler format ${metadata.format}.`);
+			}
+			let detectedArch: tg.System.Arch | undefined;
+			if (metadata.format === "elf") {
+				detectedArch = metadata.arch;
+			} else if (metadata.format === "mach-o") {
+				detectedArch = metadata.arches[0] ?? "aarch64";
+			}
+			let os: tg.System.Os = metadata.format === "elf" ? "linux" : "darwin";
+			let system = tg.system({ arch: detectedArch ?? "x86_64", os });
+			detectedHost = std.triple(system);
+		}
+
+		// Actually run the compiler on the detected system to ask what host triple it's configured for.
+		let output = tg.File.expect(
+			await tg.build(tg`${cmd} -dumpmachine > $OUTPUT`, {
+				env: std.env.object(env),
+				host: std.Triple.system(detectedHost),
+			}),
+		);
+		let host = (await output.text()).trim();
+		return std.triple(host);
+	};
 
 	export let resolveHostAndTarget = async (
 		arg?: HostAndTargetsOptions,
@@ -508,7 +496,7 @@ export namespace sdk {
 	};
 
 	/** Compile a program and assert a correct wrapper for the target was produced. If `host == target`, ensure the wrapper execute and produces the expected output. */
-	export let assertProxiedCompiler = tg.target(async (arg: ProxyTestArg) => {
+	export let assertProxiedCompiler = async (arg: ProxyTestArg) => {
 		// Determine requested host and target.
 		let expected = await resolveHostAndTarget({
 			host: arg.host,
@@ -562,7 +550,7 @@ export namespace sdk {
 			tg.assert(outputText === expectedOutput);
 		}
 		return true;
-	});
+	};
 
 	/** Assert the given env provides everything it should for a particuar arg. */
 	export let assertValid = async (env: std.env.Arg, arg?: sdk.Arg) => {
@@ -831,11 +819,11 @@ type RunAllSdksArg = {
 	package: tg.Target;
 };
 
-export let runAllSdks = tg.target(async (arg: RunAllSdksArg) => {
+export let runAllSdks = async (arg: RunAllSdksArg) => {
 	let options = generateAllOptions();
 	for await (let option of options) {
 		let env = await std.env.object(await sdk(option));
 		await tg.build(arg.package, { env });
 	}
 	return true;
-});
+};

--- a/packages/std/sdk.tg
+++ b/packages/std/sdk.tg
@@ -9,19 +9,20 @@ import proxy from "./sdk/proxy.tg";
 import * as std from "./tangram.tg";
 
 /** An SDK combines a compiler, a linker, a libc, and a set of basic utilities. */
+// FIXME - the outer function should resolve the args, then pass to an inner target. Improve caching!
 export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 	type Apply = {
 		bootstrapMode: Array<boolean>;
-		host: std.Triple;
-		targets: Array<std.Triple>;
+		host: std.Triple.Arg;
+		targets: Array<std.Triple.Arg>;
 		toolchain: sdk.ToolchainKind;
 		linker: sdk.LinkerKind;
 		existingSdk?: std.env.Arg;
 	};
 	let {
 		bootstrapMode: bootstrapMode_,
-		host,
-		targets,
+		host: host_,
+		targets: targets_,
 		toolchain: toolchain_,
 		linker,
 		existingSdk,
@@ -30,45 +31,39 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 			return {};
 		} else {
 			let object: tg.MutationMap<Apply> = {};
-			let targets = [];
-			if ("host" in arg) {
-				object.host = tg.Mutation.is(arg.host)
-					? arg.host
-					: std.triple(arg.host);
+			let targets: Array<std.Triple.Arg> = [];
+			if (arg.host !== undefined) {
+				object.host = arg.host;
 			}
-			if ("toolchain" in arg) {
+			if (arg.toolchain !== undefined) {
 				object.toolchain = arg.toolchain;
 			}
-			if ("linker" in arg) {
+			if (arg.linker !== undefined) {
 				object.linker = arg.linker;
 			}
-			if ("sdk" in arg) {
+			if (arg.sdk !== undefined) {
 				object.existingSdk = arg.sdk;
 			}
-			if ("bootstrapMode" in arg) {
+			if (arg.bootstrapMode !== undefined) {
 				object.bootstrapMode = tg.Mutation.is(arg.bootstrapMode)
 					? arg.bootstrapMode
-					: await tg.Mutation.arrayAppend(arg.bootstrapMode ?? false);
+					: await tg.Mutation.arrayAppend(arg.bootstrapMode);
 			}
-			if ("target" in arg) {
+			if (arg.target !== undefined) {
 				targets.push(std.triple(arg.target));
 			}
-			if ("targets" in arg) {
+			if (arg.targets !== undefined) {
 				if (tg.Mutation.is(arg.targets)) {
 					object.targets = arg.targets;
 				} else {
-					targets = targets.concat((arg.targets ?? []).map(std.triple));
+					targets = targets.concat(arg.targets ?? []);
 				}
 			}
-			object.targets = await tg.Mutation.arrayAppend(targets);
+			object.targets = await tg.Mutation.arrayAppend<std.Triple.Arg>(targets);
 			return object;
 		}
 	});
-
-	// Finalize host.
-	if (!host) {
-		host = await std.Triple.host();
-	}
+	let host = host_ ? std.triple(host_) : await std.Triple.host();
 
 	// If we're in bootstrap mode, stop here and return the bootstrap SDK.
 	let bootstrapMode = (bootstrapMode_ ?? []).some((mode) => mode);
@@ -77,7 +72,8 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 	}
 
 	// Collect target array.
-	if (!targets || targets.length === 0) {
+	let targets = (targets_ ?? []).map(std.triple);
+	if (targets.length === 0) {
 		targets = [host];
 	}
 
@@ -163,13 +159,9 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 	} else if (toolchain === "gcc") {
 		let hostToolchain = await canadianCross.toolchain({ host });
 		let proxyEnv = await proxy({ env: hostToolchain });
-		let dependenciesEnv = await dependencies.env({
-			build: host,
-			env: [hostToolchain, proxyEnv],
-			sdk: { bootstrapMode: true },
-		});
+		let dependenciesEnv = await dependencies.env({ build: host, host });
 		return std.env(hostToolchain, proxyEnv, dependenciesEnv, {
-			bootstrapMode: true,
+			bootstrapMode: true, // Prevent the utils from getting added twice, the dependencies already add them.
 		});
 	} else if (toolchain === "llvm") {
 		return tg.unimplemented();
@@ -189,9 +181,15 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 export namespace sdk {
 	export type Arg = ArgObject | undefined;
 
-	export type ArgObject = HostAndTargetsOptions & {
+	export type ArgObject = {
 		/** Provide an env consisting only of bootstrap components and a linker proxy. Will not build additional utils or bootstrap GCC. */
 		bootstrapMode?: boolean;
+		/** The machine this SDK will compile on. */
+		host?: std.Triple.Arg;
+		/** The machine this SDK produces executables for. */
+		target?: std.Triple.Arg;
+		/** A list of machines this SDK can produce executables for. */
+		targets?: Array<std.Triple.Arg>;
 		/** An alternate linker to use. */
 		linker?: LinkerKind;
 		/** An existing SDK to add to. */

--- a/packages/std/sdk/dependencies.tg
+++ b/packages/std/sdk/dependencies.tg
@@ -93,7 +93,7 @@ export let env = tg.target(async (arg?: Arg) => {
 
 export default env;
 
-export let assertProvides = tg.target(async (env: std.env.Arg) => {
+export let assertProvides = async (env: std.env.Arg) => {
 	let names = [
 		"aclocal",
 		"automake",
@@ -120,9 +120,9 @@ export let assertProvides = tg.target(async (env: std.env.Arg) => {
 		std.env.assertProvides({ env, names }),
 	]);
 	return true;
-});
+};
 
 export let test = tg.target(async () => {
-	await assertProvides(env({ sdk: { bootstrapMode: true } }));
+	await assertProvides(await env({ sdk: { bootstrapMode: true } }));
 	return true;
 });

--- a/packages/std/sdk/proxy.tg
+++ b/packages/std/sdk/proxy.tg
@@ -170,9 +170,8 @@ export let ldProxy = async (arg: LdProxyArg) => {
 	});
 
 	// Create the linker proxy.
-	let output = await std.wrap({
+	let output = await std.wrap(tgld, {
 		identity: "wrapper",
-		executable: tgld,
 		env: {
 			TANGRAM_LINKER_COMMAND_PATH: arg.linker,
 			TANGRAM_LINKER_INJECTION_PATH: injectionLibrary,

--- a/packages/std/tangram.tg
+++ b/packages/std/tangram.tg
@@ -49,7 +49,14 @@ export let testProxy = tg.target(async () => {
 	return await proxy.test();
 });
 
+import * as bootstrap from "./bootstrap.tg";
 import * as wrap from "./wrap.tg";
+export let testWrap = tg.target(async () => {
+	let shell = await bootstrap.shell();
+	let exe = tg.File.expect(await shell.get("bin/dash"));
+	return await wrap.wrap(exe, { env: { HELLO: tg.Mutation.templateAppend(tg`hi`) }});
+
+});
 export let testMuslWrapper = tg.target(async () => {
 	return await wrap.testSingleArgObjectNoMutations();
 });

--- a/packages/std/tangram.tg
+++ b/packages/std/tangram.tg
@@ -54,7 +54,7 @@ import * as wrap from "./wrap.tg";
 export let testWrap = tg.target(async () => {
 	let shell = await bootstrap.shell();
 	let exe = tg.File.expect(await shell.get("bin/dash"));
-	return await wrap.wrap(exe, { env: { HELLO: tg.Mutation.templateAppend(tg`hi`) }});
+	return await wrap.wrap(exe, { env: { HELLO: tg.Mutation.set(tg`hi`) }});
 
 });
 export let testMuslWrapper = tg.target(async () => {

--- a/packages/std/utils.tg
+++ b/packages/std/utils.tg
@@ -84,7 +84,7 @@ export let buildUtil = tg.target(
 );
 
 /** Given a file containing a shell script, change the given shebang to use /usr/bin/env.  The SDK will place bash on the path.  */
-export let changeShebang = tg.target(async (scriptFile: tg.File) => {
+export let changeShebang = async (scriptFile: tg.File) => {
 	// Ensure the file has a shebang.
 	let metadata = await std.file.executableMetadata(scriptFile);
 	tg.assert(metadata.format === "shebang");
@@ -101,9 +101,9 @@ export let changeShebang = tg.target(async (scriptFile: tg.File) => {
 	let newFileContents = `#!/usr/bin/env bash\n${fileWithoutShebangLine}`;
 	let newFile = tg.file({ contents: newFileContents, executable: true });
 	return newFile;
-});
+};
 
-export let assertProvides = tg.target(async (env: std.env.Arg) => {
+export let assertProvides = async (env: std.env.Arg) => {
 	let names = [
 		"bash",
 		"ls", // coreutils
@@ -117,7 +117,7 @@ export let assertProvides = tg.target(async (env: std.env.Arg) => {
 	];
 	await std.env.assertProvides({ env, names });
 	return true;
-});
+};
 
 export let test = tg.target(async () => {
 	let utilsEnv = await env({ sdk: { bootstrapMode: true } });

--- a/packages/std/wrap.tg
+++ b/packages/std/wrap.tg
@@ -444,15 +444,10 @@ export namespace wrap {
 					env?.kind === "set",
 					"Malformed env, expected set mutation but recieved " + env,
 				);
-				tg.assert(
-					env.value.kind === "map",
-					"Malformed env, expected a map but recieved " + env.value,
-				);
 				let envMap: wrap.Manifest.EnvMap = await envMapFromMapValue(env.value);
 				// If the running env is a set mutation, grab the current contents.
 				let map: wrap.Manifest.EnvMap = await envMapFromManifestEnv(result);
 				for await (let [name, val] of Object.entries(envMap)) {
-					console.log("name", name, "val", val);
 					if (val === undefined) {
 						// do nothing
 					} else {
@@ -463,9 +458,7 @@ export namespace wrap {
 							map[name] = [];
 						}
 						for (let mutation of val) {
-							console.log("map at name", name, map[name]);
 							let lastExistingMutation = map[name]?.at(-1);
-							console.log("lastExistingMutation", lastExistingMutation);
 							if (lastExistingMutation) {
 								// Attempt to merge the current mutation with the previous.
 								let mergedMutations = await mergeMutations(
@@ -1062,44 +1055,6 @@ let manifestSymlinkFromArg = async (
 	}
 };
 
-// FIXME remove or restore
-// /** Given a manifest value, produce the env object it contains. Error if it's malformed. */
-// let envMapFromManifestValue = async (
-// 	value: wrap.Manifest.Value,
-// ): Promise<wrap.Manifest.EnvMap> => {
-// 	if (value.kind === "map") {
-// 		let ret: wrap.Manifest.EnvMap = {};
-// 		for (let [key, val] of Object.entries(value.value)) {
-// 			if (val.kind === "mutation") {
-// 				ret[key] = [await mutationFromManifestMutation(val.value)];
-// 			} else if (val.kind === "array") {
-// 				let arr = [];
-// 				for (let mutation of val.value) {
-// 					tg.assert(
-// 						mutation.kind === "mutation",
-// 						"Malformed env, expected mutation but received " + mutation,
-// 					);
-// 					arr.push(mutation.value);
-// 				}
-// 				ret[key] = await Promise.all(arr.map(mutationFromManifestMutation));
-// 			} else {
-// 				throw new Error(
-// 					"Malformed env, expected either a mutation or array of mutations.",
-// 				);
-// 			}
-// 		}
-// 		return ret;
-// 	} else {
-// 		throw new Error("Malformed env, expected a map.");
-// 	}
-// };
-
-// let manifestValueFromManifestMutation = (
-// 	mutation: wrap.Manifest.Mutation,
-// ): wrap.Manifest.Value => {
-// 	return { kind: "mutation", value: mutation };
-// };
-
 let valueIsTemplateLike = (
 	value: tg.Value,
 ): value is string | tg.Template | tg.Artifact => {
@@ -1666,7 +1621,6 @@ let envMapFromMapValue = async (
 	);
 	let ret: wrap.Manifest.EnvMap = {};
 	for (let [key, val] of Object.entries(value.value)) {
-		console.log("key", key, "val", val);
 		if (val.kind === "mutation") {
 			ret[key] = [await mutationFromManifestMutation(val.value)];
 		} else if (val.kind === "array") {

--- a/packages/std/wrap.tg
+++ b/packages/std/wrap.tg
@@ -201,6 +201,8 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 		env: manifestEnv,
 		args: manifestArgs ?? [],
 	};
+	console.log("manifest", manifest);
+	console.log("json", tg.encoding.json.encode(manifest));
 
 	// Get the wrapper executable.
 	let host = host_ ? std.triple(host_) : await std.Triple.host();
@@ -303,14 +305,14 @@ export namespace wrap {
 		interpreter?: Manifest.Interpreter;
 		executable: Manifest.Executable;
 		env?: Manifest.Mutation;
-		args: Array<Manifest.Template>;
+		args?: Array<Manifest.Template>;
 	};
 
 	export let envMapFromManifestEnv = async (
 		mutation: wrap.Manifest.Mutation | undefined,
 	): Promise<wrap.Manifest.EnvMap> => {
 		let ret: wrap.Manifest.EnvMap = {};
-		if (mutation?.kind === "unset" || mutation?.value === undefined) {
+		if (mutation?.kind !== "set") {
 			return ret;
 		}
 		tg.assert(mutation.kind === "set", "Malformed env, expected set or unset.");
@@ -571,17 +573,19 @@ export namespace wrap {
 		export type Mutation =
 			| { kind: "unset" }
 			| { kind: "set"; value: Manifest.Value }
-			| { kind: "set_if_unset"; value: Manifest.Value }
+			| { kind: "setIfUnset"; value: Manifest.Value }
 			| {
-					kind: "template_prepend";
-					value: { template: Manifest.Template; separator?: string };
+					kind: "templatePrepend";
+					template: Manifest.Template;
+					separator?: string;
 			  }
 			| {
-					kind: "template_append";
-					value: { template: Manifest.Template; separator?: string };
+					kind: "templateAppend";
+					template: Manifest.Template;
+					separator?: string;
 			  }
-			| { kind: "array_prepend"; value: Array<Manifest.Value> }
-			| { kind: "array_append"; value: Array<Manifest.Value> };
+			| { kind: "arrayPrepend"; values: Array<Manifest.Value> }
+			| { kind: "arrayAppend"; values: Array<Manifest.Value> };
 
 		// Matches tg::value::Data
 		export type Value =
@@ -1095,7 +1099,7 @@ let manifestMutationFromMutation = async (
 			`Expected a template arg, but got ${JSON.stringify(value)}.`,
 		);
 		return {
-			kind: "set_if_unset",
+			kind: "setIfUnset",
 			value: manifestValueFromManifestTemplate(
 				await manifestTemplateFromArg(value),
 			),
@@ -1107,11 +1111,9 @@ let manifestMutationFromMutation = async (
 			`Expected a template arg, but got ${JSON.stringify(template)}.`,
 		);
 		return {
-			kind: "template_prepend",
-			value: {
-				template: await manifestTemplateFromArg(template),
-				separator: mutation.inner.separator,
-			},
+			kind: "templatePrepend",
+			template: await manifestTemplateFromArg(template),
+			separator: mutation.inner.separator,
 		};
 	} else if (mutation.inner.kind === "template_append") {
 		let template = mutation.inner.template;
@@ -1120,28 +1122,26 @@ let manifestMutationFromMutation = async (
 			`Expected a template arg, but got ${JSON.stringify(template)}.`,
 		);
 		return {
-			kind: "template_append",
-			value: {
-				template: await manifestTemplateFromArg(template),
-				separator: mutation.inner.separator,
-			},
+			kind: "templateAppend",
+			template: await manifestTemplateFromArg(template),
+			separator: mutation.inner.separator,
 		};
 	} else if (mutation.inner.kind === "array_prepend") {
 		tg.assert(mutation.inner.values.every(valueIsTemplateLike));
-		let value = await Promise.all(
+		let values = await Promise.all(
 			mutation.inner.values.map(async (arg) =>
 				manifestValueFromManifestTemplate(await manifestTemplateFromArg(arg)),
 			),
 		);
-		return { kind: "array_prepend", value };
+		return { kind: "arrayPrepend", values };
 	} else if (mutation.inner.kind === "array_append") {
 		tg.assert(mutation.inner.values.every(valueIsTemplateLike));
-		let value = await Promise.all(
+		let values = await Promise.all(
 			mutation.inner.values.map(async (arg) =>
 				manifestValueFromManifestTemplate(await manifestTemplateFromArg(arg)),
 			),
 		);
-		return { kind: "array_append", value };
+		return { kind: "arrayAppend", values };
 	} else {
 		return tg.unreachable();
 	}
@@ -1491,27 +1491,27 @@ let mutationFromManifestMutation = (
 		return Promise.resolve(tg.Mutation.unset());
 	} else if (manifestMutation.kind === "set") {
 		return tg.Mutation.set(valueFromManifestValue(manifestMutation.value));
-	} else if (manifestMutation.kind === "set_if_unset") {
+	} else if (manifestMutation.kind === "setIfUnset") {
 		return tg.Mutation.setIfUnset(
 			valueFromManifestValue(manifestMutation.value),
 		);
-	} else if (manifestMutation.kind === "array_prepend") {
+	} else if (manifestMutation.kind === "arrayPrepend") {
 		return tg.Mutation.arrayAppend(
-			manifestMutation.value.map(valueFromManifestValue),
+			manifestMutation.values.map(valueFromManifestValue),
 		);
-	} else if (manifestMutation.kind === "array_append") {
+	} else if (manifestMutation.kind === "arrayAppend") {
 		return tg.Mutation.arrayAppend(
-			manifestMutation.value.map(valueFromManifestValue),
+			manifestMutation.values.map(valueFromManifestValue),
 		);
-	} else if (manifestMutation.kind === "template_prepend") {
+	} else if (manifestMutation.kind === "templatePrepend") {
 		return tg.Mutation.templatePrepend(
-			templateFromManifestTemplate(manifestMutation.value.template),
-			manifestMutation.value.separator,
+			templateFromManifestTemplate(manifestMutation.template),
+			manifestMutation.separator,
 		);
-	} else if (manifestMutation.kind === "template_append") {
+	} else if (manifestMutation.kind === "templateAppend") {
 		return tg.Mutation.templateAppend(
-			templateFromManifestTemplate(manifestMutation.value.template),
-			manifestMutation.value.separator,
+			templateFromManifestTemplate(manifestMutation.template),
+			manifestMutation.separator,
 		);
 	} else {
 		return tg.unreachable();
@@ -1768,16 +1768,16 @@ function* manifestMutationReferences(
 		case "unset":
 			break;
 		case "set":
-		case "set_if_unset":
+		case "setIfUnset":
 			yield* manifestValueReferences(mutation.value);
 			break;
-		case "template_prepend":
-		case "template_append":
-			yield* manifestTemplateReferences(mutation.value.template);
+		case "templatePrepend":
+		case "templateAppend":
+			yield* manifestTemplateReferences(mutation.template);
 			break;
-		case "array_prepend":
-		case "array_append":
-			for (let value of mutation.value) {
+		case "arrayPrepend":
+		case "arrayAppend":
+			for (let value of mutation.values) {
 				yield* manifestValueReferences(value);
 			}
 			break;

--- a/packages/std/wrap.tg
+++ b/packages/std/wrap.tg
@@ -201,8 +201,6 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 		env: manifestEnv,
 		args: manifestArgs ?? [],
 	};
-	console.log("manifest", manifest);
-	console.log("json", tg.encoding.json.encode(manifest));
 
 	// Get the wrapper executable.
 	let host = host_ ? std.triple(host_) : await std.Triple.host();

--- a/packages/std/wrap.tg
+++ b/packages/std/wrap.tg
@@ -328,7 +328,7 @@ export namespace wrap {
 			let result = undefined;
 			for (let mutation of mutations ?? []) {
 				if (mutation) {
-					result = await mutateTemplate(undefined, mutation);
+					result = await mutateTemplate(result, mutation);
 				}
 			}
 			yield [key, result];

--- a/packages/std/wrap.tg
+++ b/packages/std/wrap.tg
@@ -11,7 +11,7 @@ import * as workspace from "./wrap/workspace.tg";
 /** Wrap an executable. */
 export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 	type Apply = {
-		host: std.Triple;
+		host: std.Triple.Arg;
 		identity: wrap.Identity;
 		interpreter?:
 			| tg.File
@@ -50,10 +50,8 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 			tg.File.assert(file);
 			// Try to read the manifest from it.
 			let existingManifest = await wrap.Manifest.read(file);
-			if (existingManifest) {
-				let env_ = await maybeMutatonEnvArgObjectFromManifestEnv(
-					existingManifest.env,
-				);
+			if (existingManifest !== undefined) {
+				let env_ = await envArgObjectFromManifestEnv(existingManifest.env);
 				let env = tg.Mutation.is(env_)
 					? env_
 					: await tg.Mutation.arrayAppend(env_);
@@ -89,31 +87,32 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 			};
 		} else if (isArgObject(arg)) {
 			let object: tg.MutationMap<Apply> = {};
-			if ("env" in arg) {
+			if (arg.env !== undefined) {
 				object.env = tg.Mutation.is(arg.env)
 					? arg.env
-					: await tg.Mutation.arrayAppend<wrap.Manifest.Env>([
-							(await wrap.manifestEnvFromArg(std.flatten(arg.env))) ?? {
-								kind: "map",
-								value: {},
-							},
-					  ]);
+					: await tg.Mutation.arrayAppend<std.env.Arg>(arg.env);
 			}
-			if ("identity" in arg) {
+			if (arg.identity !== undefined) {
 				object.identity = arg.identity ?? "executable";
 			}
-			if ("executable" in arg) {
-				object.executable = {
-					kind:
-						tg.Template.is(arg.executable) ||
-						tg.Artifact.is(arg.executable) ||
-						typeof arg.executable === "string"
-							? "path"
-							: "content",
-					value: await manifestTemplateFromArg(arg.executable),
-				};
+			if (arg.executable !== undefined) {
+				if (
+					tg.Template.is(arg.executable) ||
+					tg.Artifact.is(arg.executable) ||
+					typeof arg.executable === "string"
+				) {
+					object.executable = {
+						kind: "content",
+						value: await manifestTemplateFromArg(arg.executable),
+					};
+				} else {
+					object.executable = {
+						kind: "path",
+						value: await manifestSymlinkFromArg(arg.executable),
+					};
+				}
 			}
-			if ("libraryPaths" in arg) {
+			if (arg.libraryPaths !== undefined) {
 				if (arg.libraryPaths !== undefined) {
 					object.libraryPaths = tg.Mutation.is(arg.libraryPaths)
 						? arg.libraryPaths
@@ -122,20 +121,20 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 						  );
 				}
 			}
-			if ("interpreter" in arg) {
+			if (arg.interpreter !== undefined) {
 				object.interpreter = arg.interpreter;
 			}
-			if ("executable" in arg) {
+			if (arg.executable !== undefined) {
 				object.executable = arg.executable;
 			}
-			if ("args" in arg) {
+			if (arg.args !== undefined) {
 				object.manifestArgs = tg.Mutation.is(arg.args)
 					? arg.args
 					: await tg.Mutation.arrayAppend(
 							(arg.args ?? []).map(manifestTemplateFromArg),
 					  );
 			}
-			if ("host" in arg) {
+			if (arg.host !== undefined) {
 				object.host = std.triple(arg.host);
 			}
 
@@ -180,7 +179,7 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 		let paths = manifestInterpreter.libraryPaths ?? [];
 		if (libraryPaths) {
 			paths = paths.concat(
-				await Promise.all(libraryPaths.map(manifestTemplateFromArg)),
+				await Promise.all(libraryPaths.map(manifestSymlinkFromArg)),
 			);
 		}
 		manifestInterpreter.libraryPaths = paths;
@@ -197,7 +196,7 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 	};
 
 	// Get the wrapper executable.
-	let host = await std.Triple.host(host_);
+	let host = host_ ? std.triple(host_) : await std.Triple.host();
 	let wrapper = await workspace.wrapper({ host });
 
 	// Write the manifest to the wrapper and return.
@@ -304,10 +303,10 @@ export namespace wrap {
 	export async function* envVars(
 		env: wrap.Manifest.Env | undefined,
 	): AsyncGenerator<[string, tg.Template | undefined]> {
-		if (env === undefined || env.kind !== "map") {
+		if (env === undefined || env.kind !== "set") {
 			return;
 		}
-		let map = env.value;
+		let map = envMapFromManifestValue(env.value);
 		for (let [key, mutations] of Object.entries(map)) {
 			let result: tg.Template | undefined;
 			for (let mutation of std.flatten([mutations])) {
@@ -319,12 +318,10 @@ export namespace wrap {
 	}
 
 	export let manifestEnvFromArg = async (
-		arg: std.env.Arg | wrap.Manifest.Env | undefined,
+		arg: std.env.Arg | undefined,
 	): Promise<wrap.Manifest.Env | undefined> => {
-		if (arg && "kind" in arg && (arg.kind === "unset" || arg.kind === "map")) {
-			return arg as wrap.Manifest.Env;
-		} else if (arg === undefined) {
-			return { kind: "map", value: {} };
+		if (arg === undefined) {
+			return undefined;
 		} else if (tg.Mutation.is(arg)) {
 			tg.assert(
 				arg.inner.kind === "unset",
@@ -356,13 +353,7 @@ export namespace wrap {
 				pushOrSet(
 					ret,
 					"PATH",
-					manifestMaybeMutationFromManifestMutation({
-						kind: "template_prepend",
-						value: {
-							template: await manifestTemplateFromArg(await tg`${arg}/bin`),
-							separator: ":",
-						},
-					}),
+					await tg.Mutation.templatePrepend(tg`${arg}/bin`, ":"),
 				);
 			}
 			let includeDir = await arg.tryGet("include");
@@ -377,15 +368,7 @@ export namespace wrap {
 					pushOrSet(
 						ret,
 						"CPATH",
-						manifestMaybeMutationFromManifestMutation({
-							kind: "template_prepend",
-							value: {
-								template: await manifestTemplateFromArg(
-									await tg`${arg}/include`,
-								),
-								separator: ":",
-							},
-						}),
+						await tg.Mutation.templatePrepend(tg`${arg}/include`, ":"),
 					);
 				}
 			}
@@ -393,31 +376,17 @@ export namespace wrap {
 				pushOrSet(
 					ret,
 					"LIBRARY_PATH",
-					manifestMaybeMutationFromManifestMutation({
-						kind: "template_prepend",
-						value: {
-							template: await manifestTemplateFromArg(await tg`${arg}/lib`),
-							separator: ":",
-						},
-					}),
+					await tg.Mutation.templatePrepend(tg`${arg}/lib`, ":"),
 				);
 				if (await arg.tryGet("lib/pkgconfig")) {
 					pushOrSet(
 						ret,
 						"PKG_CONFIG_PATH",
-						manifestMaybeMutationFromManifestMutation({
-							kind: "template_prepend",
-							value: {
-								template: await manifestTemplateFromArg(
-									await tg`${arg}/lib/pkgconfig`,
-								),
-								separator: ":",
-							},
-						}),
+						await tg.Mutation.templatePrepend(tg`${arg}/lib/pkgconfig`, ":"),
 					);
 				}
 			}
-			return { kind: "map", value: ret };
+			return manifestMutationFromMutation(await tg.Mutation.set(ret));
 		} else if (Array.isArray(arg)) {
 			// If the arg is an array, then recurse.
 			return mergeEnvs(...(await Promise.all(arg.map(manifestEnvFromArg))));
@@ -426,7 +395,7 @@ export namespace wrap {
 			let ret = Object.fromEntries(
 				await Promise.all(
 					Object.entries(arg).map<
-						Promise<[string, Array<wrap.Manifest.MaybeMutation>]>
+						Promise<[string, Array<wrap.Manifest.Mutation>]>
 					>(async ([key, mutationArgs]) => {
 						let mutations = tg.Mutation.is(mutationArgs)
 							? [await manifestMutationFromMutation(mutationArgs)]
@@ -435,24 +404,19 @@ export namespace wrap {
 										.flatten([mutationArgs])
 										.map(manifestMutationFromMaybeMutation),
 							  );
-						return [
-							key,
-							mutations.map((mutation) => {
-								return { kind: "mutation", value: mutation };
-							}),
-						];
+						return [key, mutations];
 					}),
 				),
 			);
-			return { kind: "map", value: ret };
+			return manifestMutationFromMutation(await tg.Mutation.set(ret));
 		} else {
 			return tg.unreachable();
 		}
 	};
 
-	export let mergeEnvs = (
+	export let mergeEnvs = async (
 		...envs: Array<wrap.Manifest.Env | undefined>
-	): wrap.Manifest.Env | undefined => {
+	): Promise<wrap.Manifest.Env | undefined> => {
 		let result: wrap.Manifest.Env | undefined;
 		for (let env of envs) {
 			if (env === undefined) {
@@ -460,10 +424,15 @@ export namespace wrap {
 			} else if (env.kind === "unset") {
 				result = env;
 			} else {
+				tg.assert(
+					result?.kind === "set",
+					"Malformed env, unexpected mutation.",
+				);
 				let envMap = env.value ?? {};
-				let map: wrap.Manifest.EnvMap =
-					result?.kind === "map" ? result?.value : {};
-				for (let [name, val] of Object.entries(envMap)) {
+				let map: wrap.Manifest.EnvMap = manifestEnvMapFromManifestValue(
+					result?.value,
+				);
+				for await (let [name, val] of Object.entries(envMap)) {
 					if (val === undefined) {
 						// do nothing
 					} else {
@@ -475,24 +444,17 @@ export namespace wrap {
 						}
 						for (let mutation of val) {
 							let lastExistingMutation = map[name]?.at(-1);
-							if (
-								lastExistingMutation &&
-								lastExistingMutation.kind === "mutation"
-							) {
+							if (lastExistingMutation) {
 								// Attempt to merge the current mutation with the previous.
-								if (mutation.kind === "mutation") {
-									let mergedMutations = mergeManifestMutations(
-										lastExistingMutation.value,
-										mutation.value,
-									).map((mutation) =>
-										manifestMaybeMutationFromManifestMutation(mutation),
-									);
+								let mergedMutations = mergeManifestMutations(
+									lastExistingMutation,
+									mutation.value,
+								);
 
-									// Replace the last mutation with the merged mutations.
-									map[name] = (map[name] ?? [])
-										.slice(0, -1)
-										.concat(mergedMutations);
-								}
+								// Replace the last mutation with the merged mutations.
+								map[name] = (map[name] ?? [])
+									.slice(0, -1)
+									.concat(mergedMutations);
 							} else {
 								// Otherwise, just append the mutation.
 								map[name] = (map[name] ?? []).concat([mutation]);
@@ -500,7 +462,7 @@ export namespace wrap {
 						}
 					}
 				}
-				result = { kind: "map", value: map };
+				result = await manifestMutationFromMutation(await tg.Mutation.set(map));
 			}
 		}
 		return result;
@@ -517,50 +479,58 @@ export namespace wrap {
 
 		export type NormalInterpreter = {
 			kind: "normal";
-			path: Manifest.Template;
+			path: Manifest.Symlink;
 			args?: Array<Manifest.Template>;
 		};
 
 		export type LdLinuxInterpreter = {
 			kind: "ld-linux";
-			path: Manifest.Template;
-			libraryPaths?: Array<Manifest.Template>;
-			preloads?: Array<Manifest.Template>;
+			path: Manifest.Symlink;
+			libraryPaths?: Array<Manifest.Symlink>;
+			preloads?: Array<Manifest.Symlink>;
 			args?: Array<Manifest.Template>;
 		};
 
 		export type LdMuslInterpreter = {
 			kind: "ld-musl";
-			path: Manifest.Template;
-			libraryPaths?: Array<Manifest.Template>;
-			preloads?: Array<Manifest.Template>;
+			path: Manifest.Symlink;
+			libraryPaths?: Array<Manifest.Symlink>;
+			preloads?: Array<Manifest.Symlink>;
 			args?: Array<Manifest.Template>;
 		};
 
 		export type DyLdInterpreter = {
 			kind: "dyld";
-			libraryPaths?: Array<Manifest.Template>;
-			preloads?: Array<Manifest.Template>;
+			libraryPaths?: Array<Manifest.Symlink>;
+			preloads?: Array<Manifest.Symlink>;
 		};
 
 		export type Executable =
-			| { kind: "path"; value: Manifest.Template }
+			| { kind: "path"; value: Manifest.Symlink }
 			| { kind: "content"; value: Manifest.Template };
 
+		export type Symlink = {
+			artifact?: tg.Artifact.Id;
+			path?: string;
+		};
+
+		// Matches tg::template::Data
 		export type Template = {
 			components: Array<Manifest.Template.Component>;
 		};
 
+		// Matches tg::template::component::Data
 		export namespace Template {
 			export type Component =
 				| { kind: "string"; value: string }
 				| { kind: "artifact"; value: tg.Artifact.Id };
 		}
 
+		// Matches tg::mutation::Data
 		export type Mutation =
 			| { kind: "unset" }
-			| { kind: "set"; value: Manifest.Template }
-			| { kind: "set_if_unset"; value: Manifest.Template }
+			| { kind: "set"; value: Manifest.Value }
+			| { kind: "set_if_unset"; value: Manifest.Value }
 			| {
 					kind: "template_prepend";
 					value: { template: Manifest.Template; separator?: string };
@@ -569,18 +539,27 @@ export namespace wrap {
 					kind: "template_append";
 					value: { template: Manifest.Template; separator?: string };
 			  }
-			| { kind: "array_prepend"; value: Array<Manifest.Template> }
-			| { kind: "array_append"; value: Array<Manifest.Template> };
+			| { kind: "array_prepend"; value: Array<Manifest.Value> }
+			| { kind: "array_append"; value: Array<Manifest.Value> };
 
-		export type Env = { kind: "unset" } | { kind: "map"; value: EnvMap };
-
-		export type EnvMap = {
-			[key: string]: Array<Manifest.MaybeMutation>;
-		};
-
-		export type MaybeMutation =
+		// Matches tg::value::Data
+		export type Value =
+			| { kind: "null" }
+			| { kind: "bool"; value: boolean }
+			| { kind: "number"; value: number }
+			| { kind: "string"; value: string }
+			| { kind: "directory"; value: tg.Directory.Id }
+			| { kind: "file"; value: tg.File.Id }
+			| { kind: "symlink"; value: tg.Symlink.Id }
+			| { kind: "template"; value: Manifest.Template }
 			| { kind: "mutation"; value: Manifest.Mutation }
-			| { kind: "template"; value: Manifest.Template };
+			| { kind: "array"; value: Array<Value> }
+			| { kind: "map"; value: { [key: string]: Value } };
+
+		// An Env can be any mutation, but only Unset or Set where the value is an EnvMap are valid.
+		export type Env = Manifest.Mutation;
+		// The expected value type in a Manifest.Env of the Set variant.
+		export type EnvMap = { [key: string]: Array<Manifest.Mutation> };
 
 		/** Read a manifest from the end of a file. */
 		export let read = async (
@@ -703,15 +682,49 @@ const MANIFEST_MAGIC_NUMBER: Uint8Array = new Uint8Array([
 
 const MANIFEST_VERSION = 0;
 
+let manifestEnvMapFromManifestValue = (
+	value: wrap.Manifest.Value | undefined,
+): wrap.Manifest.EnvMap => {
+	let ret: wrap.Manifest.EnvMap = {};
+	if (value === undefined) {
+		return ret;
+	} else if (value.kind === "map") {
+		for (let [key, val] of Object.entries(value.value)) {
+			if (val.kind === "mutation") {
+				ret[key] = [val.value];
+			} else if (val.kind === "array") {
+				for (let mutation of val.value) {
+					let arr = ret[key] ?? [];
+					tg.assert(
+						mutation.kind === "mutation",
+						"Malformed env, expected mutation.",
+					);
+					arr.push(mutation.value);
+					ret[key] = arr;
+				}
+			} else {
+				throw new Error(
+					"Malformed env, expected either a mutation or array of mutations.",
+				);
+			}
+		}
+		return ret;
+	} else {
+		return tg.unreachable();
+	}
+};
+
 let manifestExecutableFromArg = async (
 	arg: string | tg.Template | tg.File | tg.Symlink | wrap.Manifest.Executable,
 ): Promise<wrap.Manifest.Executable> => {
 	if (isManifestExecutable(arg)) {
 		return arg;
 	} else if (tg.File.is(arg) || tg.Symlink.is(arg)) {
+		let value = await manifestSymlinkFromArg(arg);
+		tg.assert(value);
 		return {
 			kind: "path",
-			value: await manifestTemplateFromArg(arg),
+			value,
 		};
 	} else if (typeof arg === "string" || tg.Template.is(arg)) {
 		return {
@@ -743,7 +756,7 @@ let manifestInterpreterFromArg = async (
 	// If the arg is an executable, then wrap it and create a normal interpreter.
 	if (tg.File.is(arg) || tg.Symlink.is(arg)) {
 		let interpreter = await std.wrap(arg);
-		let path = await manifestTemplateFromArg(interpreter);
+		let path = await manifestSymlinkFromArg(interpreter);
 		return {
 			kind: "normal",
 			path,
@@ -754,9 +767,13 @@ let manifestInterpreterFromArg = async (
 	// Otherwise, create the interpreter specified by the arg object.
 	if ("kind" in arg && arg.kind === "ld-linux") {
 		// Handle an ld-linux interpreter.
-		let path = await manifestTemplateFromArg(arg.executable);
+		let path = await manifestSymlinkFromArg(arg.executable);
 		let libraryPaths = arg.libraryPaths
-			? await Promise.all(arg.libraryPaths.map(manifestTemplateFromArg))
+			? await Promise.all(
+					arg.libraryPaths.map(async (arg) =>
+						manifestSymlinkFromArg(await tg.template(arg)),
+					),
+			  )
 			: undefined;
 
 		// Build an injection dylib to match the interpreter.
@@ -782,9 +799,13 @@ let manifestInterpreterFromArg = async (
 		});
 
 		// Combine the injection with any additional preloads specified by the caller.
-		let preloads = [await manifestTemplateFromArg(injectionLibrary)];
+		let preloads = [await manifestSymlinkFromArg(injectionLibrary)];
 		let additionalPreloads = arg.preloads
-			? await Promise.all(arg.preloads?.map(manifestTemplateFromArg))
+			? await Promise.all(
+					arg.preloads?.map(async (arg) =>
+						manifestSymlinkFromArg(await tg.template(arg)),
+					),
+			  )
 			: [];
 		preloads = preloads.concat(additionalPreloads);
 		let args = arg.args
@@ -799,9 +820,13 @@ let manifestInterpreterFromArg = async (
 		};
 	} else if ("kind" in arg && arg.kind === "ld-musl") {
 		// Handle an ld-musl interpreter.
-		let path = await manifestTemplateFromArg(arg.executable);
+		let path = await manifestSymlinkFromArg(arg.executable);
 		let libraryPaths = arg.libraryPaths
-			? await Promise.all(arg.libraryPaths.map(manifestTemplateFromArg))
+			? await Promise.all(
+					arg.libraryPaths.map(async (arg) =>
+						manifestSymlinkFromArg(await tg.template(arg)),
+					),
+			  )
 			: undefined;
 
 		// Build an injection dylib to match the interpreter.
@@ -827,9 +852,13 @@ let manifestInterpreterFromArg = async (
 		});
 
 		// Combine the injection with any additional preloads specified by the caller.
-		let preloads = [await manifestTemplateFromArg(injectionLibrary)];
+		let preloads = [await manifestSymlinkFromArg(injectionLibrary)];
 		let additionalPreloads = arg.preloads
-			? await Promise.all(arg.preloads?.map(manifestTemplateFromArg))
+			? await Promise.all(
+					arg.preloads?.map(async (arg) =>
+						manifestSymlinkFromArg(await tg.template(arg)),
+					),
+			  )
 			: [];
 		preloads = preloads.concat(additionalPreloads);
 
@@ -846,15 +875,23 @@ let manifestInterpreterFromArg = async (
 	} else if ("kind" in arg && arg.kind === "dyld") {
 		// Handle a dyld interpreter.
 		let libraryPaths = arg.libraryPaths
-			? await Promise.all(arg.libraryPaths.map(manifestTemplateFromArg))
+			? await Promise.all(
+					arg.libraryPaths.map(async (arg) =>
+						manifestSymlinkFromArg(await tg.template(arg)),
+					),
+			  )
 			: undefined;
 		// Select the universal machO injecton dylib.  Either arch will produce the same result, so just pick one.
 		let injectionLibrary = await injection.default({
 			host: `aarch64-apple-darwin`,
 		});
-		let preloads = [await manifestTemplateFromArg(injectionLibrary)];
+		let preloads = [await manifestSymlinkFromArg(injectionLibrary)];
 		let additionalPreloads = arg.preloads
-			? await Promise.all(arg.preloads?.map(manifestTemplateFromArg))
+			? await Promise.all(
+					arg.preloads?.map(async (arg) =>
+						manifestSymlinkFromArg(await tg.template(arg)),
+					),
+			  )
 			: [];
 		preloads = preloads.concat(additionalPreloads);
 		return {
@@ -864,7 +901,7 @@ let manifestInterpreterFromArg = async (
 		};
 	} else {
 		// Handle a normal interpreter.
-		let path = await manifestTemplateFromArg(arg.executable);
+		let path = await manifestSymlinkFromArg(arg.executable);
 		let args = await Promise.all(arg.args?.map(manifestTemplateFromArg) ?? []);
 		return {
 			kind: "normal",
@@ -917,7 +954,7 @@ let manifestInterpreterFromExecutableArg = async (
 				kind: "dyld",
 				libraryPaths: undefined,
 				preloads: [
-					await manifestTemplateFromArg(
+					await manifestSymlinkFromArg(
 						await injection.default({ host: triple }),
 					),
 				],
@@ -961,11 +998,15 @@ let manifestInterpreterFromElf = async (
 		let { ldso, libDir } = await std.sdk.toolchainComponents({
 			env: toolchainDir,
 		});
+		tg.assert(
+			ldso,
+			"Could not find a valid ldso, required for Linux wrappers.",
+		);
 		return {
 			kind: "ld-linux",
-			path: await manifestTemplateFromArg(ldso),
-			libraryPaths: [await manifestTemplateFromArg(libDir)],
-			preloads: [await manifestTemplateFromArg(injectionLib)],
+			path: await manifestSymlinkFromArg(ldso),
+			libraryPaths: [await manifestSymlinkFromArg(libDir)],
+			preloads: [await manifestSymlinkFromArg(injectionLib)],
 			args: undefined,
 		};
 	} else if (metadata.interpreter?.includes("ld-musl")) {
@@ -976,9 +1017,9 @@ let manifestInterpreterFromElf = async (
 		let ldso = tg.File.expect(await libDir.get(interpreterName(host)));
 		return {
 			kind: "ld-musl",
-			path: await manifestTemplateFromArg(ldso),
-			libraryPaths: [await manifestTemplateFromArg(libDir)],
-			preloads: [await manifestTemplateFromArg(injectionLib)],
+			path: await manifestSymlinkFromArg(ldso),
+			libraryPaths: [await manifestSymlinkFromArg(libDir)],
+			preloads: [await manifestSymlinkFromArg(injectionLib)],
 			args: undefined,
 		};
 	} else {
@@ -1004,35 +1045,46 @@ export let defaultShellInterpreter = tg.target(async () => {
 	return bash;
 });
 
-export let maybeMutatonEnvArgObjectFromManifestEnv = async (
-	env: wrap.Manifest.Env | undefined,
-): Promise<tg.MaybeMutation<std.env.ArgObject>> => {
-	if (env === undefined) {
-		return Promise.resolve({});
-	}
-	if (env.kind === "unset") {
-		return tg.Mutation.unset();
+let manifestValueFromMutation = (
+	mutation: tg.Mutation,
+): Promise<wrap.Manifest.Value> => {
+	return tg.unimplemented();
+};
+
+let manifestSymlinkFromArg = async (
+	arg: string | tg.Template | tg.Artifact,
+): Promise<wrap.Manifest.Symlink> => {
+	if (typeof arg === "string" || tg.Template.is(arg)) {
+		return manifestSymlinkFromArg(await tg.symlink(arg));
+	} else if (tg.Artifact.is(arg)) {
+		return { artifact: await arg.id() };
 	} else {
-		return envArgObjectFromManifestEnvMap(env.value);
+		return tg.unreachable();
 	}
 };
 
-let envArgObjectFromManifestEnvMap = async (
-	env: wrap.Manifest.EnvMap,
+let manifestSymlinkFromManifestTemplate = async (
+	template: wrap.Manifest.Template,
+): Promise<wrap.Manifest.Symlink> => {
+	return tg.unimplemented();
+	// let components = template.components;
+	// if (components.length === 1) {
+	// 	// Just an artifact
+	// 	return { path: mponents[0].value };
+	// } else {
+	// }
+};
+
+let envArgObjectFromManifestEnv = async (
+	env: wrap.Manifest.Env | undefined,
 ): Promise<std.env.ArgObject> => {
 	let ret: std.env.ArgObject = {};
-	for (let [key, value] of Object.entries(env)) {
-		ret[key] = await Promise.all(
-			value.map(async (mutation) => {
-				if (mutation.kind === "mutation") {
-					return await mutationFromManifestMutation(mutation.value);
-				} else if (mutation.kind === "template") {
-					return await templateFromManifestTemplate(mutation.value);
-				} else {
-					return tg.unreachable();
-				}
-			}),
-		);
+	if (env === undefined) {
+		return ret;
+	}
+	let map = envMapFromManifestValue(manifestValueFromManifestMutation(env));
+	for (let [key, value] of Object.entries(map)) {
+		ret[key] = await Promise.all(value.map(mutationFromManifestMutation));
 		if (ret[key] instanceof Array) {
 			let arr = ret[key];
 			tg.assert(arr instanceof Array);
@@ -1045,9 +1097,16 @@ let envArgObjectFromManifestEnvMap = async (
 	return ret;
 };
 
-let manifestMaybeMutationFromManifestMutation = (
+/** Given a manifest value, produce the env object it contains. Error if it's malformed. */
+let envMapFromManifestValue = (
+	value: wrap.Manifest.Value,
+): wrap.Manifest.EnvMap => {
+	return tg.unimplemented();
+};
+
+let manifestValueFromManifestMutation = (
 	mutation: wrap.Manifest.Mutation,
-): wrap.Manifest.MaybeMutation => {
+): wrap.Manifest.Value => {
 	return { kind: "mutation", value: mutation };
 };
 
@@ -1070,7 +1129,12 @@ let manifestMutationFromMutation = async (
 			valueIsTemplateLike(value),
 			`Expected a template arg, but got ${JSON.stringify(value)}.`,
 		);
-		return { kind: "set", value: await manifestTemplateFromArg(value) };
+		return {
+			kind: "set",
+			value: manifestValueFromManifestTemplate(
+				await manifestTemplateFromArg(value),
+			),
+		};
 	} else if (mutation.inner.kind === "set_if_unset") {
 		let value = mutation.inner.value;
 		tg.assert(
@@ -1079,7 +1143,9 @@ let manifestMutationFromMutation = async (
 		);
 		return {
 			kind: "set_if_unset",
-			value: await manifestTemplateFromArg(value),
+			value: manifestValueFromManifestTemplate(
+				await manifestTemplateFromArg(value),
+			),
 		};
 	} else if (mutation.inner.kind === "template_prepend") {
 		let template = mutation.inner.template;
@@ -1110,13 +1176,17 @@ let manifestMutationFromMutation = async (
 	} else if (mutation.inner.kind === "array_prepend") {
 		tg.assert(mutation.inner.values.every(valueIsTemplateLike));
 		let value = await Promise.all(
-			mutation.inner.values.map(manifestTemplateFromArg),
+			mutation.inner.values.map(async (arg) =>
+				manifestValueFromManifestTemplate(await manifestTemplateFromArg(arg)),
+			),
 		);
 		return { kind: "array_prepend", value };
 	} else if (mutation.inner.kind === "array_append") {
 		tg.assert(mutation.inner.values.every(valueIsTemplateLike));
 		let value = await Promise.all(
-			mutation.inner.values.map(manifestTemplateFromArg),
+			mutation.inner.values.map(async (arg) =>
+				manifestValueFromManifestTemplate(await manifestTemplateFromArg(arg)),
+			),
 		);
 		return { kind: "array_append", value };
 	} else {
@@ -1161,13 +1231,43 @@ let mergeManifestMutations = (
 			},
 		];
 	} else if (a.kind === "unset" && b.kind === "template_prepend") {
-		return [{ kind: "set", value: b.value.template }];
+		return [
+			{
+				kind: "set",
+				value: manifestValueFromManifestTemplate(b.value.template),
+			},
+		];
 	} else if (a.kind === "unset" && b.kind === "template_append") {
-		return [{ kind: "set", value: b.value.template }];
+		return [
+			{
+				kind: "set",
+				value: manifestValueFromManifestTemplate(b.value.template),
+			},
+		];
 	} else if (a.kind === "unset" && b.kind === "array_append") {
-		return [{ kind: "set", value: joinManifestTemplates(":", ...b.value) }];
+		return [
+			{
+				kind: "set",
+				value: manifestValueFromManifestTemplate(
+					joinManifestTemplates(
+						":",
+						...b.value.map(manifestTemplateFromManifestValue),
+					),
+				),
+			},
+		];
 	} else if (a.kind === "unset" && b.kind === "array_prepend") {
-		return [{ kind: "set", value: joinManifestTemplates(":", ...b.value) }];
+		return [
+			{
+				kind: "set",
+				value: manifestValueFromManifestTemplate(
+					joinManifestTemplates(
+						":",
+						...b.value.map(manifestTemplateFromManifestValue),
+					),
+				),
+			},
+		];
 	} else if (a.kind === "set" && b.kind === "unset") {
 		return [b];
 	} else if (a.kind === "set" && b.kind === "set") {
@@ -1176,27 +1276,29 @@ let mergeManifestMutations = (
 		return [a];
 	} else if (a.kind === "set" && b.kind === "template_prepend") {
 		let setVal = a.value;
-		tg.assert(isManifestTemplate(setVal));
 		return [
 			{
 				kind: "set",
-				value: joinManifestTemplates(
-					b.value.separator,
-					setVal,
-					b.value.template,
+				value: manifestValueFromManifestTemplate(
+					joinManifestTemplates(
+						b.value.separator,
+						manifestTemplateFromManifestValue(setVal),
+						b.value.template,
+					),
 				),
 			},
 		];
 	} else if (a.kind === "set" && b.kind === "template_append") {
 		let setVal = a.value;
-		tg.assert(isManifestTemplate(setVal));
 		return [
 			{
 				kind: "set",
-				value: joinManifestTemplates(
-					b.value.separator,
-					b.value.template,
-					setVal,
+				value: manifestValueFromManifestTemplate(
+					joinManifestTemplates(
+						b.value.separator,
+						b.value.template,
+						manifestTemplateFromManifestValue(setVal),
+					),
 				),
 			},
 		];
@@ -1311,25 +1413,46 @@ let mergeManifestMutations = (
 	}
 };
 
+let manifestValueFromManifestTemplate = (
+	template: wrap.Manifest.Template,
+): wrap.Manifest.Value => {
+	return {
+		kind: "template",
+		value: template,
+	};
+};
+
+let manifestTemplateFromManifestValue = (
+	value: wrap.Manifest.Value,
+): wrap.Manifest.Template => {
+	if (value.kind === "template") {
+		return value.value;
+	} else if (value.kind === "string") {
+		return {
+			components: [{ kind: "string", value: value.value }],
+		};
+	} else if (
+		value.kind === "directory" ||
+		value.kind === "file" ||
+		value.kind === "symlink"
+	) {
+		return {
+			components: [{ kind: "artifact", value: value.value }],
+		};
+	} else {
+		throw new Error(
+			"Cannot convert value to template: " + JSON.stringify(value),
+		);
+	}
+};
+
 let mutateTemplate = async (
 	t: tg.Template | undefined,
-	maybeMutation: wrap.Manifest.MaybeMutation,
+	mutation: wrap.Manifest.Mutation,
 ): Promise<tg.Template | undefined> => {
-	let mutation: wrap.Manifest.Mutation =
-		maybeMutation.kind === "mutation"
-			? maybeMutation.value
-			: { kind: "set", value: maybeMutation.value };
 	let template = await manifestTemplateFromArg(t);
-	if (mutation.kind === "array_append") {
-		let values = mutation.value;
-		return templateFromManifestTemplate(
-			joinManifestTemplates(":", template, ...values),
-		);
-	} else if (mutation.kind === "array_prepend") {
-		let values = mutation.value;
-		return templateFromManifestTemplate(
-			joinManifestTemplates(":", ...values, template),
-		);
+	if (mutation.kind === "array_append" || mutation.kind === "array_prepend") {
+		throw new Error("Cannot apply an array mutation to a template");
 	} else if (mutation.kind === "template_append") {
 		return templateFromManifestTemplate(
 			joinManifestTemplates(
@@ -1347,10 +1470,14 @@ let mutateTemplate = async (
 			),
 		);
 	} else if (mutation.kind === "set") {
-		return templateFromManifestTemplate(mutation.value);
+		return templateFromManifestTemplate(
+			manifestTemplateFromManifestValue(mutation.value),
+		);
 	} else if (mutation.kind === "set_if_unset") {
 		if (template?.components.length === 0) {
-			return templateFromManifestTemplate(mutation.value);
+			return templateFromManifestTemplate(
+				manifestTemplateFromManifestValue(mutation.value),
+			);
 		}
 	} else if (mutation.kind === "unset") {
 		return tg``;
@@ -1384,20 +1511,18 @@ let mutationFromManifestMutation = (
 	if (manifestMutation.kind === "unset") {
 		return Promise.resolve(tg.Mutation.unset());
 	} else if (manifestMutation.kind === "set") {
-		return tg.Mutation.set(
-			templateFromManifestTemplate(manifestMutation.value),
-		);
+		return tg.Mutation.set(valueFromManifestValue(manifestMutation.value));
 	} else if (manifestMutation.kind === "set_if_unset") {
 		return tg.Mutation.setIfUnset(
-			templateFromManifestTemplate(manifestMutation.value),
+			valueFromManifestValue(manifestMutation.value),
 		);
 	} else if (manifestMutation.kind === "array_prepend") {
 		return tg.Mutation.arrayAppend(
-			manifestMutation.value.map(templateFromManifestTemplate),
+			manifestMutation.value.map(valueFromManifestValue),
 		);
 	} else if (manifestMutation.kind === "array_append") {
 		return tg.Mutation.arrayAppend(
-			manifestMutation.value.map(templateFromManifestTemplate),
+			manifestMutation.value.map(valueFromManifestValue),
 		);
 	} else if (manifestMutation.kind === "template_prepend") {
 		return tg.Mutation.templatePrepend(
@@ -1412,6 +1537,12 @@ let mutationFromManifestMutation = (
 	} else {
 		return tg.unreachable();
 	}
+};
+
+let valueFromManifestValue = (
+	value: wrap.Manifest.Value,
+): Promise<tg.Value> => {
+	return tg.unimplemented();
 };
 
 /** Yield the key/value pairs this manifest sets once all mutations are applied. */
@@ -1560,35 +1691,35 @@ async function* manifestReferences(
 			break;
 		}
 		case "normal":
-			yield* manifestTemplateReferences(manifest.interpreter.path);
+			yield* manifestSymlinkReferences(manifest.interpreter.path);
 			for (let arg of manifest.interpreter.args ?? []) {
 				yield* manifestTemplateReferences(arg);
 			}
 			break;
 		case "ld-linux": {
-			yield* manifestTemplateReferences(manifest.interpreter.path);
+			yield* manifestSymlinkReferences(manifest.interpreter.path);
 			if (manifest.interpreter.libraryPaths) {
 				for (let libraryPath of manifest.interpreter.libraryPaths) {
-					yield* manifestTemplateReferences(libraryPath);
+					yield* manifestSymlinkReferences(libraryPath);
 				}
 			}
 			if (manifest.interpreter.preloads) {
 				for (let preload of manifest.interpreter.preloads) {
-					yield* manifestTemplateReferences(preload);
+					yield* manifestSymlinkReferences(preload);
 				}
 			}
 			break;
 		}
 		case "ld-musl": {
-			yield* manifestTemplateReferences(manifest.interpreter.path);
+			yield* manifestSymlinkReferences(manifest.interpreter.path);
 			if (manifest.interpreter.libraryPaths) {
 				for (let libraryPath of manifest.interpreter.libraryPaths) {
-					yield* manifestTemplateReferences(libraryPath);
+					yield* manifestSymlinkReferences(libraryPath);
 				}
 			}
 			if (manifest.interpreter.preloads) {
 				for (let preload of manifest.interpreter.preloads) {
-					yield* manifestTemplateReferences(preload);
+					yield* manifestSymlinkReferences(preload);
 				}
 			}
 			break;
@@ -1596,12 +1727,12 @@ async function* manifestReferences(
 		case "dyld": {
 			if (manifest.interpreter.libraryPaths) {
 				for (let libraryPath of manifest.interpreter.libraryPaths) {
-					yield* manifestTemplateReferences(libraryPath);
+					yield* manifestSymlinkReferences(libraryPath);
 				}
 			}
 			if (manifest.interpreter.preloads) {
 				for (let preload of manifest.interpreter.preloads) {
-					yield* manifestTemplateReferences(preload);
+					yield* manifestSymlinkReferences(preload);
 				}
 			}
 			break;
@@ -1609,40 +1740,11 @@ async function* manifestReferences(
 	}
 
 	// Get the references from the executable.
-	yield* manifestTemplateReferences(manifest.executable.value);
+	yield* manifestExecutableReferences(manifest.executable);
 
 	// Get the references from the env.
-	if (manifest.env?.kind == "map") {
-		for (let mutations of Object.values(manifest.env.value)) {
-			for (let maybeMutation of mutations) {
-				if (maybeMutation.kind === "template") {
-					// It's a template.
-					yield* manifestTemplateReferences(maybeMutation.value);
-				} else if (maybeMutation.kind === "mutation") {
-					// It's a mutation.
-					let mutation = maybeMutation.value;
-					// Get the references from the mutation.
-					switch (mutation.kind) {
-						case "unset":
-							break;
-						case "set":
-						case "set_if_unset":
-							yield* manifestTemplateReferences(mutation.value);
-							break;
-						case "template_prepend":
-						case "template_append":
-							yield* manifestTemplateReferences(mutation.value.template);
-							break;
-						case "array_prepend":
-						case "array_append":
-							for (let value of mutation.value) {
-								yield* manifestTemplateReferences(value);
-							}
-							break;
-					}
-				}
-			}
-		}
+	if (manifest.env) {
+		yield* manifestMutationReferences(manifest.env);
 	}
 
 	// Get the references from the args.
@@ -1652,6 +1754,52 @@ async function* manifestReferences(
 				yield* manifestTemplateReferences(arg);
 			}
 		}
+	}
+}
+
+/** Yield the artifacts prent in the manifest env. */
+function* manifestMutationReferences(
+	mutation: wrap.Manifest.Mutation,
+): Generator<tg.Artifact> {
+	switch (mutation.kind) {
+		case "unset":
+			break;
+		case "set":
+		case "set_if_unset":
+			yield* manifestValueReferences(mutation.value);
+			break;
+		case "template_prepend":
+		case "template_append":
+			yield* manifestTemplateReferences(mutation.value.template);
+			break;
+		case "array_prepend":
+		case "array_append":
+			for (let value of mutation.value) {
+				yield* manifestValueReferences(value);
+			}
+			break;
+	}
+}
+
+/** Yield the artifacts references by an executable. */
+function* manifestExecutableReferences(
+	executable: wrap.Manifest.Executable,
+): Generator<tg.Artifact> {
+	if (executable.kind === "path") {
+		yield* manifestSymlinkReferences(executable.value);
+	} else if (executable.kind === "content") {
+		yield* manifestTemplateReferences(executable.value);
+	} else {
+		return tg.unreachable();
+	}
+}
+
+/** Yield the artifact referenced by a symlink. */
+function* manifestSymlinkReferences(
+	symlink: wrap.Manifest.Symlink,
+): Generator<tg.Artifact> {
+	if (symlink.artifact) {
+		yield tg.Artifact.withId(symlink.artifact);
 	}
 }
 
@@ -1665,6 +1813,14 @@ function* manifestTemplateReferences(
 		}
 	}
 }
+
+/** Yield the artifacts referenes by a value. */
+function* manifestValueReferences(
+	value: wrap.Manifest.Value,
+): Generator<tg.Artifact> {
+	return tg.unimplemented();
+}
+
 export let artifactId = (artifact: tg.Artifact): Promise<tg.Artifact.Id> => {
 	if (tg.Directory.is(artifact)) {
 		return artifact.id();

--- a/packages/std/wrap.tg
+++ b/packages/std/wrap.tg
@@ -1045,11 +1045,12 @@ export let defaultShellInterpreter = tg.target(async () => {
 	return bash;
 });
 
-let manifestValueFromMutation = (
-	mutation: tg.Mutation,
-): Promise<wrap.Manifest.Value> => {
-	return tg.unimplemented();
-};
+// FIXME - remove if unused!
+// let manifestValueFromMutation = (
+// 	mutation: tg.Mutation,
+// ): Promise<wrap.Manifest.Value> => {
+// 	return tg.unimplemented();
+// };
 
 let manifestSymlinkFromArg = async (
 	arg: string | tg.Template | tg.Artifact,
@@ -1063,17 +1064,18 @@ let manifestSymlinkFromArg = async (
 	}
 };
 
-let manifestSymlinkFromManifestTemplate = async (
-	template: wrap.Manifest.Template,
-): Promise<wrap.Manifest.Symlink> => {
-	return tg.unimplemented();
-	// let components = template.components;
-	// if (components.length === 1) {
-	// 	// Just an artifact
-	// 	return { path: mponents[0].value };
-	// } else {
-	// }
-};
+// FIXME - remove if unused!
+// let manifestSymlinkFromManifestTemplate = async (
+// 	template: wrap.Manifest.Template,
+// ): Promise<wrap.Manifest.Symlink> => {
+// 	return tg.unimplemented();
+// 	// let components = template.components;
+// 	// if (components.length === 1) {
+// 	// 	// Just an artifact
+// 	// 	return { path: mponents[0].value };
+// 	// } else {
+// 	// }
+// };
 
 let envArgObjectFromManifestEnv = async (
 	env: wrap.Manifest.Env | undefined,

--- a/packages/std/wrap.tg
+++ b/packages/std/wrap.tg
@@ -98,14 +98,21 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 			if (arg.executable !== undefined) {
 				if (
 					tg.Template.is(arg.executable) ||
-					tg.Artifact.is(arg.executable) ||
 					typeof arg.executable === "string"
 				) {
 					object.executable = {
 						kind: "content",
 						value: await manifestTemplateFromArg(arg.executable),
 					};
+					if (!arg.interpreter) {
+						let defaultShell = await defaultShellInterpreter();
+						object.interpreter = await manifestInterpreterFromArg(defaultShell);
+					}
+					if (!arg.identity) {
+						object.identity = "executable";
+					}
 				} else {
+					// FIXME - use the branch logic from the file/symlink case above.
 					object.executable = {
 						kind: "path",
 						value: await manifestSymlinkFromArg(arg.executable),
@@ -295,31 +302,64 @@ export namespace wrap {
 		identity: Identity;
 		interpreter?: Manifest.Interpreter;
 		executable: Manifest.Executable;
-		env?: Manifest.Env;
+		env?: Manifest.Mutation;
 		args: Array<Manifest.Template>;
+	};
+
+	export let envMapFromManifestEnv = async (
+		mutation: wrap.Manifest.Mutation | undefined,
+	): Promise<wrap.Manifest.EnvMap> => {
+		let ret: wrap.Manifest.EnvMap = {};
+		if (mutation?.kind === "unset" || mutation?.value === undefined) {
+			return ret;
+		}
+		tg.assert(mutation.kind === "set", "Malformed env, expected set or unset.");
+		let value = mutation.value;
+		tg.assert(
+			value.kind === "map",
+			"Malformed env, expected a map of mutations.",
+		);
+		for (let [key, val] of Object.entries(value.value)) {
+			if (val.kind === "mutation") {
+				ret[key] = [await mutationFromManifestMutation(val.value)];
+			} else if (val.kind === "array") {
+				ret[key] = await Promise.all(
+					val.value.map(async (val) => {
+						tg.assert(
+							val.kind === "mutation",
+							"Malformed env, expected a mutation.",
+						);
+						return await mutationFromManifestMutation(val.value);
+					}),
+				);
+			} else {
+				throw new Error(
+					"Malformed env, expected a mutation or array of mutations.",
+				);
+			}
+		}
+		return ret;
 	};
 
 	/** Yield the key/value pairs this manifest sets once all mutations are applied. */
 	export async function* envVars(
-		env: wrap.Manifest.Env | undefined,
+		map: wrap.Manifest.EnvMap | undefined,
 	): AsyncGenerator<[string, tg.Template | undefined]> {
-		if (env === undefined || env.kind !== "set") {
+		if (map === undefined) {
 			return;
 		}
-		let map = envMapFromManifestValue(env.value);
 		for (let [key, mutations] of Object.entries(map)) {
-			let result: tg.Template | undefined;
-			for (let mutation of std.flatten([mutations])) {
-				result = await mutateTemplate(result, mutation);
+			let result = undefined;
+			for (let mutation of mutations) {
+				result = await mutateTemplate(undefined, mutation);
 			}
-			let value = result;
-			yield [key, value];
+			yield [key, result];
 		}
 	}
 
 	export let manifestEnvFromArg = async (
 		arg: std.env.Arg | undefined,
-	): Promise<wrap.Manifest.Env | undefined> => {
+	): Promise<wrap.Manifest.Mutation | undefined> => {
 		if (arg === undefined) {
 			return undefined;
 		} else if (tg.Mutation.is(arg)) {
@@ -415,9 +455,9 @@ export namespace wrap {
 	};
 
 	export let mergeEnvs = async (
-		...envs: Array<wrap.Manifest.Env | undefined>
-	): Promise<wrap.Manifest.Env | undefined> => {
-		let result: wrap.Manifest.Env | undefined;
+		...envs: Array<wrap.Manifest.Mutation | undefined>
+	): Promise<wrap.Manifest.Mutation | undefined> => {
+		let result: wrap.Manifest.Mutation | undefined;
 		for (let env of envs) {
 			if (env === undefined) {
 				return undefined;
@@ -430,24 +470,16 @@ export namespace wrap {
 				);
 				let envMap = env.value ?? {};
 				// If the running env is a set mutation, grab the current contents.
-				let map: wrap.Manifest.EnvMap = manifestEnvMapFromManifestValue(
-					result?.kind === "set" ? result?.value : { kind: "map", value: {} },
-				);
+				let map: wrap.Manifest.EnvMap = await envMapFromManifestEnv(result);
 				for await (let [name, val] of Object.entries(envMap)) {
 					if (val === undefined) {
 						// do nothing
 					} else {
-						if (!(val instanceof Array)) {
-							val = [val];
-						}
-						if (!(name in map)) {
-							map[name] = [];
-						}
 						for (let mutation of val) {
 							let lastExistingMutation = map[name]?.at(-1);
 							if (lastExistingMutation) {
 								// Attempt to merge the current mutation with the previous.
-								let mergedMutations = mergeManifestMutations(
+								let mergedMutations = await mergeMutations(
 									lastExistingMutation,
 									mutation.value,
 								);
@@ -569,14 +601,9 @@ export namespace wrap {
 			| { kind: "array"; value: Array<Manifest.Value> }
 			| { kind: "map"; value: { [key: string]: Manifest.Value } };
 
-		// An Env can be any mutation, but only Unset or Set where the value is an EnvMap are valid.
-		export type Env = Manifest.Mutation;
-		// The expected value type in a Manifest.Env of the Set variant.
-		export type EnvMap = { [key: string]: EnvValueArray };
-		export type EnvValueArray = Manifest.Value; // THis should be an array of manifest mutations.
-
-		// The non-serializeable type of an EnvMap.
-		export type EnvObject = Record<string, Array<tg.Mutation<tg.Template.Arg>>>;
+		// The non-serializeable type of a normalized env.
+		export type Env = tg.Mutation<EnvMap>;
+		export type EnvMap = Record<string, Array<tg.Mutation<tg.Template.Arg>>>;
 
 		/** Read a manifest from the end of a file. */
 		export let read = async (
@@ -699,38 +726,6 @@ const MANIFEST_MAGIC_NUMBER: Uint8Array = new Uint8Array([
 ]);
 
 const MANIFEST_VERSION = 0;
-
-let manifestEnvMapFromManifestValue = (
-	value: wrap.Manifest.Value | undefined,
-): wrap.Manifest.EnvMap => {
-	let ret: wrap.Manifest.EnvMap = {};
-	if (value === undefined) {
-		return ret;
-	} else if (value.kind === "map") {
-		for (let [key, val] of Object.entries(value.value)) {
-			if (val.kind === "mutation") {
-				ret[key] = [val.value];
-			} else if (val.kind === "array") {
-				for (let mutation of val.value) {
-					let arr = ret[key] ?? [];
-					tg.assert(
-						mutation.kind === "mutation",
-						"Malformed env, expected mutation.",
-					);
-					arr.push(mutation.value);
-					ret[key] = arr;
-				}
-			} else {
-				throw new Error(
-					"Malformed env, expected either a mutation or array of mutations.",
-				);
-			}
-		}
-		return ret;
-	} else {
-		return tg.unreachable();
-	}
-};
 
 let manifestExecutableFromArg = async (
 	arg: string | tg.Template | tg.File | tg.Symlink | wrap.Manifest.Executable,
@@ -1076,36 +1071,24 @@ let manifestSymlinkFromArg = async (
 };
 
 let envArgObjectFromManifestEnv = async (
-	env: wrap.Manifest.Env | undefined,
+	env: wrap.Manifest.Mutation | undefined,
 ): Promise<std.env.ArgObject> => {
 	let ret: std.env.ArgObject = {};
 	if (env === undefined) {
 		return ret;
 	}
-	let map = envMapFromManifestValue(manifestValueFromManifestMutation(env));
-	for (let [key, value] of Object.entries(map)) {
-		ret[key] = await Promise.all(value.map(mutationFromManifestMutation));
-		if (ret[key] instanceof Array) {
-			let arr = ret[key];
-			tg.assert(arr instanceof Array);
-			tg.assert(arr.length > 0);
-			if (arr.length === 1) {
-				ret[key] = arr[0];
-			}
-		}
-	}
-	return ret;
+	return envMapFromManifestValue(manifestValueFromManifestMutation(env));
 };
 
 /** Given a manifest value, produce the env object it contains. Error if it's malformed. */
-let envMapFromManifestValue = (
+let envMapFromManifestValue = async (
 	value: wrap.Manifest.Value,
-): wrap.Manifest.EnvMap => {
+): Promise<wrap.Manifest.EnvMap> => {
 	if (value.kind === "map") {
 		let ret: wrap.Manifest.EnvMap = {};
 		for (let [key, val] of Object.entries(value.value)) {
 			if (val.kind === "mutation") {
-				ret[key] = [val.value];
+				ret[key] = [await mutationFromManifestMutation(val.value)];
 			} else if (val.kind === "array") {
 				let arr = [];
 				for (let mutation of val.value) {
@@ -1115,7 +1098,7 @@ let envMapFromManifestValue = (
 					);
 					arr.push(mutation.value);
 				}
-				ret[key] = arr;
+				ret[key] = await Promise.all(arr.map(mutationFromManifestMutation));
 			} else {
 				throw new Error(
 					"Malformed env, expected either a mutation or array of mutations.",
@@ -1232,199 +1215,241 @@ let manifestMutationFromMaybeMutation = async (
 	}
 };
 
-let mergeManifestMutations = (
-	a: wrap.Manifest.Mutation,
-	b: wrap.Manifest.Mutation,
-): Array<wrap.Manifest.Mutation> => {
-	if (a.kind === "unset" && b.kind === "unset") {
+let mergeMutations = async (
+	a: tg.Mutation,
+	b: tg.Mutation,
+): Promise<Array<tg.Mutation>> => {
+	if (a.inner.kind === "unset" && b.inner.kind === "unset") {
 		return [b];
-	} else if (a.kind === "unset" && b.kind === "set") {
+	} else if (a.inner.kind === "unset" && b.inner.kind === "set") {
 		return [b];
-	} else if (a.kind === "unset" && b.kind === "set_if_unset") {
-		let val = b.value;
-		return [
-			{
-				kind: "set",
-				value: val,
-			},
-		];
-	} else if (a.kind === "unset" && b.kind === "template_prepend") {
-		return [
-			{
-				kind: "set",
-				value: manifestValueFromManifestTemplate(b.value.template),
-			},
-		];
-	} else if (a.kind === "unset" && b.kind === "template_append") {
-		return [
-			{
-				kind: "set",
-				value: manifestValueFromManifestTemplate(b.value.template),
-			},
-		];
-	} else if (a.kind === "unset" && b.kind === "array_append") {
-		return [
-			{
-				kind: "set",
-				value: manifestValueFromManifestTemplate(
-					joinManifestTemplates(
-						":",
-						...b.value.map(manifestTemplateFromManifestValue),
-					),
-				),
-			},
-		];
-	} else if (a.kind === "unset" && b.kind === "array_prepend") {
-		return [
-			{
-				kind: "set",
-				value: manifestValueFromManifestTemplate(
-					joinManifestTemplates(
-						":",
-						...b.value.map(manifestTemplateFromManifestValue),
-					),
-				),
-			},
-		];
-	} else if (a.kind === "set" && b.kind === "unset") {
+	} else if (a.inner.kind === "unset" && b.inner.kind === "set_if_unset") {
+		let val = b.inner.value;
+		return [await tg.Mutation.set<tg.Value>(val)];
+	} else if (a.inner.kind === "unset" && b.inner.kind === "template_prepend") {
+		return [await tg.Mutation.set(b.inner.template)];
+	} else if (a.inner.kind === "unset" && b.inner.kind === "template_append") {
+		return [await tg.Mutation.set(b.inner.template)];
+	} else if (a.inner.kind === "unset" && b.inner.kind === "array_append") {
 		return [b];
-	} else if (a.kind === "set" && b.kind === "set") {
+	} else if (a.inner.kind === "unset" && b.inner.kind === "array_prepend") {
 		return [b];
-	} else if (a.kind === "set" && b.kind === "set_if_unset") {
+	} else if (a.inner.kind === "set" && b.inner.kind === "unset") {
+		return [b];
+	} else if (a.inner.kind === "set" && b.inner.kind === "set") {
+		return [b];
+	} else if (a.inner.kind === "set" && b.inner.kind === "set_if_unset") {
 		return [a];
-	} else if (a.kind === "set" && b.kind === "template_prepend") {
-		let setVal = a.value;
-		return [
-			{
-				kind: "set",
-				value: manifestValueFromManifestTemplate(
-					joinManifestTemplates(
-						b.value.separator,
-						manifestTemplateFromManifestValue(setVal),
-						b.value.template,
-					),
-				),
-			},
-		];
-	} else if (a.kind === "set" && b.kind === "template_append") {
-		let setVal = a.value;
-		return [
-			{
-				kind: "set",
-				value: manifestValueFromManifestTemplate(
-					joinManifestTemplates(
-						b.value.separator,
-						b.value.template,
-						manifestTemplateFromManifestValue(setVal),
-					),
-				),
-			},
-		];
-	} else if (a.kind === "set" && b.kind === "array_append") {
-		return [a, b];
-	} else if (a.kind === "set" && b.kind === "array_prepend") {
-		return [a, b];
-	} else if (a.kind === "set_if_unset" && b.kind === "unset") {
-		return [b];
-	} else if (a.kind === "set_if_unset" && b.kind === "set") {
-		return [b];
-	} else if (a.kind === "set_if_unset" && b.kind === "set_if_unset") {
-		return [a];
-	} else if (a.kind === "set_if_unset" && b.kind === "template_prepend") {
-		return [a, b];
-	} else if (a.kind === "set_if_unset" && b.kind === "template_append") {
-		return [a, b];
-	} else if (a.kind === "set_if_unset" && b.kind === "array_append") {
-		return [a, b];
-	} else if (a.kind === "set_if_unset" && b.kind === "array_prepend") {
-		return [a, b];
-	} else if (a.kind === "template_prepend" && b.kind === "unset") {
-		return [b];
-	} else if (a.kind === "template_prepend" && b.kind === "set") {
-		return [b];
-	} else if (a.kind === "template_prepend" && b.kind === "set_if_unset") {
-		return [a];
-	} else if (a.kind === "template_prepend" && b.kind === "template_prepend") {
-		if (a.value.separator === b.value.separator) {
+	} else if (a.inner.kind === "set" && b.inner.kind === "template_prepend") {
+		let setVal = a.inner.value;
+		if (isTemplateArg(setVal)) {
 			return [
-				{
-					kind: "template_prepend",
-					value: {
-						template: joinManifestTemplates(
-							a.value.separator,
-							b.value.template,
-							a.value.template,
-						),
-						separator: a.value.separator,
-					},
-				},
+				await tg.Mutation.set(
+					tg.Template.join(
+						b.inner.separator,
+						b.inner.template,
+						tg.template(setVal),
+					),
+				),
 			];
 		} else {
 			return [a, b];
 		}
-	} else if (a.kind === "template_prepend" && b.kind === "template_append") {
-		return [a, b];
-	} else if (a.kind === "template_prepend" && b.kind === "array_append") {
-		return [a, b];
-	} else if (a.kind === "template_prepend" && b.kind === "array_prepend") {
-		return [a, b];
-	} else if (a.kind === "template_append" && b.kind === "unset") {
-		return [b];
-	} else if (a.kind === "template_append" && b.kind === "set") {
-		return [b];
-	} else if (a.kind === "template_append" && b.kind === "set_if_unset") {
-		return [a];
-	} else if (a.kind === "template_append" && b.kind === "template_prepend") {
-		return [a, b];
-	} else if (a.kind === "template_append" && b.kind === "template_append") {
-		if (a.value.separator === b.value.separator) {
+	} else if (a.inner.kind === "set" && b.inner.kind === "template_append") {
+		let setVal = a.inner.value;
+		if (isTemplateArg(setVal)) {
 			return [
-				{
-					kind: "template_append",
-					value: {
-						template: joinManifestTemplates(
-							a.value.separator,
-							a.value.template,
-							b.value.template,
-						),
-						separator: a.value.separator,
-					},
-				},
+				await tg.Mutation.set(
+					tg.Template.join(
+						b.inner.separator,
+						tg.template(setVal),
+						b.inner.template,
+					),
+				),
 			];
 		} else {
 			return [a, b];
 		}
-	} else if (a.kind === "template_append" && b.kind === "array_append") {
+	} else if (a.inner.kind === "set" && b.inner.kind === "array_append") {
 		return [a, b];
-	} else if (a.kind === "template_append" && b.kind === "array_prepend") {
+	} else if (a.inner.kind === "set" && b.inner.kind === "array_prepend") {
 		return [a, b];
-	} else if (a.kind === "array_append" && b.kind === "unset") {
+	} else if (a.inner.kind === "set_if_unset" && b.inner.kind === "unset") {
 		return [b];
-	} else if (a.kind === "array_append" && b.kind === "set") {
+	} else if (a.inner.kind === "set_if_unset" && b.inner.kind === "set") {
 		return [b];
-	} else if (a.kind === "array_append" && b.kind === "set_if_unset") {
+	} else if (
+		a.inner.kind === "set_if_unset" &&
+		b.inner.kind === "set_if_unset"
+	) {
 		return [a];
-	} else if (a.kind === "array_append" && b.kind === "array_append") {
-		return [{ kind: "array_append", value: a.value.concat(b.value) }];
-	} else if (a.kind === "array_append" && b.kind === "array_prepend") {
+	} else if (
+		a.inner.kind === "set_if_unset" &&
+		b.inner.kind === "template_prepend"
+	) {
 		return [a, b];
-	} else if (a.kind === "array_append" && b.kind === "template_append") {
+	} else if (
+		a.inner.kind === "set_if_unset" &&
+		b.inner.kind === "template_append"
+	) {
 		return [a, b];
-	} else if (a.kind === "array_append" && b.kind === "template_prepend") {
+	} else if (
+		a.inner.kind === "set_if_unset" &&
+		b.inner.kind === "array_append"
+	) {
 		return [a, b];
-	} else if (a.kind === "array_prepend" && b.kind === "unset") {
+	} else if (
+		a.inner.kind === "set_if_unset" &&
+		b.inner.kind === "array_prepend"
+	) {
+		return [a, b];
+	} else if (a.inner.kind === "template_prepend" && b.inner.kind === "unset") {
 		return [b];
-	} else if (a.kind === "array_prepend" && b.kind === "set") {
+	} else if (a.inner.kind === "template_prepend" && b.inner.kind === "set") {
 		return [b];
-	} else if (a.kind === "array_prepend" && b.kind === "set_if_unset") {
+	} else if (
+		a.inner.kind === "template_prepend" &&
+		b.inner.kind === "set_if_unset"
+	) {
 		return [a];
-	} else if (a.kind === "array_prepend" && b.kind === "array_append") {
+	} else if (
+		a.inner.kind === "template_prepend" &&
+		b.inner.kind === "template_prepend"
+	) {
+		if (a.inner.separator === b.inner.separator) {
+			return [
+				await tg.Mutation.templatePrepend(
+					tg.Template.join(
+						a.inner.separator,
+						b.inner.template,
+						a.inner.template,
+					),
+				),
+			];
+		} else {
+			return [a, b];
+		}
+	} else if (
+		a.inner.kind === "template_prepend" &&
+		b.inner.kind === "template_append"
+	) {
 		return [a, b];
-	} else if (a.kind === "array_prepend" && b.kind === "array_prepend") {
-		return [{ kind: "array_prepend", value: b.value.concat(a.value) }];
-	} else if (a.kind === "array_prepend" && b.kind === "template_append") {
+	} else if (
+		a.inner.kind === "template_prepend" &&
+		b.inner.kind === "array_append"
+	) {
 		return [a, b];
-	} else if (a.kind === "array_prepend" && b.kind === "template_prepend") {
+	} else if (
+		a.inner.kind === "template_prepend" &&
+		b.inner.kind === "array_prepend"
+	) {
+		return [a, b];
+	} else if (a.inner.kind === "template_append" && b.inner.kind === "unset") {
+		return [b];
+	} else if (a.inner.kind === "template_append" && b.inner.kind === "set") {
+		return [b];
+	} else if (
+		a.inner.kind === "template_append" &&
+		b.inner.kind === "set_if_unset"
+	) {
+		return [a];
+	} else if (
+		a.inner.kind === "template_append" &&
+		b.inner.kind === "template_prepend"
+	) {
+		return [a, b];
+	} else if (
+		a.inner.kind === "template_append" &&
+		b.inner.kind === "template_append"
+	) {
+		if (a.inner.separator === b.inner.separator) {
+			return [
+				await tg.Mutation.templateAppend(
+					tg.Template.join(
+						a.inner.separator,
+						a.inner.template,
+						b.inner.template,
+					),
+				),
+			];
+		} else {
+			return [a, b];
+		}
+	} else if (
+		a.inner.kind === "template_append" &&
+		b.inner.kind === "array_append"
+	) {
+		return [a, b];
+	} else if (
+		a.inner.kind === "template_append" &&
+		b.inner.kind === "array_prepend"
+	) {
+		return [a, b];
+	} else if (a.inner.kind === "array_append" && b.inner.kind === "unset") {
+		return [b];
+	} else if (a.inner.kind === "array_append" && b.inner.kind === "set") {
+		return [b];
+	} else if (
+		a.inner.kind === "array_append" &&
+		b.inner.kind === "set_if_unset"
+	) {
+		return [a];
+	} else if (
+		a.inner.kind === "array_append" &&
+		b.inner.kind === "array_append"
+	) {
+		return [
+			await tg.Mutation.arrayAppend<tg.Value>(
+				a.inner.values.concat(b.inner.values),
+			),
+		];
+	} else if (
+		a.inner.kind === "array_append" &&
+		b.inner.kind === "array_prepend"
+	) {
+		return [a, b];
+	} else if (
+		a.inner.kind === "array_append" &&
+		b.inner.kind === "template_append"
+	) {
+		return [a, b];
+	} else if (
+		a.inner.kind === "array_append" &&
+		b.inner.kind === "template_prepend"
+	) {
+		return [a, b];
+	} else if (a.inner.kind === "array_prepend" && b.inner.kind === "unset") {
+		return [b];
+	} else if (a.inner.kind === "array_prepend" && b.inner.kind === "set") {
+		return [b];
+	} else if (
+		a.inner.kind === "array_prepend" &&
+		b.inner.kind === "set_if_unset"
+	) {
+		return [a];
+	} else if (
+		a.inner.kind === "array_prepend" &&
+		b.inner.kind === "array_append"
+	) {
+		return [a, b];
+	} else if (
+		a.inner.kind === "array_prepend" &&
+		b.inner.kind === "array_prepend"
+	) {
+		return [
+			await tg.Mutation.arrayPrepend<tg.Value>(
+				b.inner.values.concat(a.inner.values),
+			),
+		];
+	} else if (
+		a.inner.kind === "array_prepend" &&
+		b.inner.kind === "template_append"
+	) {
+		return [a, b];
+	} else if (
+		a.inner.kind === "array_prepend" &&
+		b.inner.kind === "template_prepend"
+	) {
 		return [a, b];
 	} else {
 		return tg.unreachable();
@@ -1440,65 +1465,37 @@ let manifestValueFromManifestTemplate = (
 	};
 };
 
-let manifestTemplateFromManifestValue = (
-	value: wrap.Manifest.Value,
-): wrap.Manifest.Template => {
-	if (value.kind === "template") {
-		return value.value;
-	} else if (value.kind === "string") {
-		return {
-			components: [{ kind: "string", value: value.value }],
-		};
-	} else if (
-		value.kind === "directory" ||
-		value.kind === "file" ||
-		value.kind === "symlink"
-	) {
-		return {
-			components: [{ kind: "artifact", value: value.value }],
-		};
-	} else {
-		throw new Error(
-			"Cannot convert value to template: " + JSON.stringify(value),
-		);
-	}
-};
-
 let mutateTemplate = async (
-	t: tg.Template | undefined,
-	mutation: wrap.Manifest.Mutation,
+	template: tg.Template | undefined,
+	mutation: tg.Mutation<tg.Template.Arg>,
 ): Promise<tg.Template | undefined> => {
-	let template = await manifestTemplateFromArg(t);
-	if (mutation.kind === "array_append" || mutation.kind === "array_prepend") {
+	if (
+		mutation.inner.kind === "array_append" ||
+		mutation.inner.kind === "array_prepend"
+	) {
 		throw new Error("Cannot apply an array mutation to a template");
-	} else if (mutation.kind === "template_append") {
-		return templateFromManifestTemplate(
-			joinManifestTemplates(
-				mutation.value.separator,
-				template,
-				mutation.value.template,
-			),
+	} else if (mutation.inner.kind === "template_append") {
+		return tg.Template.join(
+			mutation.inner.separator,
+			template,
+			mutation.inner.template,
 		);
-	} else if (mutation.kind === "template_prepend") {
-		return templateFromManifestTemplate(
-			joinManifestTemplates(
-				mutation.value.separator,
-				mutation.value.template,
-				template,
-			),
+	} else if (mutation.inner.kind === "template_prepend") {
+		return tg.Template.join(
+			mutation.inner.separator,
+			mutation.inner.template,
+			template,
 		);
-	} else if (mutation.kind === "set") {
-		return templateFromManifestTemplate(
-			manifestTemplateFromManifestValue(mutation.value),
-		);
-	} else if (mutation.kind === "set_if_unset") {
+	} else if (mutation.inner.kind === "set") {
+		tg.assert(isTemplateArg(mutation.inner.value));
+		return tg.template(mutation.inner.value);
+	} else if (mutation.inner.kind === "set_if_unset") {
 		if (template?.components.length === 0) {
-			return templateFromManifestTemplate(
-				manifestTemplateFromManifestValue(mutation.value),
-			);
+			tg.assert(isTemplateArg(mutation.inner.value));
+			return tg.template(mutation.inner.value);
 		}
-	} else if (mutation.kind === "unset") {
-		return tg``;
+	} else if (mutation.inner.kind === "unset") {
+		return tg.template();
 	}
 	return tg.unreachable();
 };
@@ -1643,7 +1640,7 @@ let valueFromManifestValue = async (
 export async function* manifestEnvVars(
 	manifest: wrap.Manifest,
 ): AsyncGenerator<[string, tg.Template | undefined]> {
-	yield* wrap.envVars(manifest.env);
+	yield* wrap.envVars(await wrap.envMapFromManifestEnv(manifest.env));
 }
 
 let manifestTemplateFromArg = async (
@@ -1665,6 +1662,10 @@ let manifestTemplateFromArg = async (
 	return {
 		components,
 	};
+};
+
+let isTemplateArg = (arg: unknown): arg is tg.Template.Arg => {
+	return typeof arg === "string" || tg.Artifact.is(arg) || tg.Template.is(arg);
 };
 
 let isManifestTemplate = (
@@ -1689,90 +1690,6 @@ let isManifestTemplateComponent = (
 		"kind" in arg &&
 		(arg.kind === "string" || arg.kind === "artifact")
 	);
-};
-
-let joinManifestTemplates = (
-	separator: string | undefined,
-	...templates: Array<wrap.Manifest.Template>
-): wrap.Manifest.Template => {
-	// Join the templates.
-	templates = templates.filter((template) => template !== undefined);
-	let components: Array<wrap.Manifest.Template.Component> = [];
-	for (let i = 0; i < templates.length; i++) {
-		if (separator && i > 0 && components.length > 0) {
-			components.push({ kind: "string", value: separator });
-		}
-		let template = templates[i];
-		tg.assert(template);
-		components.push(...template.components);
-	}
-
-	// Normalize the components.
-	let normalizedComponents: Array<wrap.Manifest.Template.Component> = [];
-	for (let component of components) {
-		let lastComponent = normalizedComponents.at(-1);
-		if (component.kind === "string" && component.value === "") {
-			// Ignore empty string components.
-			continue;
-		} else if (
-			lastComponent?.kind === "string" &&
-			component.kind === "string"
-		) {
-			// Merge adjacent string components.
-			normalizedComponents.splice(-1, 1, {
-				kind: "string",
-				value: lastComponent.value + component.value,
-			});
-		} else {
-			normalizedComponents.push(component);
-		}
-	}
-
-	// If the final character is a string matching the separator, chop it.
-	let lastComponent = normalizedComponents.at(-1);
-	if (
-		lastComponent?.kind === "string" &&
-		separator &&
-		lastComponent.value.endsWith(separator)
-	) {
-		normalizedComponents.splice(-1, 1, {
-			kind: "string",
-			value: lastComponent.value.slice(0, -separator.length),
-		});
-	}
-
-	return { components: normalizedComponents };
-};
-
-let manifestTemplatesEqual = (
-	a: wrap.Manifest.Template,
-	b: wrap.Manifest.Template,
-): boolean => {
-	if (a.components.length !== b.components.length) {
-		return false;
-	}
-	for (let i = 0; i < a.components.length; i++) {
-		let aComponent = a.components[i];
-		tg.assert(aComponent !== undefined);
-		let bComponent = b.components[i];
-		tg.assert(bComponent !== undefined);
-		if (aComponent.kind !== bComponent.kind) {
-			return false;
-		}
-		if (aComponent.kind === "string" && bComponent.kind === "string") {
-			if (aComponent.value !== bComponent.value) {
-				return false;
-			}
-		} else if (
-			aComponent.kind === "artifact" &&
-			bComponent.kind === "artifact"
-		) {
-			if (aComponent.value !== bComponent.value) {
-				return false;
-			}
-		}
-	}
-	return true;
 };
 
 /** Yield the artifacts referenced by a manifest. */
@@ -1908,12 +1825,17 @@ function* manifestTemplateReferences(
 	}
 }
 
-/** Yield the artifacts referenes by a value. */
+/** Yield the artifacts referenced by a value. */
 function* manifestValueReferences(
 	value: wrap.Manifest.Value,
 ): Generator<tg.Artifact> {
-	// FIXME - dir/file/symlink!
-	if (value.kind === "template") {
+	if (value.kind === "directory") {
+		yield tg.Artifact.withId(value.value);
+	} else if (value.kind === "file") {
+		yield tg.Artifact.withId(value.value);
+	} else if (value.kind === "symlink") {
+		yield tg.Artifact.withId(value.value);
+	} else if (value.kind === "template") {
 		yield* manifestTemplateReferences(value.value);
 	} else if (value.kind === "mutation") {
 		yield* manifestMutationReferences(value.value);
@@ -1925,8 +1847,6 @@ function* manifestValueReferences(
 		for (let v of Object.values(value.value)) {
 			yield* manifestValueReferences(v);
 		}
-	} else {
-		// Nothing!
 	}
 }
 

--- a/packages/std/wrap.tg
+++ b/packages/std/wrap.tg
@@ -425,12 +425,13 @@ export namespace wrap {
 				result = env;
 			} else {
 				tg.assert(
-					result?.kind === "set",
-					"Malformed env, unexpected mutation.",
+					env?.kind === "set",
+					"Malformed env, expected set mutation but recieved " + env,
 				);
 				let envMap = env.value ?? {};
+				// If the running env is a set mutation, grab the current contents.
 				let map: wrap.Manifest.EnvMap = manifestEnvMapFromManifestValue(
-					result?.value,
+					result?.kind === "set" ? result?.value : { kind: "map", value: {} },
 				);
 				for await (let [name, val] of Object.entries(envMap)) {
 					if (val === undefined) {
@@ -466,6 +467,18 @@ export namespace wrap {
 			}
 		}
 		return result;
+	};
+
+	/** Attempt to unwrap a wrapped executable. Returns undefined if the input was not a Tangram wrapper. */
+	export let tryUnwrap = async (
+		file: tg.File,
+	): Promise<tg.File | undefined> => {
+		return tg.unimplemented();
+	};
+
+	/** Unwrap a wrapped executable. Throws an error if the input was not a Tangram executable. */
+	export let unwrap = async (file: tg.File): Promise<tg.File> => {
+		return tg.unimplemented();
 	};
 
 	export namespace Manifest {
@@ -553,13 +566,17 @@ export namespace wrap {
 			| { kind: "symlink"; value: tg.Symlink.Id }
 			| { kind: "template"; value: Manifest.Template }
 			| { kind: "mutation"; value: Manifest.Mutation }
-			| { kind: "array"; value: Array<Value> }
-			| { kind: "map"; value: { [key: string]: Value } };
+			| { kind: "array"; value: Array<Manifest.Value> }
+			| { kind: "map"; value: { [key: string]: Manifest.Value } };
 
 		// An Env can be any mutation, but only Unset or Set where the value is an EnvMap are valid.
 		export type Env = Manifest.Mutation;
 		// The expected value type in a Manifest.Env of the Set variant.
-		export type EnvMap = { [key: string]: Array<Manifest.Mutation> };
+		export type EnvMap = { [key: string]: EnvValueArray };
+		export type EnvValueArray = Manifest.Value; // THis should be an array of manifest mutations.
+
+		// The non-serializeable type of an EnvMap.
+		export type EnvObject = Record<string, Array<tg.Mutation<tg.Template.Arg>>>;
 
 		/** Read a manifest from the end of a file. */
 		export let read = async (
@@ -607,7 +624,8 @@ export namespace wrap {
 
 			return manifest;
 		};
-		// Write a manifest to a file.
+
+		/** Write a manifest to a file. */
 		export let write = async (file: tg.File, manifest: wrap.Manifest) => {
 			// Serialize the manifest.
 			let manifestBytes = tg.encoding.utf8.encode(
@@ -1045,13 +1063,6 @@ export let defaultShellInterpreter = tg.target(async () => {
 	return bash;
 });
 
-// FIXME - remove if unused!
-// let manifestValueFromMutation = (
-// 	mutation: tg.Mutation,
-// ): Promise<wrap.Manifest.Value> => {
-// 	return tg.unimplemented();
-// };
-
 let manifestSymlinkFromArg = async (
 	arg: string | tg.Template | tg.Artifact,
 ): Promise<wrap.Manifest.Symlink> => {
@@ -1063,19 +1074,6 @@ let manifestSymlinkFromArg = async (
 		return tg.unreachable();
 	}
 };
-
-// FIXME - remove if unused!
-// let manifestSymlinkFromManifestTemplate = async (
-// 	template: wrap.Manifest.Template,
-// ): Promise<wrap.Manifest.Symlink> => {
-// 	return tg.unimplemented();
-// 	// let components = template.components;
-// 	// if (components.length === 1) {
-// 	// 	// Just an artifact
-// 	// 	return { path: mponents[0].value };
-// 	// } else {
-// 	// }
-// };
 
 let envArgObjectFromManifestEnv = async (
 	env: wrap.Manifest.Env | undefined,
@@ -1103,7 +1101,31 @@ let envArgObjectFromManifestEnv = async (
 let envMapFromManifestValue = (
 	value: wrap.Manifest.Value,
 ): wrap.Manifest.EnvMap => {
-	return tg.unimplemented();
+	if (value.kind === "map") {
+		let ret: wrap.Manifest.EnvMap = {};
+		for (let [key, val] of Object.entries(value.value)) {
+			if (val.kind === "mutation") {
+				ret[key] = [val.value];
+			} else if (val.kind === "array") {
+				let arr = [];
+				for (let mutation of val.value) {
+					tg.assert(
+						mutation.kind === "mutation",
+						"Malformed env, expected mutation but received " + mutation,
+					);
+					arr.push(mutation.value);
+				}
+				ret[key] = arr;
+			} else {
+				throw new Error(
+					"Malformed env, expected either a mutation or array of mutations.",
+				);
+			}
+		}
+		return ret;
+	} else {
+		throw new Error("Malformed env, expected a map.");
+	}
 };
 
 let manifestValueFromManifestMutation = (
@@ -1127,15 +1149,9 @@ let manifestMutationFromMutation = async (
 		return { kind: "unset" };
 	} else if (mutation.inner.kind === "set") {
 		let value = mutation.inner.value;
-		tg.assert(
-			valueIsTemplateLike(value),
-			`Expected a template arg, but got ${JSON.stringify(value)}.`,
-		);
 		return {
 			kind: "set",
-			value: manifestValueFromManifestTemplate(
-				await manifestTemplateFromArg(value),
-			),
+			value: await manifestValueFromValue(value),
 		};
 	} else if (mutation.inner.kind === "set_if_unset") {
 		let value = mutation.inner.value;
@@ -1541,10 +1557,86 @@ let mutationFromManifestMutation = (
 	}
 };
 
-let valueFromManifestValue = (
+let manifestValueFromValue = async (
+	value: tg.Value,
+): Promise<wrap.Manifest.Value> => {
+	if (typeof value === undefined) {
+		return { kind: "null" };
+	} else if (typeof value === "boolean") {
+		return { kind: "bool", value };
+	} else if (typeof value === "number") {
+		return { kind: "number", value };
+	} else if (typeof value === "string") {
+		return { kind: "string", value };
+	} else if (tg.Directory.is(value)) {
+		return { kind: "directory", value: await value.id() };
+	} else if (tg.File.is(value)) {
+		return { kind: "file", value: await value.id() };
+	} else if (tg.Symlink.is(value)) {
+		return { kind: "symlink", value: await value.id() };
+	} else if (tg.Template.is(value)) {
+		return { kind: "template", value: await manifestTemplateFromArg(value) };
+	} else if (tg.Mutation.is(value)) {
+		return {
+			kind: "mutation",
+			value: await manifestMutationFromMutation(value),
+		};
+	} else if (value instanceof Array) {
+		let arr = await Promise.all(value.map(manifestValueFromValue));
+		return { kind: "array", value: arr };
+	} else if (typeof value === "object") {
+		let obj: { [key: string]: wrap.Manifest.Value } = {};
+		let entries = Object.entries(value);
+		let promises = entries.map(async ([key, val]) => {
+			return { key, value: await manifestValueFromValue(val) };
+		});
+		let resolvedEntries = await Promise.all(promises);
+		for (let entry of resolvedEntries) {
+			obj[entry.key] = entry.value;
+		}
+		return { kind: "map", value: obj };
+	} else {
+		return tg.unreachable();
+	}
+};
+
+let valueFromManifestValue = async (
 	value: wrap.Manifest.Value,
 ): Promise<tg.Value> => {
-	return tg.unimplemented();
+	if (value.kind === "null") {
+		undefined;
+	} else if (value.kind === "bool") {
+		return value.value;
+	} else if (value.kind === "number") {
+		return value.value;
+	} else if (value.kind === "string") {
+		return value.value;
+	} else if (value.kind === "directory") {
+		return tg.Directory.withId(value.value);
+	} else if (value.kind === "file") {
+		return tg.File.withId(value.value);
+	} else if (value.kind === "symlink") {
+		return tg.Symlink.withId(value.value);
+	} else if (value.kind === "template") {
+		return await templateFromManifestTemplate(value.value);
+	} else if (value.kind === "mutation") {
+		return mutationFromManifestMutation(value.value);
+	} else if (value.kind === "array") {
+		return await Promise.all(value.value.map(valueFromManifestValue));
+	} else if (value.kind === "map") {
+		let ret: tg.Value = {};
+		let entries = Object.entries(value.value);
+		let promises = entries.map(async ([key, val]) => {
+			return { key, value: await valueFromManifestValue(val) };
+		});
+		let resolvedEntries = await Promise.all(promises);
+		for (let entry of resolvedEntries) {
+			ret[entry.key] = entry.value;
+		}
+		return ret;
+	} else {
+		return tg.unreachable();
+	}
 };
 
 /** Yield the key/value pairs this manifest sets once all mutations are applied. */
@@ -1820,7 +1912,22 @@ function* manifestTemplateReferences(
 function* manifestValueReferences(
 	value: wrap.Manifest.Value,
 ): Generator<tg.Artifact> {
-	return tg.unimplemented();
+	// FIXME - dir/file/symlink!
+	if (value.kind === "template") {
+		yield* manifestTemplateReferences(value.value);
+	} else if (value.kind === "mutation") {
+		yield* manifestMutationReferences(value.value);
+	} else if (value.kind === "array") {
+		for (let v of value.value) {
+			yield* manifestValueReferences(v);
+		}
+	} else if (value.kind === "map") {
+		for (let v of Object.values(value.value)) {
+			yield* manifestValueReferences(v);
+		}
+	} else {
+		// Nothing!
+	}
 }
 
 export let artifactId = (artifact: tg.Artifact): Promise<tg.Artifact.Id> => {

--- a/packages/std/wrap.tg
+++ b/packages/std/wrap.tg
@@ -420,7 +420,10 @@ export namespace wrap {
 						let mutations = tg.Mutation.is(mutationArgs)
 							? [mutationArgs]
 							: await Promise.all(
-									std.flatten([mutationArgs]).map(normalizeEnvVarValue),
+									std
+										.flatten([mutationArgs])
+										.filter((arg) => arg !== undefined)
+										.map(normalizeEnvVarValue),
 							  );
 						return [key, mutations];
 					}),
@@ -1147,26 +1150,6 @@ let manifestMutationFromMutation = async (
 	}
 };
 
-let manifestMutationFromMaybeMutation = async (
-	mutation?: tg.MaybeMutation,
-): Promise<wrap.Manifest.Mutation> => {
-	if (mutation === undefined) {
-		return {
-			kind: "unset",
-		};
-	}
-	if (!tg.Mutation.is(mutation)) {
-		return manifestMutationFromMutation(
-			await tg.mutation<tg.Value>({
-				kind: "set",
-				value: mutation,
-			}),
-		);
-	} else {
-		return manifestMutationFromMutation(mutation);
-	}
-};
-
 let mergeMutations = async (
 	a: tg.Mutation,
 	b: tg.Mutation,
@@ -1410,7 +1393,7 @@ let mergeMutations = async (
 
 let normalizeEnvVarValue = async (value: unknown): Promise<tg.Mutation> => {
 	if (value === undefined) {
-		return tg.Mutation.templateAppend("");
+		return tg.Mutation.arrayAppend(tg``);
 	} else if (tg.Mutation.is(value)) {
 		return value;
 	} else if (isTemplateArg(value)) {
@@ -1624,7 +1607,7 @@ let manifestTemplateFromArg = async (
 		}),
 	);
 	return {
-		components,
+		components: components ?? [],
 	};
 };
 

--- a/packages/std/wrap.tg
+++ b/packages/std/wrap.tg
@@ -486,13 +486,27 @@ export namespace wrap {
 	/** Attempt to unwrap a wrapped executable. Returns undefined if the input was not a Tangram wrapper. */
 	export let tryUnwrap = async (
 		file: tg.File,
-	): Promise<tg.File | undefined> => {
-		return tg.unimplemented();
+	): Promise<tg.Template | tg.Symlink | undefined> => {
+		let manifest = await wrap.Manifest.read(file);
+		if (!manifest) {
+			return undefined;
+		}
+		if (manifest.executable.kind === "content") {
+			return templateFromManifestTemplate(manifest.executable.value);
+		} else {
+			return manifest.executable.value as tg.Symlink | tg.Template;
+		}
 	};
 
 	/** Unwrap a wrapped executable. Throws an error if the input was not a Tangram executable. */
-	export let unwrap = async (file: tg.File): Promise<tg.File> => {
-		return tg.unimplemented();
+	export let unwrap = async (
+		file: tg.File,
+	): Promise<tg.Template | tg.Symlink> => {
+		let result = await tryUnwrap(file);
+		if (!result) {
+			throw new Error("File does not have a wrapper manifest.");
+		}
+		return result;
 	};
 
 	export namespace Manifest {
@@ -1025,7 +1039,7 @@ let manifestInterpreterFromElf = async (
 	}
 };
 
-export let defaultShellInterpreter = tg.target(async () => {
+export let defaultShellInterpreter = async () => {
 	// Provide bash for the detected host system. Don't assume an existing SDK.
 	let shellArtifact = await std.utils.bash.build({
 		sdk: { bootstrapMode: true },
@@ -1041,7 +1055,7 @@ export let defaultShellInterpreter = tg.target(async () => {
 		env,
 	});
 	return bash;
-});
+};
 
 let manifestSymlinkFromArg = async (
 	arg: string | tg.Template | tg.Artifact,
@@ -1394,8 +1408,10 @@ let mergeMutations = async (
 	}
 };
 
-let normalizeEnvVarValue = async (value: tg.Value): Promise<tg.Mutation> => {
-	if (tg.Mutation.is(value)) {
+let normalizeEnvVarValue = async (value: unknown): Promise<tg.Mutation> => {
+	if (value === undefined) {
+		return tg.Mutation.templateAppend("");
+	} else if (tg.Mutation.is(value)) {
 		return value;
 	} else if (isTemplateArg(value)) {
 		return tg.Mutation.set(tg.template(value));

--- a/packages/std/wrap.tg
+++ b/packages/std/wrap.tg
@@ -445,7 +445,7 @@ export namespace wrap {
 			} else {
 				tg.assert(
 					env?.kind === "set",
-					"Malformed env, expected set mutation but recieved " + env,
+					"Malformed env, expected set mutation but recieved " + env?.kind,
 				);
 				let envMap: wrap.Manifest.EnvMap = await envMapFromMapValue(env.value);
 				// If the running env is a set mutation, grab the current contents.
@@ -1063,13 +1063,22 @@ export let defaultShellInterpreter = async () => {
 };
 
 let manifestSymlinkFromArg = async (
-	arg: string | tg.Template | tg.Artifact,
+	arg: string | tg.Template | tg.Artifact | wrap.Manifest.Template,
 ): Promise<wrap.Manifest.Symlink> => {
-	if (typeof arg === "string" || tg.Template.is(arg)) {
+	if (isManifestTemplate(arg)) {
+		let t = await templateFromManifestTemplate(arg);
+		return manifestSymlinkFromArg(t);
+	} else if (typeof arg === "string" || tg.Template.is(arg)) {
 		return manifestSymlinkFromArg(await tg.symlink(arg));
+	} else if (tg.Symlink.is(arg)) {
+		return {
+			artifact: await (await arg.artifact())?.id(),
+			path: await arg.path(),
+		};
 	} else if (tg.Artifact.is(arg)) {
 		return { artifact: await arg.id() };
 	} else {
+		console.log("Bad arg", arg);
 		return tg.unreachable();
 	}
 };
@@ -1114,7 +1123,7 @@ let manifestMutationFromMutation = async (
 		return {
 			kind: "templatePrepend",
 			template: await manifestTemplateFromArg(template),
-			separator: mutation.inner.separator,
+			separator: mutation.inner.separator ?? ":",
 		};
 	} else if (mutation.inner.kind === "template_append") {
 		let template = mutation.inner.template;
@@ -1125,7 +1134,7 @@ let manifestMutationFromMutation = async (
 		return {
 			kind: "templateAppend",
 			template: await manifestTemplateFromArg(template),
-			separator: mutation.inner.separator,
+			separator: mutation.inner.separator ?? ":",
 		};
 	} else if (mutation.inner.kind === "array_prepend") {
 		tg.assert(mutation.inner.values.every(valueIsTemplateLike));

--- a/packages/std/wrap.tg
+++ b/packages/std/wrap.tg
@@ -51,7 +51,7 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 			// Try to read the manifest from it.
 			let existingManifest = await wrap.Manifest.read(file);
 			if (existingManifest !== undefined) {
-				let env_ = await envArgObjectFromManifestEnv(existingManifest.env);
+				let env_ = await wrap.envMapFromManifestEnv(existingManifest.env);
 				let env = tg.Mutation.is(env_)
 					? env_
 					: await tg.Mutation.arrayAppend(env_);
@@ -314,31 +314,7 @@ export namespace wrap {
 			return ret;
 		}
 		tg.assert(mutation.kind === "set", "Malformed env, expected set or unset.");
-		let value = mutation.value;
-		tg.assert(
-			value.kind === "map",
-			"Malformed env, expected a map of mutations.",
-		);
-		for (let [key, val] of Object.entries(value.value)) {
-			if (val.kind === "mutation") {
-				ret[key] = [await mutationFromManifestMutation(val.value)];
-			} else if (val.kind === "array") {
-				ret[key] = await Promise.all(
-					val.value.map(async (val) => {
-						tg.assert(
-							val.kind === "mutation",
-							"Malformed env, expected a mutation.",
-						);
-						return await mutationFromManifestMutation(val.value);
-					}),
-				);
-			} else {
-				throw new Error(
-					"Malformed env, expected a mutation or array of mutations.",
-				);
-			}
-		}
-		return ret;
+		return envMapFromMapValue(mutation.value);
 	};
 
 	/** Yield the key/value pairs this manifest sets once all mutations are applied. */
@@ -350,8 +326,10 @@ export namespace wrap {
 		}
 		for (let [key, mutations] of Object.entries(map)) {
 			let result = undefined;
-			for (let mutation of mutations) {
-				result = await mutateTemplate(undefined, mutation);
+			for (let mutation of mutations ?? []) {
+				if (mutation) {
+					result = await mutateTemplate(undefined, mutation);
+				}
 			}
 			yield [key, result];
 		}
@@ -432,17 +410,15 @@ export namespace wrap {
 			return mergeEnvs(...(await Promise.all(arg.map(manifestEnvFromArg))));
 		} else if (typeof arg === "object") {
 			// Handle an object.
-			let ret = Object.fromEntries(
+			let ret: wrap.Manifest.EnvMap = Object.fromEntries(
 				await Promise.all(
 					Object.entries(arg).map<
-						Promise<[string, Array<wrap.Manifest.Mutation>]>
+						Promise<[string, Array<tg.Mutation<tg.Template.Arg>>]>
 					>(async ([key, mutationArgs]) => {
 						let mutations = tg.Mutation.is(mutationArgs)
-							? [await manifestMutationFromMutation(mutationArgs)]
+							? [mutationArgs]
 							: await Promise.all(
-									std
-										.flatten([mutationArgs])
-										.map(manifestMutationFromMaybeMutation),
+									std.flatten([mutationArgs]).map(normalizeEnvVarValue),
 							  );
 						return [key, mutations];
 					}),
@@ -468,20 +444,33 @@ export namespace wrap {
 					env?.kind === "set",
 					"Malformed env, expected set mutation but recieved " + env,
 				);
-				let envMap = env.value ?? {};
+				tg.assert(
+					env.value.kind === "map",
+					"Malformed env, expected a map but recieved " + env.value,
+				);
+				let envMap: wrap.Manifest.EnvMap = await envMapFromMapValue(env.value);
 				// If the running env is a set mutation, grab the current contents.
 				let map: wrap.Manifest.EnvMap = await envMapFromManifestEnv(result);
 				for await (let [name, val] of Object.entries(envMap)) {
+					console.log("name", name, "val", val);
 					if (val === undefined) {
 						// do nothing
 					} else {
+						if (!(val instanceof Array)) {
+							val = [val];
+						}
+						if (!(name in map)) {
+							map[name] = [];
+						}
 						for (let mutation of val) {
+							console.log("map at name", name, map[name]);
 							let lastExistingMutation = map[name]?.at(-1);
+							console.log("lastExistingMutation", lastExistingMutation);
 							if (lastExistingMutation) {
 								// Attempt to merge the current mutation with the previous.
 								let mergedMutations = await mergeMutations(
 									lastExistingMutation,
-									mutation.value,
+									mutation,
 								);
 
 								// Replace the last mutation with the merged mutations.
@@ -603,7 +592,10 @@ export namespace wrap {
 
 		// The non-serializeable type of a normalized env.
 		export type Env = tg.Mutation<EnvMap>;
-		export type EnvMap = Record<string, Array<tg.Mutation<tg.Template.Arg>>>;
+		export type EnvMap = Record<
+			string,
+			Array<tg.Mutation<tg.Template.Arg>> | undefined
+		>;
 
 		/** Read a manifest from the end of a file. */
 		export let read = async (
@@ -1070,52 +1062,43 @@ let manifestSymlinkFromArg = async (
 	}
 };
 
-let envArgObjectFromManifestEnv = async (
-	env: wrap.Manifest.Mutation | undefined,
-): Promise<std.env.ArgObject> => {
-	let ret: std.env.ArgObject = {};
-	if (env === undefined) {
-		return ret;
-	}
-	return envMapFromManifestValue(manifestValueFromManifestMutation(env));
-};
+// FIXME remove or restore
+// /** Given a manifest value, produce the env object it contains. Error if it's malformed. */
+// let envMapFromManifestValue = async (
+// 	value: wrap.Manifest.Value,
+// ): Promise<wrap.Manifest.EnvMap> => {
+// 	if (value.kind === "map") {
+// 		let ret: wrap.Manifest.EnvMap = {};
+// 		for (let [key, val] of Object.entries(value.value)) {
+// 			if (val.kind === "mutation") {
+// 				ret[key] = [await mutationFromManifestMutation(val.value)];
+// 			} else if (val.kind === "array") {
+// 				let arr = [];
+// 				for (let mutation of val.value) {
+// 					tg.assert(
+// 						mutation.kind === "mutation",
+// 						"Malformed env, expected mutation but received " + mutation,
+// 					);
+// 					arr.push(mutation.value);
+// 				}
+// 				ret[key] = await Promise.all(arr.map(mutationFromManifestMutation));
+// 			} else {
+// 				throw new Error(
+// 					"Malformed env, expected either a mutation or array of mutations.",
+// 				);
+// 			}
+// 		}
+// 		return ret;
+// 	} else {
+// 		throw new Error("Malformed env, expected a map.");
+// 	}
+// };
 
-/** Given a manifest value, produce the env object it contains. Error if it's malformed. */
-let envMapFromManifestValue = async (
-	value: wrap.Manifest.Value,
-): Promise<wrap.Manifest.EnvMap> => {
-	if (value.kind === "map") {
-		let ret: wrap.Manifest.EnvMap = {};
-		for (let [key, val] of Object.entries(value.value)) {
-			if (val.kind === "mutation") {
-				ret[key] = [await mutationFromManifestMutation(val.value)];
-			} else if (val.kind === "array") {
-				let arr = [];
-				for (let mutation of val.value) {
-					tg.assert(
-						mutation.kind === "mutation",
-						"Malformed env, expected mutation but received " + mutation,
-					);
-					arr.push(mutation.value);
-				}
-				ret[key] = await Promise.all(arr.map(mutationFromManifestMutation));
-			} else {
-				throw new Error(
-					"Malformed env, expected either a mutation or array of mutations.",
-				);
-			}
-		}
-		return ret;
-	} else {
-		throw new Error("Malformed env, expected a map.");
-	}
-};
-
-let manifestValueFromManifestMutation = (
-	mutation: wrap.Manifest.Mutation,
-): wrap.Manifest.Value => {
-	return { kind: "mutation", value: mutation };
-};
+// let manifestValueFromManifestMutation = (
+// 	mutation: wrap.Manifest.Mutation,
+// ): wrap.Manifest.Value => {
+// 	return { kind: "mutation", value: mutation };
+// };
 
 let valueIsTemplateLike = (
 	value: tg.Value,
@@ -1456,6 +1439,16 @@ let mergeMutations = async (
 	}
 };
 
+let normalizeEnvVarValue = async (value: tg.Value): Promise<tg.Mutation> => {
+	if (tg.Mutation.is(value)) {
+		return value;
+	} else if (isTemplateArg(value)) {
+		return tg.Mutation.set(tg.template(value));
+	} else {
+		throw new Error("Unexpected value type: " + value);
+	}
+};
+
 let manifestValueFromManifestTemplate = (
 	template: wrap.Manifest.Template,
 ): wrap.Manifest.Value => {
@@ -1662,6 +1655,35 @@ let manifestTemplateFromArg = async (
 	return {
 		components,
 	};
+};
+
+let envMapFromMapValue = async (
+	value: wrap.Manifest.Value,
+): Promise<wrap.Manifest.EnvMap> => {
+	tg.assert(
+		value.kind === "map",
+		"Malformed env, expected a map of mutations.",
+	);
+	let ret: wrap.Manifest.EnvMap = {};
+	for (let [key, val] of Object.entries(value.value)) {
+		console.log("key", key, "val", val);
+		if (val.kind === "mutation") {
+			ret[key] = [await mutationFromManifestMutation(val.value)];
+		} else if (val.kind === "array") {
+			ret[key] = await Promise.all(
+				val.value.map(async (inner) => {
+					let val = await valueFromManifestValue(inner);
+					tg.assert(tg.Mutation.is(val), "Malformed env, expected a mutation.");
+					return val;
+				}),
+			);
+		} else {
+			throw new Error(
+				"Malformed env, expected a mutation or array of mutations.",
+			);
+		}
+	}
+	return ret;
 };
 
 let isTemplateArg = (arg: unknown): arg is tg.Template.Arg => {


### PR DESCRIPTION
This PR introduces a breaking change to the types that comprise the wrapper manifest, as well as some additional changes:

* More judicious use of tg.target
* Consistent pattern in tg.Args.apply blocks
* Stop using serialize-only types for performing operations in `wrap.tg`
* As a consequence of above, avoid unnecessary conversions
* Remove unused crates from package workspace
* Linker proxy respects specified interpreters
* Linker proxy minimizes unnecessary references
* Linker proxy gained an option to produce a combined library directory. Disabled for now.
* Implement `std.wrap.unwrap()`/`tryUnwrap()`
* Corrected some error-handling cases
* Properly validate env values when converting to/from manifest