### PR TITLE
fix(std/env): retain all required references

### DIFF
--- a/packages/std/bootstrap/make.tg.ts
+++ b/packages/std/bootstrap/make.tg.ts
@@ -51,10 +51,11 @@ export let build = tg.target(async (arg?: std.Triple.HostArg) => {
 export default build;
 
 export let test = tg.target(async () => {
+	let directory = build();
 	await std.assert.pkg({
 		binaries: ["make"],
-		directory: build(),
+		directory,
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/bootstrap/musl.tg.ts
+++ b/packages/std/bootstrap/musl.tg.ts
@@ -35,14 +35,12 @@ export let build = tg.target(async (arg?: std.sdk.BuildEnvArg) => {
 	let host = await std.Triple.host(arg);
 	let hostSystem = std.Triple.system(host);
 
-	let prepare = "set -x && env";
-	let configure_ = { args: [`--enable-debug`, `--enable-optimize`] };
+	let configure = { args: [`--enable-debug`, `--enable-optimize=*`] };
 
-	let install = tg`make DESTDIR="$OUTPUT" install`;
+	let install = `make DESTDIR="$OUTPUT" install`;
 
 	let phases = {
-		prepare,
-		configure: configure_,
+		configure,
 		install,
 	};
 
@@ -64,7 +62,6 @@ export let build = tg.target(async (arg?: std.sdk.BuildEnvArg) => {
 	});
 
 	// The ld-musl symlink installed by default points to a broken absolute path. Use a relativesymlink instead.
-
 	result = await tg.directory(result, {
 		[`lib/${interpreterName(hostSystem)}`]: tg.symlink("libc.so"),
 	});

--- a/packages/std/image.tg.ts
+++ b/packages/std/image.tg.ts
@@ -88,3 +88,23 @@ export let testBasicRootfs = tg.target(async () => {
 
 	return imageFile;
 });
+
+export let testOciBasicEnv = tg.target(async () => {
+	let detectedHost = await std.Triple.host();
+	let host = bootstrap.toolchainTriple(detectedHost);
+	let utils = await std.utils.env({ host, sdk: { bootstrapMode: true } });
+	let basicEnv = await std.env(
+		utils,
+		{ NAME: "Tangram" },
+		{ bootstrapMode: true },
+	);
+	return basicEnv;
+});
+
+export let testBasicEnvImage = tg.target(async () => {
+	let basicEnv = await testOciBasicEnv();
+	let imageFile = await image(basicEnv, {
+		 cmd: ["bash"],
+	});
+	return imageFile;
+});

--- a/packages/std/image/oci.tg.ts
+++ b/packages/std/image/oci.tg.ts
@@ -188,6 +188,7 @@ export let imageFromLayers = async (
 	};
 
 	// Add the layers as blobs.
+	let utils = bootstrap.utils();
 	let layerDescriptors = await Promise.all(
 		layers.map(async (layer) => {
 			let file = await std.build(tg`gzip -nc ${layer.tar} > $OUTPUT`);
@@ -234,7 +235,7 @@ export let imageFromLayers = async (
 	});
 
 	// Tar the result and return it.
-	let image = await std.build(tg`tar -cf $OUTPUT -C ${directory} .`);
+	let image = await std.build(tg`tar -chf $OUTPUT -C ${directory} .`);
 	tg.File.assert(image);
 	return image;
 };
@@ -267,6 +268,7 @@ export type Layer = {
 	diffId: string;
 };
 
+import * as bootstrap from "../bootstrap.tg.ts";
 export let layer = tg.target(
 	async (directory: tg.Directory): Promise<Layer> => {
 		let bundle = directory.bundle();

--- a/packages/std/sdk/dependencies.tg.ts
+++ b/packages/std/sdk/dependencies.tg.ts
@@ -114,7 +114,9 @@ export let assertProvides = async (env: std.env.Arg) => {
 	return true;
 };
 
+import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	await assertProvides(await env({ sdk: { bootstrapMode: true } }));
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	await assertProvides(await env({ host, sdk: { bootstrapMode: true } }));
 	return true;
 });

--- a/packages/std/sdk/dependencies/autoconf.tg.ts
+++ b/packages/std/sdk/dependencies/autoconf.tg.ts
@@ -174,11 +174,10 @@ export let patchAutom4teCfg = tg.target(
 
 		let env = [arg?.env, std.sdk(arg?.sdk)];
 
-		let dir = tg.Directory.expect(
+		let patchedAutom4teCfg = tg.File.expect(
 			await tg.build(
 				tg`
-			mkdir -p $OUTPUT
-			cat <<'EOF' | tee $OUTPUT/autom4te.cfg
+			cat <<'EOF' | tee $OUTPUT
 			${contents}
 		`,
 				{ env: await std.env.object(env) },
@@ -186,16 +185,18 @@ export let patchAutom4teCfg = tg.target(
 		);
 
 		return tg.directory(autoconf, {
-			["share/autoconf/autom4te.cfg"]: dir.get("autom4te.cfg"),
+			["share/autoconf/autom4te.cfg"]: patchedAutom4teCfg,
 		});
 	},
 );
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["autoconf"],
 		metadata,
 	});

--- a/packages/std/sdk/dependencies/automake.tg.ts
+++ b/packages/std/sdk/dependencies/automake.tg.ts
@@ -118,10 +118,12 @@ export let build = tg.target(async (arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
-		binaries: ["autmake"],
+		directory: build({ host, sdk: { bootstrapMode: true } }),
+		binaries: ["automake"],
 		metadata,
 	});
 	return true;

--- a/packages/std/sdk/dependencies/bc.tg.ts
+++ b/packages/std/sdk/dependencies/bc.tg.ts
@@ -73,9 +73,11 @@ export let build = tg.target(async (arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["bc"],
 		metadata,
 	});

--- a/packages/std/sdk/dependencies/bison.tg.ts
+++ b/packages/std/sdk/dependencies/bison.tg.ts
@@ -59,9 +59,11 @@ export let build = tg.target((arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["bison"],
 		metadata,
 	});

--- a/packages/std/sdk/dependencies/bzip2.tg.ts
+++ b/packages/std/sdk/dependencies/bzip2.tg.ts
@@ -79,9 +79,11 @@ export let build = tg.target(async (arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: [{ name: "bzip2", testArgs: ["--help"] }],
 		libs: [{ name: "bz2", dylib: false, staticlib: true }],
 		metadata,

--- a/packages/std/sdk/dependencies/file.tg.ts
+++ b/packages/std/sdk/dependencies/file.tg.ts
@@ -88,10 +88,12 @@ export let build = tg.target(async (arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	// TODO - test magic file wrapping.
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["file"],
 		metadata,
 	});

--- a/packages/std/sdk/dependencies/flex.tg.ts
+++ b/packages/std/sdk/dependencies/flex.tg.ts
@@ -62,9 +62,11 @@ export let build = tg.target((arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["flex"],
 		metadata,
 	});

--- a/packages/std/sdk/dependencies/gperf.tg.ts
+++ b/packages/std/sdk/dependencies/gperf.tg.ts
@@ -50,9 +50,11 @@ export let build = tg.target((arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["gperf"],
 		metadata,
 	});

--- a/packages/std/sdk/dependencies/help2man.tg.ts
+++ b/packages/std/sdk/dependencies/help2man.tg.ts
@@ -67,9 +67,11 @@ export let build = tg.target(async (arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["help2man"],
 		metadata,
 	});

--- a/packages/std/sdk/dependencies/libffi.tg.ts
+++ b/packages/std/sdk/dependencies/libffi.tg.ts
@@ -58,9 +58,11 @@ export let build = tg.target((arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		libs: ["ffi"],
 	});
 	return true;

--- a/packages/std/sdk/dependencies/m4.tg.ts
+++ b/packages/std/sdk/dependencies/m4.tg.ts
@@ -51,9 +51,11 @@ export let build = tg.target((arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["m4"],
 		metadata,
 	});

--- a/packages/std/sdk/dependencies/make.tg.ts
+++ b/packages/std/sdk/dependencies/make.tg.ts
@@ -50,11 +50,12 @@ export let build = tg.target(async (arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
-	let makeArtifact = await build({ sdk: { bootstrapMode: true } });
-	// await std.assert.pkg({
-	// 	directory: makeArtifact,
-	// 	binaries: ["make"],
-	// 	metadata,
-	// });
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let makeArtifact = await build({ host, sdk: { bootstrapMode: true } });
+	await std.assert.pkg({
+		directory: makeArtifact,
+		binaries: ["make"],
+		metadata,
+	});
 	return makeArtifact;
 });

--- a/packages/std/sdk/dependencies/patch.tg.ts
+++ b/packages/std/sdk/dependencies/patch.tg.ts
@@ -51,9 +51,11 @@ export let build = tg.target((arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["patch"],
 		metadata,
 	});

--- a/packages/std/sdk/dependencies/perl.tg.ts
+++ b/packages/std/sdk/dependencies/perl.tg.ts
@@ -154,8 +154,9 @@ export let build = tg.target(async (arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["perl"],
 		metadata,
 	});

--- a/packages/std/sdk/dependencies/pkg_config.tg.ts
+++ b/packages/std/sdk/dependencies/pkg_config.tg.ts
@@ -103,9 +103,11 @@ export let path = tg.target(
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["pkg-config"],
 		metadata,
 	});

--- a/packages/std/sdk/dependencies/python.tg.ts
+++ b/packages/std/sdk/dependencies/python.tg.ts
@@ -60,7 +60,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let os = build.os;
 
 	let additionalEnv: std.env.Arg = {
-		TANGRAM_LINKER_LIBRARY_PATH_STRATEGY: "resolve",
+		TANGRAM_LINKER_LIBRARY_PATH_OPT_LEVEL: "resolve",
 	};
 	if (os === "darwin") {
 		additionalEnv = {
@@ -105,8 +105,9 @@ export let build = tg.target(async (arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["python3"],
 		metadata,
 	});

--- a/packages/std/sdk/dependencies/texinfo.tg.ts
+++ b/packages/std/sdk/dependencies/texinfo.tg.ts
@@ -49,9 +49,11 @@ export let build = tg.target((arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["makeinfo", "texi2any"],
 		metadata,
 	});

--- a/packages/std/sdk/dependencies/xz.tg.ts
+++ b/packages/std/sdk/dependencies/xz.tg.ts
@@ -84,8 +84,10 @@ export let build = tg.target(async (arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let xzArtifact = await build({ sdk: { bootstrapMode: true } });
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let xzArtifact = build({ host, sdk: { bootstrapMode: true } });
 	await std.assert.pkg({
 		directory: xzArtifact,
 		binaries: ["xz"],

--- a/packages/std/sdk/dependencies/zlib.tg.ts
+++ b/packages/std/sdk/dependencies/zlib.tg.ts
@@ -56,9 +56,11 @@ export let build = tg.target((arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		libs: ["z"],
 	});
 	return true;

--- a/packages/std/sdk/dependencies/zstd.tg.ts
+++ b/packages/std/sdk/dependencies/zstd.tg.ts
@@ -62,9 +62,11 @@ export let build = tg.target(async (arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		libs: ["zstd"],
 	});
 	return true;

--- a/packages/std/sdk/proxy.tg.ts
+++ b/packages/std/sdk/proxy.tg.ts
@@ -98,7 +98,7 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 						binDir = tg.directory(binDir, {
 							bin: {
 								[`${targetString}-gfortran`]: wrappedGFortran,
-							}
+							},
 						});
 					}
 				} else {
@@ -119,7 +119,7 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 							bin: {
 								gfortran: wrappedGFortran,
 								[`${hostString}-gfortran`]: tg.symlink("gfortran"),
-							}
+							},
 						});
 					}
 				}
@@ -220,11 +220,17 @@ export let ldProxy = async (arg: LdProxyArg) => {
 	let output = await std.wrap(tgld, {
 		identity: "wrapper",
 		env: {
-			TANGRAM_LINKER_COMMAND_PATH: arg.linker,
-			TANGRAM_LINKER_INJECTION_PATH: injectionLibrary,
-			TANGRAM_LINKER_INTERPRETER_ARGS: arg.interpreterArgs,
-			TANGRAM_LINKER_INTERPRETER_PATH: arg.interpreter ?? "none",
-			TANGRAM_LINKER_WRAPPER_PATH: wrapper,
+			TANGRAM_LINKER_COMMAND_PATH: tg.Mutation.setIfUnset<tg.File | tg.Symlink>(
+				arg.linker,
+			),
+			TANGRAM_LINKER_INJECTION_PATH: tg.Mutation.setIfUnset(injectionLibrary),
+			TANGRAM_LINKER_INTERPRETER_ARGS: arg.interpreterArgs
+				? tg.Mutation.setIfUnset(arg.interpreterArgs)
+				: undefined,
+			TANGRAM_LINKER_INTERPRETER_PATH: tg.Mutation.setIfUnset<tg.File | "none">(
+				arg.interpreter ?? "none",
+			),
+			TANGRAM_LINKER_WRAPPER_PATH: tg.Mutation.setIfUnset(wrapper),
 		},
 		sdk: arg.sdk,
 	});
@@ -250,7 +256,7 @@ int main() {
 			{
 				env: await std.env.object(bootstrapSDK, {
 					TGLD_TRACING: "tangram=trace",
-					TANGRAM_LINKER_LIBRARY_PATH_STRATEGY: "combine",
+					TANGRAM_LINKER_LIBRARY_PATH_OPT_LEVEL: "combine",
 					TANGRAM_WRAPPER_TRACING: "tangram=trace",
 				}),
 			},

--- a/packages/std/utils/bash.tg.ts
+++ b/packages/std/utils/bash.tg.ts
@@ -1,6 +1,5 @@
-import * as bootstrap from "../bootstrap.tg.ts";
 import * as std from "../tangram.tg.ts";
-import { buildUtil } from "../utils.tg.ts";
+import { buildUtil, prerequisites } from "../utils.tg.ts";
 
 export let metadata = {
 	name: "bash",
@@ -48,11 +47,17 @@ export let build = tg.target((arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
+	//let prepare = "set +e";
 	let configure = {
 		args: ["--without-bash-malloc"],
 	};
+	//let fixup = "mkdir -p $OUTPUT && cp config.log $OUTPUT";
 
-	let env = [bootstrap.make.build(arg), env_];
+	let env = [
+		prerequisites({ host }),
+		// { TGLD_TRACING: "tangram=trace" },
+		env_,
+	];
 
 	let output = buildUtil(
 		{
@@ -74,11 +79,14 @@ export let build = tg.target((arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let directory = build({ host, sdk: { bootstrapMode: true } });
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
-		binaries: ["bash"],
+		directory,
+		//binaries: ["bash"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/utils/diffutils.tg.ts
+++ b/packages/std/utils/diffutils.tg.ts
@@ -1,6 +1,5 @@
-import * as bootstrap from "../bootstrap.tg.ts";
 import * as std from "../tangram.tg.ts";
-import { buildUtil } from "../utils.tg.ts";
+import { buildUtil, prerequisites } from "../utils.tg.ts";
 
 let metadata = {
 	name: "diffutils",
@@ -34,7 +33,7 @@ export let build = tg.target((arg?: Arg) => {
 		args: ["--disable-dependency-tracking", "--disable-rpath"],
 	};
 
-	let env = [bootstrap.make.build(arg), env_];
+	let env = [prerequisites({ host }), env_];
 
 	let output = buildUtil(
 		{
@@ -52,9 +51,11 @@ export let build = tg.target((arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["cmp", "diff"],
 		metadata,
 	});

--- a/packages/std/utils/findutils.tg.ts
+++ b/packages/std/utils/findutils.tg.ts
@@ -1,6 +1,6 @@
 import * as bootstrap from "../bootstrap.tg.ts";
 import * as std from "../tangram.tg.ts";
-import { buildUtil } from "../utils.tg.ts";
+import { buildUtil, prerequisites } from "../utils.tg.ts";
 
 export let metadata = {
 	name: "findutils",
@@ -54,7 +54,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		args: ["--disable-dependency-tracking", "--disable-rpath"],
 	};
 
-	let env = [bootstrap.make.build(arg), env_];
+	let env = [prerequisites({ host }), env_];
 
 	let output = buildUtil(
 		{
@@ -74,8 +74,9 @@ export let build = tg.target(async (arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["find", "locate", "xargs"],
 		metadata,
 	});

--- a/packages/std/utils/gawk.tg.ts
+++ b/packages/std/utils/gawk.tg.ts
@@ -1,6 +1,5 @@
-import * as bootstrap from "../bootstrap.tg.ts";
 import * as std from "../tangram.tg.ts";
-import { buildUtil } from "../utils.tg.ts";
+import { buildUtil, prerequisites } from "../utils.tg.ts";
 
 export let metadata = {
 	name: "gawk",
@@ -34,7 +33,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		args: ["--disable-dependency-tracking", "--disable-rpath"],
 	};
 
-	let env = [bootstrap.make.build(arg), env_];
+	let env = [prerequisites({ host }), env_];
 
 	let output = buildUtil(
 		{
@@ -53,9 +52,11 @@ export let build = tg.target(async (arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["gawk"],
 		metadata,
 	});

--- a/packages/std/utils/grep.tg.ts
+++ b/packages/std/utils/grep.tg.ts
@@ -1,6 +1,5 @@
-import * as bootstrap from "../bootstrap.tg.ts";
 import * as std from "../tangram.tg.ts";
-import { buildUtil } from "../utils.tg.ts";
+import { buildUtil, prerequisites } from "../utils.tg.ts";
 
 export let metadata = {
 	name: "grep",
@@ -39,7 +38,7 @@ export let build = tg.target((arg?: Arg) => {
 		],
 	};
 
-	let env = [bootstrap.make.build(arg), env_];
+	let env = [prerequisites({ host }), env_];
 
 	let output = buildUtil(
 		{
@@ -58,9 +57,11 @@ export let build = tg.target((arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["grep"],
 		metadata,
 	});

--- a/packages/std/utils/gzip.tg.ts
+++ b/packages/std/utils/gzip.tg.ts
@@ -1,6 +1,5 @@
-import * as bootstrap from "../bootstrap.tg.ts";
 import * as std from "../tangram.tg.ts";
-import { buildUtil } from "../utils.tg.ts";
+import { buildUtil, prerequisites } from "../utils.tg.ts";
 
 export let metadata = {
 	name: "gzip",
@@ -34,7 +33,7 @@ export let build = tg.target((arg?: Arg) => {
 		args: ["--disable-dependency-tracking"],
 	};
 
-	let env = [bootstrap.make.build(arg), env_];
+	let env = [prerequisites({ host }), env_];
 
 	let output = buildUtil(
 		{
@@ -66,9 +65,11 @@ export let build = tg.target((arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["gzip"],
 		metadata,
 	});

--- a/packages/std/utils/sed.tg.ts
+++ b/packages/std/utils/sed.tg.ts
@@ -1,6 +1,5 @@
-import * as bootstrap from "../bootstrap.tg.ts";
 import * as std from "../tangram.tg.ts";
-import { buildUtil } from "../utils.tg.ts";
+import { buildUtil, prerequisites } from "../utils.tg.ts";
 
 export let metadata = {
 	name: "sed",
@@ -34,7 +33,7 @@ export let build = tg.target((arg?: Arg) => {
 		args: ["--disable-dependency-tracking"],
 	};
 
-	let env = [bootstrap.make.build(arg), env_];
+	let env = [prerequisites({ host }), env_];
 
 	let output = buildUtil(
 		{
@@ -52,9 +51,11 @@ export let build = tg.target((arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["sed"],
 		metadata,
 	});

--- a/packages/std/utils/tar.tg.ts
+++ b/packages/std/utils/tar.tg.ts
@@ -1,6 +1,5 @@
-import * as bootstrap from "../bootstrap.tg.ts";
 import * as std from "../tangram.tg.ts";
-import { buildUtil } from "../utils.tg.ts";
+import { buildUtil, prerequisites } from "../utils.tg.ts";
 import libiconv from "./libiconv.tg.ts";
 
 export let metadata = {
@@ -37,7 +36,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	// Bug: https://savannah.gnu.org/bugs/?64441.
 	// Fix http://git.savannah.gnu.org/cgit/tar.git/commit/?id=8632df39
 	// Remove in next release.
-	let dependencies = [bootstrap.make.build(arg)];
+	let dependencies: tg.Unresolved<std.env.Arg> = [prerequisites({ host })];
 	let additionalEnv = {};
 	if (build.os === "darwin") {
 		dependencies.push(libiconv(arg));
@@ -68,9 +67,11 @@ export let build = tg.target(async (arg?: Arg) => {
 
 export default build;
 
+import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
+	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	await std.assert.pkg({
-		directory: build({ sdk: { bootstrapMode: true } }),
+		directory: build({ host, sdk: { bootstrapMode: true } }),
 		binaries: ["tar"],
 		metadata,
 	});


### PR DESCRIPTION
* use bootstrap triple for util/SDK dependency tests
* build `musl` earlier to replace bootstrap musl at runtime
* rename `LibraryPathOptimizationStrategy` to `LibraryPathOptimizationLevel`
* Add assertion for file references