### PR TITLE
refactor(std/sdk): consistent bootstrap mode

### DIFF
--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -817,9 +817,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
 
 [[package]]
 name = "hex"
@@ -1039,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
 ]
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=df8e9383dcf7269d8fc57ee8da0db6d0ed508af2#df8e9383dcf7269d8fc57ee8da0db6d0ed508af2"
+source = "git+https://github.com/tangramdotdev/tangram?rev=caf5ae94f89cc7a0edfdc3d3ca56789da378201a#caf5ae94f89cc7a0edfdc3d3ca56789da378201a"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -1799,7 +1799,7 @@ dependencies = [
 [[package]]
 name = "tangram_error"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=df8e9383dcf7269d8fc57ee8da0db6d0ed508af2#df8e9383dcf7269d8fc57ee8da0db6d0ed508af2"
+source = "git+https://github.com/tangramdotdev/tangram?rev=caf5ae94f89cc7a0edfdc3d3ca56789da378201a#caf5ae94f89cc7a0edfdc3d3ca56789da378201a"
 dependencies = [
  "serde",
  "thiserror",
@@ -1828,7 +1828,7 @@ dependencies = [
 [[package]]
 name = "tangram_util"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=df8e9383dcf7269d8fc57ee8da0db6d0ed508af2#df8e9383dcf7269d8fc57ee8da0db6d0ed508af2"
+source = "git+https://github.com/tangramdotdev/tangram?rev=caf5ae94f89cc7a0edfdc3d3ca56789da378201a#caf5ae94f89cc7a0edfdc3d3ca56789da378201a"
 dependencies = [
  "bytes",
  "futures",
@@ -1871,13 +1871,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -2135,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-xid"
@@ -2214,9 +2213,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2224,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
@@ -2239,9 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2249,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2262,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "webpki-roots"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -24,8 +24,8 @@ itertools = "0.12"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "df8e9383dcf7269d8fc57ee8da0db6d0ed508af2" }
-tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "df8e9383dcf7269d8fc57ee8da0db6d0ed508af2" }
+tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "caf5ae94f89cc7a0edfdc3d3ca56789da378201a" }
+tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "caf5ae94f89cc7a0edfdc3d3ca56789da378201a" }
 tokio = { version = "1", default-features = false, features = ["rt", "macros", "fs", "parking_lot"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "parking_lot"] }

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -203,7 +203,7 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 			build: host,
 			host,
 			env: envs,
-			sdk: { bootstrapMode: true },
+			bootstrapMode: true,
 		});
 		envs.push(dependenciesEnv);
 
@@ -459,8 +459,8 @@ export namespace sdk {
 			os === "darwin"
 				? "ld"
 				: flavor === "gcc"
-				  ? `${targetPrefix}ld`
-				  : "ld.lld";
+					? `${targetPrefix}ld`
+					: "ld.lld";
 		let foundLd = await directory.tryGet(`bin/${linkerName}`);
 		tg.assert(foundLd, `Unable to find ${linkerName}.`);
 		let ld = await tg.symlink(tg`${directory}/bin/${linkerName}`);

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -308,6 +308,7 @@ export namespace sdk {
 	};
 
 	export type BuildEnvArg = {
+		bootstrapMode?: boolean;
 		build?: std.Triple.Arg;
 		env?: std.env.Arg;
 		host?: std.Triple.Arg;

--- a/packages/std/sdk/binutils.tg.ts
+++ b/packages/std/sdk/binutils.tg.ts
@@ -76,7 +76,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		};
 	}
 	let env = [
-		dependencies.env({ ...rest, host: build }),
+		dependencies.env({ ...rest, env: env_, host: build }),
 		additionalEnv,
 		env_,
 	];

--- a/packages/std/sdk/binutils.tg.ts
+++ b/packages/std/sdk/binutils.tg.ts
@@ -76,7 +76,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		};
 	}
 	let env = [
-		dependencies.env({ host: build, sdk: rest.sdk }),
+		dependencies.env({ ...rest, host: build }),
 		additionalEnv,
 		env_,
 	];

