### PR TITLE
fix(openssl): prevent creating lib64 directory in output

### DIFF
--- a/packages/openssl/tangram.tg.ts
+++ b/packages/openssl/tangram.tg.ts
@@ -69,7 +69,6 @@ export let openssl = tg.target(async (arg?: Arg) => {
 		},
 		autotools,
 	);
-	console.log("openssl", await openssl.id());
 
 	return tg.directory(openssl, {
 		["bin/openssl"]: std.wrap(


### PR DESCRIPTION
The default behavior on `x86_64-linux` is to create a `lib64` directory for libraries, but on `aarch64-linux` and `darwin`, it just creates `lib`, which we prefer. This PR instead specifies `lib` during configuration, ensuring uniformity across supported systems.