--- a/packages/std/sdk/cmake.tg.ts
+++ b/packages/std/sdk/cmake.tg.ts
@@ -57,7 +57,7 @@ export let cmake = tg.target(async (arg?: Arg) => {
 		],
 	};
 
-	let deps = [dependencies.env({ host: build, sdk: rest.sdk })];
+	let deps = [dependencies.env({ ...rest, env: env_, host: build })];
 	let env = [
 		...deps,
 		{

--- a/packages/std/sdk/dependencies.tg.ts
+++ b/packages/std/sdk/dependencies.tg.ts
@@ -126,7 +126,7 @@ export let env = tg.target(async (arg?: Arg) => {
 	}
 
 	// The final env contains the standard utils and all packages from this module.
-	return std.env(...dependencies, { bootstrapMode: true });
+	return dependencies;
 });
 
 export default env;
@@ -165,6 +165,8 @@ export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
-	await assertProvides(await env({ host, bootstrapMode, env: sdk }));
+	let deps = await env({ host, bootstrapMode, env: sdk });
+	await assertProvides(deps);
+	await tg.build(tg`set -x && echo "hi" && which grep`, { env: await std.env.object(deps) });
 	return true;
 });

--- a/packages/std/sdk/dependencies.tg.ts
+++ b/packages/std/sdk/dependencies.tg.ts
@@ -167,6 +167,5 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let deps = await env({ host, bootstrapMode, env: sdk });
 	await assertProvides(deps);
-	await tg.build(tg`set -x && echo "hi" && which grep`, { env: await std.env.object(deps) });
 	return true;
 });

--- a/packages/std/sdk/dependencies.tg.ts
+++ b/packages/std/sdk/dependencies.tg.ts
@@ -163,6 +163,8 @@ export let assertProvides = async (env: std.env.Arg) => {
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
-	await assertProvides(await env({ host, sdk: { bootstrapMode: true } }));
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	await assertProvides(await env({ host, bootstrapMode, env: sdk }));
 	return true;
 });

--- a/packages/std/sdk/dependencies/autoconf.tg.ts
+++ b/packages/std/sdk/dependencies/autoconf.tg.ts
@@ -195,10 +195,13 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["autoconf"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/autoconf.tg.ts
+++ b/packages/std/sdk/dependencies/autoconf.tg.ts
@@ -172,7 +172,7 @@ export let patchAutom4teCfg = tg.target(
 			contents = tg`${contents}${newLine}\n`;
 		}
 
-		let env = [arg?.env, std.sdk(arg?.sdk)];
+		let env = [arg?.env, std.sdk({ bootstrapMode: arg?.bootstrapMode },arg?.sdk)];
 
 		let patchedAutom4teCfg = tg.File.expect(
 			await tg.build(

--- a/packages/std/sdk/dependencies/automake.tg.ts
+++ b/packages/std/sdk/dependencies/automake.tg.ts
@@ -121,10 +121,13 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["automake"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/bc.tg.ts
+++ b/packages/std/sdk/dependencies/bc.tg.ts
@@ -76,10 +76,13 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["bc"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/bison.tg.ts
+++ b/packages/std/sdk/dependencies/bison.tg.ts
@@ -62,10 +62,13 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["bison"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/bzip2.tg.ts
+++ b/packages/std/sdk/dependencies/bzip2.tg.ts
@@ -41,7 +41,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let sourceDir = source_ ?? source();
 
 	// Define phases.
-	let prepare = tg`set -x && cp -R ${sourceDir}/* .`;
+	let prepare = tg`cp -R ${sourceDir}/* .`;
 	let install = `make install PREFIX=$OUTPUT`;
 	// NOTE - these symlinks get installed with absolute paths pointing to the ephermeral output directory. Use relative links instead.
 	let fixup = `
@@ -82,11 +82,14 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: [{ name: "bzip2", testArgs: ["--help"] }],
 		libs: [{ name: "bz2", dylib: false, staticlib: true }],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/file.tg.ts
+++ b/packages/std/sdk/dependencies/file.tg.ts
@@ -92,10 +92,13 @@ import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	// TODO - test magic file wrapping.
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["file"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/flex.tg.ts
+++ b/packages/std/sdk/dependencies/flex.tg.ts
@@ -65,10 +65,13 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["flex"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/gperf.tg.ts
+++ b/packages/std/sdk/dependencies/gperf.tg.ts
@@ -53,10 +53,13 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["gperf"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/help2man.tg.ts
+++ b/packages/std/sdk/dependencies/help2man.tg.ts
@@ -70,10 +70,13 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["help2man"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/libffi.tg.ts
+++ b/packages/std/sdk/dependencies/libffi.tg.ts
@@ -61,9 +61,12 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		libs: ["ffi"],
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/m4.tg.ts
+++ b/packages/std/sdk/dependencies/m4.tg.ts
@@ -54,10 +54,13 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["m4"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/make.tg.ts
+++ b/packages/std/sdk/dependencies/make.tg.ts
@@ -31,7 +31,9 @@ export let build = tg.target(async (arg?: Arg) => {
 	let configure = {
 		args: ["--disable-dependency-tracking"],
 	};
-	let phases = { prepare: "set +e", configure, fixup: "mkdir -p $OUTPUT && cp config.log $OUTPUT/config.log" };
+	let phases = {
+		configure,
+	};
 
 	let env = [std.utils.env(arg), bootstrap.make.build(arg), env_];
 
@@ -51,7 +53,9 @@ export default build;
 
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
-	let makeArtifact = await build({ host, sdk: { bootstrapMode: true } });
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let makeArtifact = await build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
 		directory: makeArtifact,
 		binaries: ["make"],

--- a/packages/std/sdk/dependencies/patch.tg.ts
+++ b/packages/std/sdk/dependencies/patch.tg.ts
@@ -54,10 +54,13 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["patch"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/perl.tg.ts
+++ b/packages/std/sdk/dependencies/perl.tg.ts
@@ -155,10 +155,13 @@ export default build;
 
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["perl"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/pkg_config.tg.ts
+++ b/packages/std/sdk/dependencies/pkg_config.tg.ts
@@ -124,10 +124,13 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["pkg-config"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/python.tg.ts
+++ b/packages/std/sdk/dependencies/python.tg.ts
@@ -105,10 +105,13 @@ export default build;
 
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["python3"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/texinfo.tg.ts
+++ b/packages/std/sdk/dependencies/texinfo.tg.ts
@@ -52,10 +52,13 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["makeinfo", "texi2any"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/dependencies/xz.tg.ts
+++ b/packages/std/sdk/dependencies/xz.tg.ts
@@ -88,7 +88,9 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
-	let xzArtifact = build({ host, sdk: { bootstrapMode: true } });
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let xzArtifact = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
 		directory: xzArtifact,
 		binaries: ["xz"],

--- a/packages/std/sdk/dependencies/zlib.tg.ts
+++ b/packages/std/sdk/dependencies/zlib.tg.ts
@@ -59,7 +59,9 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
-	let directory = build({ host, sdk: { bootstrapMode: true } });
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
 		directory,
 		libs: ["z"],

--- a/packages/std/sdk/dependencies/zstd.tg.ts
+++ b/packages/std/sdk/dependencies/zstd.tg.ts
@@ -65,9 +65,12 @@ export default build;
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		libs: ["zstd"],
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/sdk/gcc.tg.ts
+++ b/packages/std/sdk/gcc.tg.ts
@@ -164,7 +164,7 @@ export let build = tg.target(async (arg: Arg) => {
 	let phases = { prepare, configure };
 
 	let env = [
-		dependencies.env({ host: build, sdk: rest.sdk }),
+		dependencies.env({ ...rest, env: env_, host: build }),
 		additionalEnv,
 		env_,
 	];

--- a/packages/std/sdk/gcc/toolchain.tg.ts
+++ b/packages/std/sdk/gcc/toolchain.tg.ts
@@ -106,7 +106,13 @@ type BuildSysrootArg = std.sdk.BuildEnvArg & {
 };
 
 export let buildSysroot = tg.target(async (arg: BuildSysrootArg) => {
-	let { build: build_, crossBinutils, host: host_, ...rest } = arg ?? {};
+	let {
+		build: build_,
+		crossBinutils,
+		env,
+		host: host_,
+		...rest
+	} = arg ?? {};
 
 	let host = host_ ? std.triple(host_) : await std.Triple.host();
 	let buildTriple = build_ ? std.triple(build_) : host;
@@ -117,6 +123,7 @@ export let buildSysroot = tg.target(async (arg: BuildSysrootArg) => {
 		include: await kernelHeaders({
 			...rest,
 			build: buildTriple,
+			env,
 			host: target,
 		}),
 	});
@@ -131,6 +138,7 @@ export let buildSysroot = tg.target(async (arg: BuildSysrootArg) => {
 		...rest,
 		binutils: crossBinutils,
 		build: buildTriple,
+		env,
 		host: buildTriple,
 		sysroot: linuxHeadersSysroot,
 		target,

--- a/packages/std/sdk/gcc/toolchain.tg.ts
+++ b/packages/std/sdk/gcc/toolchain.tg.ts
@@ -57,7 +57,6 @@ type CrossToolchainArg = std.sdk.BuildEnvArg & {
 export let crossToolchain = tg.target(async (arg: CrossToolchainArg) => {
 	let {
 		build: build_,
-		env: env_,
 		host: host_,
 		sysroot: sysroot_,
 		target: target_,
@@ -107,13 +106,7 @@ type BuildSysrootArg = std.sdk.BuildEnvArg & {
 };
 
 export let buildSysroot = tg.target(async (arg: BuildSysrootArg) => {
-	let {
-		build: build_,
-		crossBinutils,
-		env: env_,
-		host: host_,
-		...rest
-	} = arg ?? {};
+	let { build: build_, crossBinutils, host: host_, ...rest } = arg ?? {};
 
 	let host = host_ ? std.triple(host_) : await std.Triple.host();
 	let buildTriple = build_ ? std.triple(build_) : host;
@@ -121,7 +114,11 @@ export let buildSysroot = tg.target(async (arg: BuildSysrootArg) => {
 
 	// Produce the linux headers.
 	let linuxHeaders = await tg.directory({
-		include: await kernelHeaders({ build: buildTriple, host: target }),
+		include: await kernelHeaders({
+			...rest,
+			build: buildTriple,
+			host: target,
+		}),
 	});
 	console.log("linuxHeaders", await linuxHeaders.id());
 

--- a/packages/std/sdk/libc.tg.ts
+++ b/packages/std/sdk/libc.tg.ts
@@ -6,7 +6,7 @@ type LibCArg = std.sdk.BuildEnvArg & {
 	// /** Optionally point to a specific implementation of libcc. Only supported for musl, glibc requires libgcc. */
 	// libcc?: tg.File;
 	linuxHeaders: tg.Directory;
-	target?: std.Triple.Arg
+	target?: std.Triple.Arg;
 };
 
 /** Obtain the proper standard C library for the given host triple. */

--- a/packages/std/sdk/libc/glibc.tg.ts
+++ b/packages/std/sdk/libc/glibc.tg.ts
@@ -105,14 +105,13 @@ export default tg.target(async (arg: Arg) => {
 			LIBRARY_PATH: tg.Mutation.unset(),
 			TANGRAM_LINKER_PASSTHROUGH: "1",
 		},
-		env_
+		env_,
 	];
 
 	let result = await std.autotools.build(
 		{
 			...rest,
 			...std.Triple.rotate({ build, host }),
-			bootstrapMode: true, // FIXME - shouldn't be necessary
 			env,
 			opt: "2",
 			phases,

--- a/packages/std/sdk/libc/glibc.tg.ts
+++ b/packages/std/sdk/libc/glibc.tg.ts
@@ -67,7 +67,7 @@ export default tg.target(async (arg: Arg) => {
 		additionalFlags.push("--enable-crypt");
 	}
 
-	let prepare = `mkdir -p $OUTPUT`;
+	let prepare = `mkdir -p $OUTPUT && env`;
 
 	let configure = {
 		args: [
@@ -95,19 +95,24 @@ export default tg.target(async (arg: Arg) => {
 	};
 
 	let env = [
-		dependencies.env({ ...rest, env: env_, host: build }),
+		dependencies.env({
+			...rest,
+			env: std.sdk({ host: build, bootstrapMode: rest.bootstrapMode }),
+			host: build,
+		}),
 		{
 			CPATH: tg.Mutation.unset(),
 			LIBRARY_PATH: tg.Mutation.unset(),
 			TANGRAM_LINKER_PASSTHROUGH: "1",
 		},
-		env_,
+		env_
 	];
 
 	let result = await std.autotools.build(
 		{
 			...rest,
 			...std.Triple.rotate({ build, host }),
+			bootstrapMode: true, // FIXME - shouldn't be necessary
 			env,
 			opt: "2",
 			phases,

--- a/packages/std/sdk/libc/glibc.tg.ts
+++ b/packages/std/sdk/libc/glibc.tg.ts
@@ -95,7 +95,7 @@ export default tg.target(async (arg: Arg) => {
 	};
 
 	let env = [
-		dependencies.env({ host: build, sdk: rest.sdk }),
+		dependencies.env({ ...rest, env: env_, host: build }),
 		{
 			CPATH: tg.Mutation.unset(),
 			LIBRARY_PATH: tg.Mutation.unset(),

--- a/packages/std/sdk/libc/musl.tg.ts
+++ b/packages/std/sdk/libc/musl.tg.ts
@@ -90,7 +90,7 @@ export default tg.target(async (arg?: Arg) => {
 	};
 
 	let env = [
-		dependencies.env({ host: build, sdk: rest.sdk }),
+		dependencies.env({ ...rest, env: env_, host: build }),
 		{ CPATH: tg.Mutation.unset() },
 		env_,
 	];

--- a/packages/std/sdk/libc/musl.tg.ts
+++ b/packages/std/sdk/libc/musl.tg.ts
@@ -67,7 +67,7 @@ export default tg.target(async (arg?: Arg) => {
 				`CROSS_COMPILE="${hostString}-"`,
 				`CC="${hostString}-gcc"`,
 				"--disable-gcc-wrapper",
-		  ]
+			]
 		: [];
 
 	if (libcc) {
@@ -90,9 +90,13 @@ export default tg.target(async (arg?: Arg) => {
 	};
 
 	let env = [
-		dependencies.env({ ...rest, env: env_, host: build }),
-		{ CPATH: tg.Mutation.unset() },
 		env_,
+		dependencies.env({
+			...rest,
+			env: std.sdk({ host: build, bootstrapMode: rest.bootstrapMode }),
+			host: build,
+		}),
+		{ CPATH: tg.Mutation.unset() },
 	];
 
 	let result = await std.autotools.build(

--- a/packages/std/utils.tg.ts
+++ b/packages/std/utils.tg.ts
@@ -54,15 +54,13 @@ export let env = tg.target(async (arg?: Arg) => {
 		host,
 	});
 	let bashExecutable = tg.File.expect(await bashArtifact.get("bin/bash"));
-	let env = [
-		{
-			CONFIG_SHELL: bashExecutable,
-			SHELL: bashExecutable,
-		},
-		env_,
-	];
+	let bashEnv = {
+		CONFIG_SHELL: bashExecutable,
+		SHELL: bashExecutable,
+	};
+	let env = [bashEnv, env_];
 
-	let utils = [bashArtifact];
+	let utils = [bashArtifact, bashEnv];
 	if (parallel) {
 		utils = utils.concat(
 			await Promise.all([
@@ -87,7 +85,7 @@ export let env = tg.target(async (arg?: Arg) => {
 		utils.push(await tar({ ...rest, bootstrapMode, env, host }));
 	}
 
-	return std.env(...utils, env, { bootstrapMode: true });
+	return utils;
 });
 
 export default env;

--- a/packages/std/utils/diffutils.tg.ts
+++ b/packages/std/utils/diffutils.tg.ts
@@ -22,6 +22,7 @@ type Arg = std.sdk.BuildEnvArg & {
 export let build = tg.target(async (arg?: Arg) => {
 	let {
 		autotools = [],
+		bootstrapMode,
 		build: build_,
 		env: env_,
 		host: host_,
@@ -36,12 +37,19 @@ export let build = tg.target(async (arg?: Arg) => {
 		args: ["--disable-dependency-tracking", "--disable-rpath"],
 	};
 
-	let env = [prerequisites({ host }), env_];
+
+	let env: tg.Unresolved<Array<std.env.Arg>> = [];
+	if (bootstrapMode) {
+		env.push(prerequisites({ host }));
+	}
+	env.push(env_);
+
 
 	let output = buildUtil(
 		{
 			...rest,
 			...std.Triple.rotate({ build, host }),
+			bootstrapMode,
 			env,
 			phases: { configure },
 			source: source_ ?? source(),
@@ -57,10 +65,13 @@ export default build;
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = await build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["cmp", "diff"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/utils/gawk.tg.ts
+++ b/packages/std/utils/gawk.tg.ts
@@ -22,6 +22,7 @@ type Arg = std.sdk.BuildEnvArg & {
 export let build = tg.target(async (arg?: Arg) => {
 	let {
 		autotools = [],
+		bootstrapMode,
 		build: build_,
 		env: env_,
 		host: host_,
@@ -36,12 +37,17 @@ export let build = tg.target(async (arg?: Arg) => {
 		args: ["--disable-dependency-tracking", "--disable-rpath"],
 	};
 
-	let env = [prerequisites({ host }), env_];
+	let env: tg.Unresolved<Array<std.env.Arg>> = [];
+	if (bootstrapMode) {
+		env.push(prerequisites({ host }));
+	}
+	env.push(env_);
 
 	let output = buildUtil(
 		{
 			...rest,
 			...std.Triple.rotate({ build, host }),
+			bootstrapMode,
 			env,
 			phases: { configure },
 			source: source_ ?? source(),
@@ -58,10 +64,13 @@ export default build;
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["gawk"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/utils/grep.tg.ts
+++ b/packages/std/utils/grep.tg.ts
@@ -22,6 +22,7 @@ type Arg = std.sdk.BuildEnvArg & {
 export let build = tg.target(async (arg?: Arg) => {
 	let {
 		autotools = [],
+		bootstrapMode,
 		build: build_,
 		env: env_,
 		host: host_,
@@ -41,12 +42,17 @@ export let build = tg.target(async (arg?: Arg) => {
 		],
 	};
 
-	let env = [prerequisites({ host }), env_];
+	let env: tg.Unresolved<Array<std.env.Arg>> = [];
+	if (bootstrapMode) {
+		env.push(prerequisites({ host }));
+	}
+	env.push(env_);
 
 	let output = buildUtil(
 		{
 			...rest,
 			...std.Triple.rotate({ build, host }),
+			bootstrapMode,
 			env,
 			phases: { configure },
 			source: source(),
@@ -63,10 +69,13 @@ export default build;
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["grep"],
 		metadata,
 	});
-	return true;
+	return directory;
 });

--- a/packages/std/utils/gzip.tg.ts
+++ b/packages/std/utils/gzip.tg.ts
@@ -22,6 +22,7 @@ type Arg = std.sdk.BuildEnvArg & {
 export let build = tg.target(async (arg?: Arg) => {
 	let {
 		autotools = [],
+		bootstrapMode,
 		build: build_,
 		env: env_,
 		host: host_,
@@ -36,12 +37,17 @@ export let build = tg.target(async (arg?: Arg) => {
 		args: ["--disable-dependency-tracking"],
 	};
 
-	let env = [prerequisites({ host }), env_];
+	let env: tg.Unresolved<Array<std.env.Arg>> = [];
+	if (bootstrapMode) {
+		env.push(prerequisites({ host }));
+	}
+	env.push(env_);
 
 	let output = buildUtil(
 		{
 			...rest,
 			...std.Triple.rotate({ build, host }),
+			bootstrapMode,
 			env,
 			phases: { configure },
 			source: source_ ?? source(),
@@ -71,10 +77,13 @@ export default build;
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.Triple.host());
+	let bootstrapMode = true;
+	let sdk = std.sdk({ host, bootstrapMode });
+	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
-		directory: build({ host, sdk: { bootstrapMode: true } }),
+		directory,
 		binaries: ["gzip"],
 		metadata,
 	});
-	return true;
+	return directory;
 });


### PR DESCRIPTION
This PR refactors the SDK bootstrapping process to avoid including superfluous pieces of the bootstrap artifacts in build environments after their Tangram-native replacements have been built.