### PR TITLE
refactor(std/sdk): smaller sdk env

### DIFF
--- a/packages/git/tangram.tg.ts
+++ b/packages/git/tangram.tg.ts
@@ -7,7 +7,7 @@ export let metadata = {
 	license: "GPL-2.0-only",
 	name: "git",
 	repository: "https://github.com/git/git",
-	version: "2.43.0",
+	version: "2.44.0",
 };
 
 export let source = tg.target(async () => {
@@ -20,7 +20,7 @@ export let source = tg.target(async () => {
 	});
 	let url = `https://mirrors.edge.kernel.org/pub/software/scm/git/${packageArchive}`;
 	let checksum =
-		"sha256:5446603e73d911781d259e565750dcd277a42836c8e392cac91cf137aa9b76ec";
+		"sha256:e358738dcb5b5ea340ce900a0015c03ae86e804e7ff64e47aa4631ddee681de3";
 	let outer = tg.Directory.expect(
 		await std.download({ url, checksum, unpackFormat }),
 	);

--- a/packages/m4/tangram.tg.ts
+++ b/packages/m4/tangram.tg.ts
@@ -24,10 +24,15 @@ type Arg = {
 export let m4 = tg.target(async (arg?: Arg) => {
 	let { autotools = [], build, host, source: source_, ...rest } = arg ?? {};
 
+	let configure = {
+		args: ["--disable-dependency-tracking"],
+	};
+
 	return std.autotools.build(
 		{
 			...rest,
 			...tg.Triple.rotate({ build, host }),
+			phases: { configure },
 			source: source_ ?? source(),
 		},
 		autotools,
@@ -37,8 +42,11 @@ export let m4 = tg.target(async (arg?: Arg) => {
 export default m4;
 
 export let test = tg.target(async () => {
-	return std.build(tg`
-		echo "Checking that we can run m4."
-		${m4()}/bin/m4 --version
-	`);
+	let directory = m4();
+	await std.assert.pkg({
+		directory,
+		binaries: ["m4"],
+		metadata,
+	});
+	return directory;
 });

--- a/packages/nodejs/tangram.tg.ts
+++ b/packages/nodejs/tangram.tg.ts
@@ -29,7 +29,7 @@ let source = async (): Promise<tg.Directory> => {
 		["aarch64-linux"]: {
 			url: `https://nodejs.org/dist/v${version}/node-v${version}-linux-arm64.tar.xz`,
 			checksum:
-				"sha256:",
+				"sha256:c957f29eb4e341903520caf362534f0acd1db7be79c502ae8e283994eed07fe1",
 			unpackFormat: ".tar.xz",
 		},
 		["x86_64-linux"]: {

--- a/packages/nodejs/tangram.tg.ts
+++ b/packages/nodejs/tangram.tg.ts
@@ -2,7 +2,7 @@ import * as std from "tg:std" with { path: "../std" };
 
 export let metadata = {
 	name: "nodejs",
-	version: "20.11.0",
+	version: "20.11.1",
 };
 
 type ToolchainArg = {
@@ -28,30 +28,36 @@ let source = async (): Promise<tg.Directory> => {
 	} = {
 		["aarch64-linux"]: {
 			url: `https://nodejs.org/dist/v${version}/node-v${version}-linux-arm64.tar.xz`,
-			checksum: "sha256:f6df68c6793244071f69023a9b43a0cf0b13d65cbe86d55925c28e4134d9aafb",
+			checksum:
+				"sha256:",
 			unpackFormat: ".tar.xz",
 		},
 		["x86_64-linux"]: {
 			url: `https://nodejs.org/dist/v${version}/node-v${version}-linux-x64.tar.xz`,
-			checksum: "sha256:822780369d0ea309e7d218e41debbd1a03f8cdf354ebf8a4420e89f39cc2e612",
+			checksum:
+				"sha256:d8dab549b09672b03356aa2257699f3de3b58c96e74eb26a8b495fbdc9cf6fbe",
 			unpackFormat: ".tar.xz",
 		},
 		["aarch64-darwin"]: {
 			url: `https://nodejs.org/dist/v${version}/node-v${version}-darwin-arm64.tar.xz`,
-			checksum: "sha256:f18a7438723d48417f5e9be211a2f3c0520ffbf8e02703469e5153137ca0f328",
+			checksum:
+				"sha256:fd771bf3881733bfc0622128918ae6baf2ed1178146538a53c30ac2f7006af5b",
 			unpackFormat: ".tar.xz",
 		},
 		["x86_64-darwin"]: {
 			url: `https://nodejs.org/dist/v${version}/node-v${version}-darwin-x64.tar.xz`,
 			checksum:
-				"sha256:f18a7438723d48417f5e9be211a2f3c0520ffbf8e02703469e5153137ca0f328",
+				"sha256:ed69f1f300beb75fb4cad45d96aacd141c3ddca03b6d77c76b42cb258202363d",
 			unpackFormat: ".tar.xz",
 		},
 	};
 
 	// Get the NodeJS release.
 	let targetString = tg.Triple.toString(target);
-	tg.assert(targetString in releases, `Unsupported target system: ${targetString}.`);
+	tg.assert(
+		targetString in releases,
+		`Unsupported target system: ${targetString}.`,
+	);
 
 	let release = releases[targetString];
 	tg.assert(release, "Unsupported target");

--- a/packages/openssl/tangram.tg.ts
+++ b/packages/openssl/tangram.tg.ts
@@ -1,3 +1,4 @@
+import perl from "tg:perl" with { path: "../perl" };
 import * as std from "tg:std" with { path: "../std" };
 
 export let metadata = {
@@ -35,6 +36,7 @@ export let openssl = tg.target(async (arg?: Arg) => {
 	let {
 		autotools = [],
 		build,
+		env: env_,
 		host: host_,
 		source: source_,
 		...rest
@@ -60,10 +62,13 @@ export let openssl = tg.target(async (arg?: Arg) => {
 	};
 	let phases = { prepare, configure, install };
 
+	let env = [perl(arg), env_];
+
 	let openssl = await std.autotools.build(
 		{
 			...rest,
 			...tg.Triple.rotate({ build, host }),
+			env,
 			phases,
 			source: sourceDir,
 		},

--- a/packages/pcre2/tangram.tg.ts
+++ b/packages/pcre2/tangram.tg.ts
@@ -2,13 +2,13 @@ import * as std from "tg:std" with { path: "../std" };
 
 export let metadata = {
 	name: "pcre2",
-	version: "10.42",
+	version: "10.43",
 };
 
 export let source = tg.target(async () => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:c33b418e3b936ee3153de2c61cc638e7e4fe3156022a5c77d0711bcbb9d64f1f";
+		"sha256:889d16be5abb8d05400b33c25e151638b8d4bac0e2d9c76e9d6923118ae8a34e";
 	let owner = "PCRE2Project";
 	let repo = name;
 	let tag = `pcre2-${version}`;

--- a/packages/perl/perl_cpp_precomp.patch
+++ b/packages/perl/perl_cpp_precomp.patch
@@ -1,0 +1,12 @@
+diff -Naur perl-5.38.2/hints/darwin.sh perl-5.38.2_patched/hints/darwin.sh
+--- perl-5.38.2/hints/darwin.sh	2023-11-28 06:57:28
++++ perl-5.38.2_patched/hints/darwin.sh	2023-12-10 14:22:17
+@@ -130,7 +130,7 @@
+ 
+ # Avoid Apple's cpp precompiler, better for extensions
+ if [ "X`echo | ${cc} -no-cpp-precomp -E - 2>&1 >/dev/null`" = "X" ]; then
+-    cppflags="${cppflags} -no-cpp-precomp"
++    #cppflags="${cppflags} -no-cpp-precomp"
+ 
+     # This is necessary because perl's build system doesn't
+     # apply cppflags to cc compile lines as it should.

--- a/packages/perl/perl_macos_version.patch
+++ b/packages/perl/perl_macos_version.patch
@@ -1,0 +1,12 @@
+diff -Naur perl-5.38.2/hints/darwin.sh perl-5.38.2_patched/hints/darwin.sh
+--- perl-5.38.2/hints/darwin.sh	2023-11-28 06:57:28
++++ perl-5.38.2_patched/hints/darwin.sh	2023-12-10 14:18:41
+@@ -325,7 +325,7 @@
+     # sw_vers output                 what we want
+     # "ProductVersion:    10.10.5"   "10.10"
+     # "ProductVersion:    10.11"     "10.11"
+-        prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
++        prodvers="${MACOSX_DEPLOYMENT_TARGET:-14.2}"
+     case "$prodvers" in
+     [1-9][0-9].*)
+       add_macosx_version_min ccflags $prodvers

--- a/packages/perl/perl_no_fix_deps.patch
+++ b/packages/perl/perl_no_fix_deps.patch
@@ -1,0 +1,19 @@
+diff -Naur perl-5.38.2/installperl perl-5.38.2_patched/installperl
+--- perl-5.38.2/installperl	2023-11-28 06:57:28
++++ perl-5.38.2_patched/installperl	2023-12-10 14:23:51
+@@ -282,7 +282,6 @@
+     safe_unlink("$installbin/$perl_verbase$ver$exe_ext");
+     copy("perl$exe_ext", "$installbin/$perl_verbase$ver$exe_ext");
+     strip("$installbin/$perl_verbase$ver$exe_ext");
+-    fix_dep_names("$installbin/$perl_verbase$ver$exe_ext");
+     chmod(0755, "$installbin/$perl_verbase$ver$exe_ext");
+     `chtag -r "$installbin/$perl_verbase$ver$exe_ext"` if ($^O eq 'os390');
+ }
+@@ -350,7 +349,6 @@
+     if (copy_if_diff($file,"$installarchlib/CORE/$file")) {
+ 	if ($file =~ /\.(\Q$so\E|\Q$dlext\E)$/) {
+ 	    strip("-S", "$installarchlib/CORE/$file") if $^O eq 'darwin';
+-	    fix_dep_names("$installarchlib/CORE/$file");
+ 	    chmod($SO_MODE, "$installarchlib/CORE/$file");
+ 	} else {
+ 	    chmod($NON_SO_MODE, "$installarchlib/CORE/$file");

--- a/packages/perl/tangram.tg.ts
+++ b/packages/perl/tangram.tg.ts
@@ -1,0 +1,166 @@
+import bison from "tg:bison" with { path: "../bison" };
+import libffi from "tg:libffi" with { path: "../libffi" };
+import m4 from "tg:m4" with { path: "../m4" };
+import * as std from "tg:std" with { path: "../std" };
+import zlib from "tg:zlib" with { path: "../zlib" };
+
+export let metadata = {
+	name: "perl",
+	version: "5.38.2",
+};
+
+export let source = tg.target(async () => {
+	let { name, version } = metadata;
+
+	// Download raw source.
+	let unpackFormat = ".tar.gz" as const;
+	let packageArchive = std.download.packageArchive({
+		name,
+		version,
+		unpackFormat,
+	});
+	let checksum =
+		"sha256:a0a31534451eb7b83c7d6594a497543a54d488bc90ca00f5e34762577f40655e";
+	let url = `https://www.cpan.org/src/5.0/${packageArchive}`;
+	let source = tg.Directory.expect(
+		await std.download({ url, checksum, unpackFormat }),
+	);
+	source = await std.directory.unwrap(source);
+
+	// Apply patches.
+	let patches = [];
+
+	let macosPatch = tg.File.expect(
+		await tg.include("./perl_macos_version.patch"),
+	);
+	patches.push(macosPatch);
+
+	let noFixDepsPatch = tg.File.expect(
+		await tg.include("./perl_no_fix_deps.patch"),
+	);
+	patches.push(noFixDepsPatch);
+
+	let cppPrecompPatch = tg.File.expect(
+		await tg.include("./perl_cpp_precomp.patch"),
+	);
+	patches.push(cppPrecompPatch);
+
+	return std.patch(source, ...(await Promise.all(patches)));
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: tg.Triple.Arg;
+	env?: std.env.Arg;
+	host?: tg.Triple.Arg;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let perl = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build,
+		env: env_,
+		host,
+		source: source_,
+		...rest
+	} = arg ?? {};
+
+	let sourceDir = source_ ?? source();
+	let prepare = tg`cp -r ${sourceDir}/. . && chmod -R u+w .`;
+
+	let configure = {
+		args: [
+			"-des",
+			`-Dscriptdir=$OUTPUT/bin`,
+			"-Dinstallstyle=lib/perl5",
+			"-Dusethreads",
+			'-Doptimize="-O3 -pipe -fstack-protector -fwrapv -fno-strict-aliasing"',
+		],
+		command: "$SHELL Configure",
+	};
+
+	let phases = {
+		configure,
+		prepare,
+	};
+
+	let dependencies = [bison(arg), libffi(arg), m4(arg), zlib(arg)];
+	let env = [...dependencies, env_];
+
+	let perlArtifact = await std.autotools.build(
+		{
+			...rest,
+			...tg.Triple.rotate({ build, host }),
+			env,
+			phases,
+			prefixArg: "-Dprefix=",
+			source: sourceDir,
+		},
+		autotools,
+	);
+
+	let wrappedPerl = await std.wrap(
+		tg.symlink({ artifact: perlArtifact, path: "bin/perl" }),
+		{
+			identity: "wrapper",
+			env: {
+				PERL5LIB: tg.Mutation.templateAppend(
+					tg`${perlArtifact}/lib/perl5/${metadata.version}`,
+					":",
+				),
+			},
+			sdk: rest.sdk,
+		},
+	);
+
+	let scripts = [];
+	let binDir = tg.Directory.expect(await perlArtifact.get("bin"));
+	for await (let [name, artifact] of binDir) {
+		if (tg.File.is(artifact)) {
+			let metadata = await std.file.executableMetadata(artifact);
+			if (
+				metadata.format == "shebang" &&
+				metadata.interpreter.includes("perl")
+			) {
+				scripts.push(name);
+			}
+		}
+	}
+
+	for (let script of scripts) {
+		// Get the script artifact.
+		let scriptArtifact = tg.File.expect(
+			await perlArtifact.get(`bin/${script}`),
+		);
+
+		// Wrap it.
+		let wrappedScript = std.wrap(scriptArtifact, {
+			identity: "interpreter",
+			interpreter: wrappedPerl,
+			sdk: rest.sdk,
+		});
+
+		// Replace in the original artifact.
+		perlArtifact = await tg.directory(perlArtifact, {
+			[`bin/${script}`]: wrappedScript,
+		});
+	}
+
+	return tg.directory(perlArtifact, {
+		["bin/perl"]: wrappedPerl,
+	});
+});
+
+export default perl;
+
+export let test = tg.target(async () => {
+	let directory = perl();
+	await std.assert.pkg({
+		directory,
+		binaries: ["perl"],
+		metadata,
+	});
+	return directory;
+});

--- a/packages/postgresql/tangram.tg.ts
+++ b/packages/postgresql/tangram.tg.ts
@@ -1,5 +1,6 @@
 import ncurses from "tg:ncurses" with { path: "../ncurses" };
 import openssl from "tg:openssl" with { path: "../openssl" };
+import perl from "tg:perl" with { path: "../perl" };
 import readline from "tg:readline" with { path: "../readline" };
 import * as std from "tg:std" with { path: "../std" };
 import zlib from "tg:zlib" with { path: "../zlib" };
@@ -48,6 +49,7 @@ export let postgresql = tg.target(async (arg?: Arg) => {
 	let env = [
 		ncurses(arg),
 		openssl(arg),
+		perl(arg),
 		readline(arg),
 		zlib(arg),
 		{

--- a/packages/ripgrep/tangram.tg.ts
+++ b/packages/ripgrep/tangram.tg.ts
@@ -58,7 +58,7 @@ export let ripgrep = tg.target(async (arg?: Arg) => {
 export default ripgrep;
 
 export let test = tg.target(async () => {
-	let directory = ripgrep();
+	let directory = ripgrep({ rust: { useCargoVendor: true }});
 	await std.assert.pkg({
 		directory,
 		binaries: ["rg"],

--- a/packages/ripgrep/tangram.tg.ts
+++ b/packages/ripgrep/tangram.tg.ts
@@ -50,6 +50,7 @@ export let ripgrep = tg.target(async (arg?: Arg) => {
 			env,
 			features: ["pcre2"],
 			source: source_ ?? source(),
+			useCargoVendor: true,
 		},
 		rustArgs,
 	);
@@ -58,7 +59,7 @@ export let ripgrep = tg.target(async (arg?: Arg) => {
 export default ripgrep;
 
 export let test = tg.target(async () => {
-	let directory = ripgrep({ rust: { useCargoVendor: true }});
+	let directory = ripgrep();
 	await std.assert.pkg({
 		directory,
 		binaries: ["rg"],

--- a/packages/rust/Cargo.lock
+++ b/packages/rust/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -173,7 +173,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -184,7 +184,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.2"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b1be7772ee4501dba05acbe66bb1e8760f6a6c474a36035631638e4415f130"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "byteorder"
@@ -325,10 +325,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
+checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -348,7 +349,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -392,7 +393,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -453,6 +454,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c376d08ea6aa96aafe61237c7200d1241cb177b7d3a542d791f2d118e9cbb955"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -480,27 +531,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33043dcd19068b8192064c704b3f83eb464f91f1ff527b44a4e2b08d9cdb8855"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a91391accf613803c2a9bf9abccdbaa07c54b4244a5b64883f9c3c137c86be"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -563,7 +614,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "unicode-xid",
 ]
 
@@ -702,7 +753,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -774,7 +825,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -805,9 +856,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -826,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -978,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1018,10 +1069,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "js-sys"
-version = "0.3.68"
+name = "jobserver"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1056,9 +1116,22 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "lsp-types"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158c1911354ef73e8fe42da6b10c0484cb65c7f1007f28022e847706c1ab6984"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
 
 [[package]]
 name = "lzma-sys"
@@ -1103,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -1288,22 +1361,22 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1401,7 +1474,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -1416,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1487,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048a63e5b3ac996d78d402940b5fa47973d2d080c6c6fffa1d0f19c4445310b7"
+checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-webpki"
@@ -1537,7 +1610,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1549,6 +1622,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1573,7 +1657,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1590,7 +1674,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1650,12 +1734,12 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1695,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1707,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=d2aef670b12d307add48e94a6b6920d1bb6f52e2#d2aef670b12d307add48e94a6b6920d1bb6f52e2"
+source = "git+https://github.com/tangramdotdev/tangram?rev=c25e82a406c8c18340849ce900bde3044c42747e#c25e82a406c8c18340849ce900bde3044c42747e"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -1728,6 +1812,7 @@ dependencies = [
  "include_dir",
  "indoc",
  "itertools",
+ "lsp-types",
  "mime",
  "num",
  "once_cell",
@@ -1763,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "tangram_error"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=d2aef670b12d307add48e94a6b6920d1bb6f52e2#d2aef670b12d307add48e94a6b6920d1bb6f52e2"
+source = "git+https://github.com/tangramdotdev/tangram?rev=c25e82a406c8c18340849ce900bde3044c42747e#c25e82a406c8c18340849ce900bde3044c42747e"
 dependencies = [
  "serde",
  "thiserror",
@@ -1788,9 +1873,10 @@ dependencies = [
 [[package]]
 name = "tangram_util"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=d2aef670b12d307add48e94a6b6920d1bb6f52e2#d2aef670b12d307add48e94a6b6920d1bb6f52e2"
+source = "git+https://github.com/tangramdotdev/tangram?rev=c25e82a406c8c18340849ce900bde3044c42747e#c25e82a406c8c18340849ce900bde3044c42747e"
 dependencies = [
  "bytes",
+ "crossbeam",
  "futures",
  "http",
  "http-body",
@@ -1814,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1841,7 +1927,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1928,7 +2014,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1991,7 +2077,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2160,9 +2246,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2170,24 +2256,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2195,22 +2281,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "webpki-roots"
@@ -2249,7 +2335,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2267,7 +2353,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2287,17 +2373,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.3",
- "windows_aarch64_msvc 0.52.3",
- "windows_i686_gnu 0.52.3",
- "windows_i686_msvc 0.52.3",
- "windows_x86_64_gnu 0.52.3",
- "windows_x86_64_gnullvm 0.52.3",
- "windows_x86_64_msvc 0.52.3",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -2308,9 +2394,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2320,9 +2406,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2332,9 +2418,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2344,9 +2430,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2356,9 +2442,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2368,9 +2454,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2380,9 +2466,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "xattr"
@@ -2421,7 +2507,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -9,8 +9,8 @@ futures = "0.3"
 itertools = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "d2aef670b12d307add48e94a6b6920d1bb6f52e2" }
-tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "d2aef670b12d307add48e94a6b6920d1bb6f52e2" }
+tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "c25e82a406c8c18340849ce900bde3044c42747e" }
+tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "c25e82a406c8c18340849ce900bde3044c42747e" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -173,7 +173,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -184,7 +184,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.2"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b1be7772ee4501dba05acbe66bb1e8760f6a6c474a36035631638e4415f130"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "byteorder"
@@ -325,10 +325,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
+checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -348,7 +349,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -392,7 +393,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -453,6 +454,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c376d08ea6aa96aafe61237c7200d1241cb177b7d3a542d791f2d118e9cbb955"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -480,27 +531,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33043dcd19068b8192064c704b3f83eb464f91f1ff527b44a4e2b08d9cdb8855"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.6"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a91391accf613803c2a9bf9abccdbaa07c54b4244a5b64883f9c3c137c86be"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -563,7 +614,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "unicode-xid",
 ]
 
@@ -702,7 +753,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -785,7 +836,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -816,9 +867,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -837,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -989,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1029,10 +1080,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "js-sys"
-version = "0.3.68"
+name = "jobserver"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1067,9 +1127,22 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "lsp-types"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158c1911354ef73e8fe42da6b10c0484cb65c7f1007f28022e847706c1ab6984"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
 
 [[package]]
 name = "lzma-sys"
@@ -1105,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -1290,22 +1363,22 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1415,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1480,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048a63e5b3ac996d78d402940b5fa47973d2d080c6c6fffa1d0f19c4445310b7"
+checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-webpki"
@@ -1524,7 +1597,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1550,7 +1623,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1562,6 +1635,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1586,7 +1670,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1603,7 +1687,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1663,12 +1747,12 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1708,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1733,7 +1817,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=d2aef670b12d307add48e94a6b6920d1bb6f52e2#d2aef670b12d307add48e94a6b6920d1bb6f52e2"
+source = "git+https://github.com/tangramdotdev/tangram?rev=c25e82a406c8c18340849ce900bde3044c42747e#c25e82a406c8c18340849ce900bde3044c42747e"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -1754,6 +1838,7 @@ dependencies = [
  "include_dir",
  "indoc",
  "itertools",
+ "lsp-types",
  "mime",
  "num",
  "once_cell",
@@ -1797,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "tangram_error"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=d2aef670b12d307add48e94a6b6920d1bb6f52e2#d2aef670b12d307add48e94a6b6920d1bb6f52e2"
+source = "git+https://github.com/tangramdotdev/tangram?rev=c25e82a406c8c18340849ce900bde3044c42747e#c25e82a406c8c18340849ce900bde3044c42747e"
 dependencies = [
  "serde",
  "thiserror",
@@ -1826,9 +1911,10 @@ dependencies = [
 [[package]]
 name = "tangram_util"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=d2aef670b12d307add48e94a6b6920d1bb6f52e2#d2aef670b12d307add48e94a6b6920d1bb6f52e2"
+source = "git+https://github.com/tangramdotdev/tangram?rev=c25e82a406c8c18340849ce900bde3044c42747e#c25e82a406c8c18340849ce900bde3044c42747e"
 dependencies = [
  "bytes",
+ "crossbeam",
  "futures",
  "http",
  "http-body",
@@ -1869,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1896,7 +1982,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1983,7 +2069,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2046,7 +2132,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2212,9 +2298,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2222,24 +2308,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2247,22 +2333,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "webpki-roots"
@@ -2301,7 +2387,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2319,7 +2405,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -2339,17 +2425,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -2360,9 +2446,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2372,9 +2458,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2384,9 +2470,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2396,9 +2482,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2408,9 +2494,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2420,9 +2506,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2432,9 +2518,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "xattr"
@@ -2473,7 +2559,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -16,7 +16,7 @@ missing_safety_doc = "allow"
 [workspace.dependencies]
 async-recursion = "1"
 byteorder = "1"
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 fnv = "1"
 futures = "0.3"
 goblin = "0.8"
@@ -24,9 +24,14 @@ itertools = "0.12"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "d2aef670b12d307add48e94a6b6920d1bb6f52e2" }
-tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "d2aef670b12d307add48e94a6b6920d1bb6f52e2" }
-tokio = { version = "1", default-features = false, features = ["rt", "macros", "fs", "parking_lot"] }
+tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "c25e82a406c8c18340849ce900bde3044c42747e" }
+tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "c25e82a406c8c18340849ce900bde3044c42747e" }
+tokio = { version = "1", default-features = false, features = [
+  "rt",
+  "macros",
+  "fs",
+  "parking_lot",
+] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "parking_lot"] }
 xattr = "1"

--- a/packages/std/autotools.tg.ts
+++ b/packages/std/autotools.tg.ts
@@ -254,7 +254,7 @@ export let target = async (...args: tg.Args<Arg>) => {
 	};
 
 	if (debug) {
-		let fixup = `mkdir -p $OUTPUT/.tangram_logs && cp config.log $OUTPUT/.tangram_logs/config.log`;
+		let fixup = `mkdir -p $LOGDIR && cp config.log $LOGDIR/config.log`;
 		defaultPhases = {
 			fixup: { command: fixup },
 			...defaultPhases,

--- a/packages/std/bootstrap.tg.ts
+++ b/packages/std/bootstrap.tg.ts
@@ -61,9 +61,9 @@ export let toolchainTriple = (host: tg.Triple.Arg) => {
 
 	let os = tg.Triple.os(system);
 	if (os === "linux") {
-		return tg.Triple.new_(`${arch}-linux-musl`);
+		return tg.triple(`${arch}-linux-musl`);
 	} else if (os === "darwin") {
-		return tg.Triple.new_(`${arch}-apple-darwin`);
+		return tg.triple(`${arch}-apple-darwin`);
 	} else {
 		return tg.unreachable();
 	}

--- a/packages/std/packages/wrapper/Cargo.toml
+++ b/packages/std/packages/wrapper/Cargo.toml
@@ -8,9 +8,9 @@ workspace = true
 
 [dependencies]
 byteorder = { workspace = true }
-fnv = { workspace = true }
 itertools = { workspace = true }
 libc = { workspace = true }
+fnv = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/packages/std/patch.tg.ts
+++ b/packages/std/patch.tg.ts
@@ -1,4 +1,3 @@
-import gnuPatch from "./sdk/dependencies/patch.tg.ts";
 import * as std from "./tangram.tg.ts";
 
 export let patch = async (
@@ -12,7 +11,6 @@ export let patch = async (
 				cp -R ${source} $OUTPUT
 				chmod -R u+w $OUTPUT
 				cat ${patchFiles} | patch -p1 -d $OUTPUT`,
-			{ env: gnuPatch() },
 		),
 	);
 };

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -115,12 +115,12 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 			sdk: { bootstrapMode: true },
 		});
 		console.log("proxyEnv", proxyEnv);
-		let dependenciesEnv = await dependencies.env({
+		let utilsEnv = await std.utils.env({
 			host,
 			sdk: { bootstrapMode: true },
 		});
-		console.log("dependenciesEnv", dependenciesEnv);
-		return std.env(bootstrapSDK, proxyEnv, dependenciesEnv, {
+		console.log("utilsEnv", utilsEnv);
+		return std.env(bootstrapSDK, proxyEnv, utilsEnv, {
 			bootstrapMode: true,
 		});
 	}
@@ -189,7 +189,7 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 			);
 		}
 		// Build the utils using the proxied host toolchain and add them to the env.
-		env.push(dependencies.env({ env }));
+		env.push(std.utils.env({ env }));
 		return std.env(...env, { bootstrapMode: true });
 	} else if (toolchain === "gcc") {
 		// Collect environments to compose.
@@ -207,13 +207,13 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 		envs.push(proxyEnv);
 
 		// Add remaining dependencies.
-		let dependenciesEnv = await dependencies.env({
+		let utilsEnv = await std.utils.env({
 			build: host,
 			host,
 			env: envs,
 			bootstrapMode: true,
 		});
-		envs.push(dependenciesEnv);
+		envs.push(utilsEnv);
 
 		// Add any requested cross-compilers, without packages.
 		let crossEnvs = [];
@@ -268,7 +268,7 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 			let alternateLinkerEnvs = [
 				hostToolchain,
 				proxyEnv,
-				dependenciesEnv,
+				utilsEnv,
 				...crossEnvs,
 			];
 			if (tg.Directory.is(linkerDir)) {
@@ -289,7 +289,8 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 			llvm: true,
 		});
 		console.log("llvm proxy env", proxyEnv);
-		let dependenciesEnv = await dependencies.env({
+		// TODO - can you ditch any of these flags?
+		let utilsEnv = await std.utils.env({
 			env: [
 				clangToolchain,
 				proxyEnv,
@@ -307,7 +308,7 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 			host,
 			bootstrapMode: true,
 		});
-		return std.env(clangToolchain, proxyEnv, dependenciesEnv, {
+		return std.env(clangToolchain, proxyEnv, utilsEnv, {
 			bootstrapMode: true,
 		});
 	}

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -815,7 +815,7 @@ export namespace sdk {
 			await std.env.assertProvides({ env, names: ["dash", "ls"] });
 		} else {
 			// Test for the complete set.
-			await dependencies.assertProvides(env);
+			await std.utils.assertProvides(env);
 		}
 
 		// Assert it can compile and wrap for all requested targets.

--- a/packages/std/sdk/binutils.tg.ts
+++ b/packages/std/sdk/binutils.tg.ts
@@ -112,7 +112,6 @@ export let build = tg.target(async (arg?: Arg) => {
 			...rest,
 			...tg.Triple.rotate({ build, host }),
 			env,
-			// parallel: false,
 			phases,
 			source: source_ ?? source(build),
 		},

--- a/packages/std/sdk/dependencies.tg.ts
+++ b/packages/std/sdk/dependencies.tg.ts
@@ -57,13 +57,8 @@ export let env = tg.target(async (arg?: Arg) => {
 			bc({ ...rest, host }),
 			bison({ ...rest, host }),
 			gperf({ ...rest, host }),
-			m4({ ...rest, host }),
-		]),
-	);
-
-	dependencies = dependencies.concat(
-		await Promise.all([
 			libffi({ ...rest, host }),
+			m4({ ...rest, host }),
 			zlib({ ...rest, host }),
 			zstd({ ...rest, host }),
 		]),

--- a/packages/std/sdk/dependencies.tg.ts
+++ b/packages/std/sdk/dependencies.tg.ts
@@ -6,7 +6,6 @@ import autoconf from "./dependencies/autoconf.tg.ts";
 import automake from "./dependencies/automake.tg.ts";
 import bc from "./dependencies/bc.tg.ts";
 import bison from "./dependencies/bison.tg.ts";
-import bzip2 from "./dependencies/bzip2.tg.ts";
 import file from "./dependencies/file.tg.ts";
 import flex from "./dependencies/flex.tg.ts";
 import gperf from "./dependencies/gperf.tg.ts";
@@ -14,14 +13,11 @@ import help2man from "./dependencies/help2man.tg.ts";
 import libffi from "./dependencies/libffi.tg.ts";
 import libxcrypt from "./dependencies/libxcrypt.tg.ts";
 import m4 from "./dependencies/m4.tg.ts";
-import make from "./dependencies/make.tg.ts";
 import ncurses from "./dependencies/ncurses.tg.ts";
-import patch from "./dependencies/patch.tg.ts";
 import perl from "./dependencies/perl.tg.ts";
 import pkgconfig from "./dependencies/pkg_config.tg.ts";
 import python from "./dependencies/python.tg.ts";
 import texinfo from "./dependencies/texinfo.tg.ts";
-import xz from "./dependencies/xz.tg.ts";
 import zlib from "./dependencies/zlib.tg.ts";
 import zstd from "./dependencies/zstd.tg.ts";
 
@@ -29,7 +25,6 @@ export * as autoconf from "./dependencies/autoconf.tg.ts";
 export * as automake from "./dependencies/automake.tg.ts";
 export * as bc from "./dependencies/bc.tg.ts";
 export * as bison from "./dependencies/bison.tg.ts";
-export * as bzip2 from "./dependencies/bzip2.tg.ts";
 export * as file from "./dependencies/file.tg.ts";
 export * as flex from "./dependencies/flex.tg.ts";
 export * as gperf from "./dependencies/gperf.tg.ts";
@@ -37,14 +32,11 @@ export * as help2man from "./dependencies/help2man.tg.ts";
 export * as libffi from "./dependencies/libffi.tg.ts";
 export * as libxcrypt from "./dependencies/libxcrypt.tg.ts";
 export * as m4 from "./dependencies/m4.tg.ts";
-export * as make from "./dependencies/make.tg.ts";
 export * as ncurses from "./dependencies/ncurses.tg.ts";
-export * as patch from "./dependencies/patch.tg.ts";
 export * as perl from "./dependencies/perl.tg.ts";
 export * as pkgconfig from "./dependencies/pkg_config.tg.ts";
 export * as python from "./dependencies/python.tg.ts";
 export * as texinfo from "./dependencies/texinfo.tg.ts";
-export * as xz from "./dependencies/xz.tg.ts";
 export * as zlib from "./dependencies/zlib.tg.ts";
 export * as zstd from "./dependencies/zstd.tg.ts";
 
@@ -60,14 +52,10 @@ export let env = tg.target(async (arg?: Arg) => {
 	// Add the standard utils.
 	dependencies.push(await std.utils.env({ ...rest, host }));
 
-	// Add `make` built against the standard utils.
-	dependencies.push(await make({ ...rest, host }));
-
 	dependencies = dependencies.concat(
 		await Promise.all([
 			bc({ ...rest, host }),
 			bison({ ...rest, host }),
-			bzip2({ ...rest, host }),
 			gperf({ ...rest, host }),
 			m4({ ...rest, host }),
 		]),
@@ -76,8 +64,6 @@ export let env = tg.target(async (arg?: Arg) => {
 	dependencies = dependencies.concat(
 		await Promise.all([
 			libffi({ ...rest, host }),
-			patch({ ...rest, host }),
-			xz({ ...rest, host }),
 			zlib({ ...rest, host }),
 			zstd({ ...rest, host }),
 		]),
@@ -120,19 +106,15 @@ export let assertProvides = async (env: std.env.Arg) => {
 		"aclocal",
 		"automake",
 		"bc",
-		"bzip2",
 		"file",
 		"flex",
 		"gperf",
 		"help2man",
 		"m4",
-		"make",
-		"patch",
 		"perl",
 		"pkg-config",
 		"python3",
 		"texi2any", // texinfo
-		"xz",
 		"yacc", // bison
 	];
 

--- a/packages/std/sdk/dependencies/autoconf.tg.ts
+++ b/packages/std/sdk/dependencies/autoconf.tg.ts
@@ -1,7 +1,6 @@
 import * as std from "../../tangram.tg.ts";
 import bison from "./bison.tg.ts";
 import m4 from "./m4.tg.ts";
-import make from "./make.tg.ts";
 import perl from "./perl.tg.ts";
 import zlib from "./zlib.tg.ts";
 
@@ -34,7 +33,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	} = arg ?? {};
 
 	let perlArtifact = await perl(arg);
-	let dependencies = [make(arg), perlArtifact, bison(arg), m4(arg), zlib(arg)];
+	let dependencies = [perlArtifact, bison(arg), m4(arg), zlib(arg)];
 	let env = [env_, std.utils.env(arg), ...dependencies];
 
 	let autoconf = await std.utils.buildUtil(
@@ -172,7 +171,10 @@ export let patchAutom4teCfg = tg.target(
 			contents = tg`${contents}${newLine}\n`;
 		}
 
-		let env = [arg?.env, std.sdk({ bootstrapMode: arg?.bootstrapMode },arg?.sdk)];
+		let env = [
+			arg?.env,
+			std.sdk({ bootstrapMode: arg?.bootstrapMode }, arg?.sdk),
+		];
 
 		let patchedAutom4teCfg = tg.File.expect(
 			await tg.build(

--- a/packages/std/sdk/dependencies/automake.tg.ts
+++ b/packages/std/sdk/dependencies/automake.tg.ts
@@ -3,7 +3,6 @@ import autoconf from "./autoconf.tg.ts";
 import bison from "./bison.tg.ts";
 import help2man from "./help2man.tg.ts";
 import m4 from "./m4.tg.ts";
-import make from "./make.tg.ts";
 import perl from "./perl.tg.ts";
 import pkgconfig from "./pkg_config.tg.ts";
 import zlib from "./zlib.tg.ts";
@@ -51,7 +50,6 @@ export let build = tg.target(async (arg?: Arg) => {
 		bison(arg),
 		help2man(arg),
 		m4(arg),
-		make(arg),
 		pkgconfig(arg),
 		perlArtifact,
 		zlib(arg),

--- a/packages/std/sdk/dependencies/bc.tg.ts
+++ b/packages/std/sdk/dependencies/bc.tg.ts
@@ -1,5 +1,4 @@
 import * as std from "../../tangram.tg.ts";
-import make from "./make.tg.ts";
 
 export let metadata = {
 	name: "bc",
@@ -54,7 +53,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	// Define environment.
 	let ccCommand = build.os == "darwin" ? "cc -D_DARWIN_C_SOURCE" : "cc";
-	let env = [env_, std.utils.env(arg), make(arg), { CC: ccCommand }];
+	let env = [env_, std.utils.env(arg), { CC: ccCommand }];
 
 	let output = std.utils.buildUtil(
 		{

--- a/packages/std/sdk/dependencies/bison.tg.ts
+++ b/packages/std/sdk/dependencies/bison.tg.ts
@@ -1,6 +1,5 @@
 import * as std from "../../tangram.tg.ts";
 import m4 from "./m4.tg.ts";
-import make from "./make.tg.ts";
 
 export let metadata = {
 	name: "bison",
@@ -39,7 +38,7 @@ export let build = tg.target((arg?: Arg) => {
 		],
 	};
 
-	let dependencies = [m4(arg), make(arg)];
+	let dependencies = [m4(arg)];
 	let env = [env_, std.utils.env(arg), ...dependencies];
 
 	let output = std.utils.buildUtil(

--- a/packages/std/sdk/dependencies/file.tg.ts
+++ b/packages/std/sdk/dependencies/file.tg.ts
@@ -1,7 +1,6 @@
 import * as std from "../../tangram.tg.ts";
 import bison from "./bison.tg.ts";
 import m4 from "./m4.tg.ts";
-import make from "./make.tg.ts";
 import zlib from "./zlib.tg.ts";
 
 export let metadata = {
@@ -54,7 +53,7 @@ export let build = tg.target(async (arg?: Arg) => {
 			"--enable-static",
 		],
 	};
-	let dependencies = [bison(arg), m4(arg), make(arg), zlib(arg)];
+	let dependencies = [bison(arg), m4(arg), zlib(arg)];
 	let env = [env_, std.utils.env(arg), ...dependencies];
 
 	let output = await std.utils.buildUtil(

--- a/packages/std/sdk/dependencies/flex.tg.ts
+++ b/packages/std/sdk/dependencies/flex.tg.ts
@@ -1,7 +1,6 @@
 import * as std from "../../tangram.tg.ts";
 import bison from "./bison.tg.ts";
 import m4 from "./m4.tg.ts";
-import make from "./make.tg.ts";
 import zlib from "./zlib.tg.ts";
 
 export let metadata = {
@@ -44,7 +43,7 @@ export let build = tg.target((arg?: Arg) => {
 	let configure = {
 		args: ["--disable-dependency-tracking"],
 	};
-	let dependencies = [bison(arg), m4(arg), make(arg), zlib(arg)];
+	let dependencies = [bison(arg), m4(arg), zlib(arg)];
 	let env = [env_, std.utils.env(arg), ...dependencies];
 	let output = std.utils.buildUtil(
 		{

--- a/packages/std/sdk/dependencies/gperf.tg.ts
+++ b/packages/std/sdk/dependencies/gperf.tg.ts
@@ -1,5 +1,4 @@
 import * as std from "../../tangram.tg.ts";
-import make from "./make.tg.ts";
 
 export let metadata = {
 	name: "gperf",
@@ -32,7 +31,7 @@ export let build = tg.target((arg?: Arg) => {
 		args: ["--disable-dependency-tracking"],
 	};
 
-	let env = [env_, std.utils.env(arg), make(arg)];
+	let env = [env_, std.utils.env(arg)];
 
 	let output = std.utils.buildUtil(
 		{

--- a/packages/std/sdk/dependencies/help2man.tg.ts
+++ b/packages/std/sdk/dependencies/help2man.tg.ts
@@ -2,7 +2,6 @@ import * as std from "../../tangram.tg.ts";
 import autoconf from "./autoconf.tg.ts";
 import bison from "./bison.tg.ts";
 import m4 from "./m4.tg.ts";
-import make from "./make.tg.ts";
 import perl from "./perl.tg.ts";
 import zlib from "./zlib.tg.ts";
 
@@ -40,7 +39,6 @@ export let build = tg.target(async (arg?: Arg) => {
 		autoconf(arg),
 		bison(arg),
 		m4(arg),
-		make(arg),
 		perlArtifact,
 		zlib(arg),
 	];

--- a/packages/std/sdk/dependencies/libffi.tg.ts
+++ b/packages/std/sdk/dependencies/libffi.tg.ts
@@ -1,5 +1,4 @@
 import * as std from "../../tangram.tg.ts";
-import make from "./make.tg.ts";
 
 export let metadata = {
 	name: "libffi",
@@ -42,7 +41,7 @@ export let build = tg.target((arg?: Arg) => {
 		args: ["--disable-dependency-tracking"],
 	};
 
-	let env = [env_, std.utils.env(arg), make(arg)];
+	let env = [env_, std.utils.env(arg)];
 
 	return std.utils.buildUtil(
 		{

--- a/packages/std/sdk/dependencies/libxcrypt.tg.ts
+++ b/packages/std/sdk/dependencies/libxcrypt.tg.ts
@@ -1,5 +1,4 @@
 import * as std from "../../tangram.tg.ts";
-import make from "./make.tg.ts";
 import perl from "./perl.tg.ts";
 
 export let metadata = {
@@ -46,7 +45,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	};
 	let phases = { configure };
 
-	let dependencies = [make(arg), perl(arg)];
+	let dependencies = [perl(arg)];
 	let env = [env_, std.utils.env(arg), ...dependencies];
 
 	return std.autotools.build(

--- a/packages/std/sdk/dependencies/m4.tg.ts
+++ b/packages/std/sdk/dependencies/m4.tg.ts
@@ -1,5 +1,4 @@
 import * as std from "../../tangram.tg.ts";
-import make from "./make.tg.ts";
 
 export let metadata = {
 	name: "m4",
@@ -33,7 +32,7 @@ export let build = tg.target((arg?: Arg) => {
 		args: ["--disable-dependency-tracking"],
 	};
 
-	let env = [env_, std.utils.env(arg), make(arg)];
+	let env = [env_, std.utils.env(arg)];
 
 	let output = std.utils.buildUtil(
 		{

--- a/packages/std/sdk/dependencies/ncurses.tg.ts
+++ b/packages/std/sdk/dependencies/ncurses.tg.ts
@@ -1,6 +1,5 @@
 import * as bootstrap from "../../bootstrap.tg.ts";
 import * as std from "../../tangram.tg.ts";
-import make from "./make.tg.ts";
 import pkgconfig from "./pkg_config.tg.ts";
 
 export let metadata = {
@@ -64,7 +63,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		`;
 	let phases = { configure, fixup };
 
-	let env = [env_, std.utils.env(arg), make(arg), pkgconfig(arg)];
+	let env = [env_, std.utils.env(arg), pkgconfig(arg)];
 
 	return std.autotools.build(
 		{

--- a/packages/std/sdk/dependencies/perl.tg.ts
+++ b/packages/std/sdk/dependencies/perl.tg.ts
@@ -3,7 +3,6 @@ import * as std from "../../tangram.tg.ts";
 import bison from "./bison.tg.ts";
 import libffi from "./libffi.tg.ts";
 import m4 from "./m4.tg.ts";
-import make from "./make.tg.ts";
 import zlib from "./zlib.tg.ts";
 
 export let metadata = {
@@ -84,7 +83,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		prepare,
 	};
 
-	let dependencies = [bison(arg), libffi(arg), m4(arg), make(arg), zlib(arg)];
+	let dependencies = [bison(arg), libffi(arg), m4(arg), zlib(arg)];
 	let env = [env_, std.utils.env(arg), ...dependencies];
 
 	let perlArtifact = await std.utils.buildUtil(

--- a/packages/std/sdk/dependencies/pkg_config.tg.ts
+++ b/packages/std/sdk/dependencies/pkg_config.tg.ts
@@ -1,7 +1,6 @@
 import * as std from "../../tangram.tg.ts";
 import bison from "./bison.tg.ts";
 import m4 from "./m4.tg.ts";
-import make from "./make.tg.ts";
 import zlib from "./zlib.tg.ts";
 
 export let metadata = {
@@ -54,7 +53,6 @@ export let build = tg.target(async (arg?: Arg) => {
 	let dependencies: tg.Unresolved<Array<std.env.Arg>> = [
 		bison(arg),
 		m4(arg),
-		make(arg),
 		zlib(arg),
 	];
 	let additionalLibDirs = [];

--- a/packages/std/sdk/dependencies/python.tg.ts
+++ b/packages/std/sdk/dependencies/python.tg.ts
@@ -1,10 +1,8 @@
 import * as bootstrap from "../../bootstrap.tg.ts";
 import * as std from "../../tangram.tg.ts";
 import bison from "./bison.tg.ts";
-import bzip2 from "./bzip2.tg.ts";
 import libxcrypt from "./libxcrypt.tg.ts";
 import m4 from "./m4.tg.ts";
-import make from "./make.tg.ts";
 import pkgConfig from "./pkg_config.tg.ts";
 import zlib from "./zlib.tg.ts";
 
@@ -89,10 +87,8 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let dependencies = [
 		bison(arg),
-		bzip2(arg),
 		libxcrypt(arg),
 		m4(arg),
-		make(arg),
 		pkgConfig(arg),
 		zlib(arg),
 	];

--- a/packages/std/sdk/dependencies/texinfo.tg.ts
+++ b/packages/std/sdk/dependencies/texinfo.tg.ts
@@ -1,7 +1,6 @@
 import * as std from "../../tangram.tg.ts";
 import bison from "./bison.tg.ts";
 import m4 from "./m4.tg.ts";
-import make from "./make.tg.ts";
 import ncurses from "./ncurses.tg.ts";
 import perl from "./perl.tg.ts";
 import zlib from "./zlib.tg.ts";
@@ -34,14 +33,7 @@ export let build = tg.target((arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let dependencies = [
-		bison(arg),
-		m4(arg),
-		make(arg),
-		ncurses(arg),
-		perl(arg),
-		zlib(arg),
-	];
+	let dependencies = [bison(arg), m4(arg), ncurses(arg), perl(arg), zlib(arg)];
 	let env = [env_, std.utils.env(arg), ...dependencies];
 
 	return std.utils.buildUtil(

--- a/packages/std/sdk/dependencies/zlib.tg.ts
+++ b/packages/std/sdk/dependencies/zlib.tg.ts
@@ -1,5 +1,4 @@
 import * as std from "../../tangram.tg.ts";
-import make from "./make.tg.ts";
 
 export let metadata = {
 	name: "zlib",
@@ -39,7 +38,7 @@ export let build = tg.target((arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let env = [env_, std.utils.env(arg), make(arg)];
+	let env = [env_, std.utils.env(arg)];
 
 	let output = std.utils.buildUtil(
 		{

--- a/packages/std/sdk/dependencies/zstd.tg.ts
+++ b/packages/std/sdk/dependencies/zstd.tg.ts
@@ -1,5 +1,4 @@
 import * as std from "../../tangram.tg.ts";
-import make from "./make.tg.ts";
 
 export let metadata = {
 	name: "zstd",
@@ -46,7 +45,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let install = tg`make install PREFIX=$OUTPUT`;
 	let phases = { prepare, install };
 
-	let env = [env_, std.utils.env(arg), make(arg)];
+	let env = [env_, std.utils.env(arg)];
 
 	let result = std.autotools.build({
 		...rest,

--- a/packages/std/sdk/gcc/toolchain.tg.ts
+++ b/packages/std/sdk/gcc/toolchain.tg.ts
@@ -164,16 +164,7 @@ export let buildSysroot = tg.target(async (arg: BuildSysrootArg) => {
 });
 
 export let canadianCross = tg.target(async (arg?: tg.Triple.HostArg) => {
-	let systemHost = await tg.Triple.host(arg);
-
-	let host = tg.Triple.normalized(
-		tg.triple({
-			arch: tg.Triple.arch(systemHost),
-			os: tg.Triple.os(systemHost),
-			environment: tg.Triple.environment(systemHost) ?? "gnu",
-		}),
-	);
-	tg.assert(host, "Expected the detected host to normalize correctly");
+	let host = await tg.Triple.host(arg);
 
 	let target = host;
 	let build = bootstrap.toolchainTriple(host);

--- a/packages/std/sdk/gcc/toolchain.tg.ts
+++ b/packages/std/sdk/gcc/toolchain.tg.ts
@@ -201,7 +201,7 @@ export let canadianCross = tg.target(async (arg?: tg.Triple.HostArg) => {
 			"strip",
 			"strings",
 		],
-		host + "-",
+		tg.Triple.toString(host) + "-",
 	);
 	console.log("stage2 binutils", await nativeHostBinutils.id());
 

--- a/packages/std/sdk/git.tg.ts
+++ b/packages/std/sdk/git.tg.ts
@@ -2,7 +2,7 @@ import * as std from "../tangram.tg.ts";
 
 let metadata = {
 	name: "git",
-	version: "2.43.2",
+	version: "2.44.0",
 };
 
 export let source = tg.target(async () => {
@@ -15,7 +15,7 @@ export let source = tg.target(async () => {
 	});
 	let url = `https://mirrors.edge.kernel.org/pub/software/scm/git/${packageArchive}`;
 	let checksum =
-		"sha256:f612c1abc63557d50ad3849863fc9109670139fc9901e574460ec76e0511adb9";
+		"sha256:e358738dcb5b5ea340ce900a0015c03ae86e804e7ff64e47aa4631ddee681de3";
 	let outer = tg.Directory.expect(
 		await std.download({ url, checksum, unpackFormat }),
 	);

--- a/packages/std/sdk/kernel_headers.tg.ts
+++ b/packages/std/sdk/kernel_headers.tg.ts
@@ -6,13 +6,13 @@ export let metadata = {
 	license: "GPLv2",
 	name: "linux",
 	repository: "https://git.kernel.org",
-	version: "6.7.5",
+	version: "6.7.8",
 };
 
 export let source = tg.target(async () => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:29f6464061b8179cbb77fc5591e06a2199324e018c9ed730ca3e6dfb145539ff";
+		"sha256:469ff46b98685df13b56c98417c64ba7a30f8a45baf34aa99f07935e1bf65c18";
 	let unpackFormat = ".tar.xz" as const;
 	let url = `https://cdn.kernel.org/pub/linux/kernel/v6.x/${name}-${version}${unpackFormat}`;
 	let source = tg.Directory.expect(

--- a/packages/std/tangram.tg.ts
+++ b/packages/std/tangram.tg.ts
@@ -105,6 +105,9 @@ export let testUtilsLibiconv = tg.target(async () => {
 export let testUtilsAttr = tg.target(async () => {
 	return await utils.attr.test();
 });
+export let testUtilsBzip2 = tg.target(async () => {
+	return await utils.bzip2.test();
+});
 export let testUtilsDiffutils = tg.target(async () => {
 	return await utils.diffutils.test();
 });
@@ -120,11 +123,20 @@ export let testUtilsGrep = tg.target(async () => {
 export let testUtilsGzip = tg.target(async () => {
 	return await utils.gzip.test();
 });
+export let testUtilsMake = tg.target(async () => {
+	return await utils.make.test();
+});
+export let testUtilsPatch = tg.target(async () => {
+	return await utils.patch.test();
+});
 export let testUtilsSed = tg.target(async () => {
 	return await utils.sed.test();
 });
 export let testUtilsTar = tg.target(async () => {
 	return await utils.tar.test();
+});
+export let testUtilsXz = tg.target(async () => {
+	return await utils.xz.test();
 });
 export let testUtils = tg.target(async () => {
 	return await utils.test();
@@ -148,9 +160,6 @@ export let testDepsBc = tg.target(async () => {
 export let testDepsBison = tg.target(async () => {
 	return await dependencies.bison.test();
 });
-export let testDepsBzip2 = tg.target(async () => {
-	return await dependencies.bzip2.test();
-});
 export let testDepsFile = tg.target(async () => {
 	return await dependencies.file.test();
 });
@@ -172,14 +181,8 @@ export let testDepsLibXCrypt = tg.target(async () => {
 export let testDepsm4 = tg.target(async () => {
 	return await dependencies.m4.test();
 });
-export let testDepsMake = tg.target(async () => {
-	return await dependencies.make.test();
-});
 export let testDepsNcurses = tg.target(async () => {
 	return await dependencies.ncurses.test();
-});
-export let testDepsPatch = tg.target(async () => {
-	return await dependencies.patch.test();
 });
 export let testDepsPerl = tg.target(async () => {
 	return await dependencies.perl.test();
@@ -192,9 +195,6 @@ export let testDepsPython = tg.target(async () => {
 });
 export let testDepsTexinfo = tg.target(async () => {
 	return await dependencies.texinfo.test();
-});
-export let testDepsXz = tg.target(async () => {
-	return await dependencies.xz.test();
 });
 export let testDepsZlib = tg.target(async () => {
 	return await dependencies.zlib.test();

--- a/packages/std/utils.tg.ts
+++ b/packages/std/utils.tg.ts
@@ -1,16 +1,21 @@
 import * as bootstrap from "./bootstrap.tg.ts";
 import * as std from "./tangram.tg.ts";
 import * as bash from "./utils/bash.tg.ts";
+import bzip2 from "./utils/bzip2.tg.ts";
 import coreutils from "./utils/coreutils.tg.ts";
 import diffutils from "./utils/diffutils.tg.ts";
 import findutils from "./utils/findutils.tg.ts";
 import gawk from "./utils/gawk.tg.ts";
 import grep from "./utils/grep.tg.ts";
 import gzip from "./utils/gzip.tg.ts";
+import make from "./utils/make.tg.ts";
+import patch from "./utils/patch.tg.ts";
 import sed from "./utils/sed.tg.ts";
 import tar from "./utils/tar.tg.ts";
+import xz from "./utils/xz.tg.ts";
 
 export * as attr from "./utils/attr.tg.ts";
+export * as bzip2 from "./utils/bzip2.tg.ts";
 export * as bash from "./utils/bash.tg.ts";
 export * as coreutils from "./utils/coreutils.tg.ts";
 export * as diffutils from "./utils/diffutils.tg.ts";
@@ -20,8 +25,11 @@ export * as gawk from "./utils/gawk.tg.ts";
 export * as grep from "./utils/grep.tg.ts";
 export * as gzip from "./utils/gzip.tg.ts";
 export * as libiconv from "./utils/libiconv.tg.ts";
+export * as make from "./utils/make.tg.ts";
+export * as patch from "./utils/patch.tg.ts";
 export * as sed from "./utils/sed.tg.ts";
 export * as tar from "./utils/tar.tg.ts";
+export * as xz from "./utils/xz.tg.ts";
 
 type Arg = std.sdk.BuildEnvArg;
 
@@ -56,17 +64,21 @@ export let env = tg.target(async (arg?: Arg) => {
 
 	let utils = [bashArtifact, bashEnv];
 	utils = utils.concat(
-	await Promise.all([
-		coreutils({ ...rest, bootstrapMode, env, host }),
-		diffutils({ ...rest, bootstrapMode, env, host }),
-		findutils({ ...rest, bootstrapMode, env, host }),
-		gawk({ ...rest, bootstrapMode, env, host }),
-		grep({ ...rest, bootstrapMode, env, host }),
-		gzip({ ...rest, bootstrapMode, env, host }),
-		sed({ ...rest, bootstrapMode, env, host }),
-		tar({ ...rest, bootstrapMode, env, host }),
-	]),
-);
+		await Promise.all([
+			bzip2({ ...rest, bootstrapMode, env, host }),
+			coreutils({ ...rest, bootstrapMode, env, host }),
+			diffutils({ ...rest, bootstrapMode, env, host }),
+			findutils({ ...rest, bootstrapMode, env, host }),
+			gawk({ ...rest, bootstrapMode, env, host }),
+			grep({ ...rest, bootstrapMode, env, host }),
+			gzip({ ...rest, bootstrapMode, env, host }),
+			make({ ...rest, bootstrapMode, env, host }),
+			patch({ ...rest, bootstrapMode, env, host }),
+			sed({ ...rest, bootstrapMode, env, host }),
+			tar({ ...rest, bootstrapMode, env, host }),
+			xz({ ...rest, bootstrapMode, env, host }),
+		]),
+	);
 	return utils;
 });
 
@@ -175,14 +187,18 @@ export let changeShebang = async (scriptFile: tg.File) => {
 export let assertProvides = async (env: std.env.Arg) => {
 	let names = [
 		"bash",
+		"bzip2",
 		"ls", // coreutils
 		"diff", // diffutils
 		"find", // findutils
 		"gawk",
 		"grep",
 		"gzip",
+		"make",
+		"patch",
 		"sed",
 		"tar",
+		"xz",
 	];
 	await std.env.assertProvides({ env, names });
 	return true;

--- a/packages/std/utils/bash.tg.ts
+++ b/packages/std/utils/bash.tg.ts
@@ -56,8 +56,8 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let configureArgs = ["--without-bash-malloc", "--disable-nls"];
 
-	// If not in bootstrap mode or if the provided env has ncurses in the library path, use it instead of termcap.
-	if (!bootstrapMode || (await providesNcurses(env_))) {
+	// If the provided env has ncurses in the library path, use it instead of termcap.
+	if (await providesNcurses(env_)) {
 		configureArgs.push("--with-curses");
 	}
 

--- a/packages/std/utils/coreutils.tg.ts
+++ b/packages/std/utils/coreutils.tg.ts
@@ -87,8 +87,6 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let configure = {
 		args: [
-			`--build=${tg.Triple.toString(build)}`,
-			`--host=${tg.Triple.toString(host)}`,
 			"--disable-dependency-tracking",
 			"--disable-libcap",
 			"--disable-nls",

--- a/packages/std/utils/make.tg.ts
+++ b/packages/std/utils/make.tg.ts
@@ -1,5 +1,6 @@
-import * as bootstrap from "../../bootstrap.tg.ts";
-import * as std from "../../tangram.tg.ts";
+import * as bootstrap from "../bootstrap.tg.ts";
+import * as std from "../tangram.tg.ts";
+import { buildUtil, prerequisites } from "../utils.tg.ts";
 
 export let metadata = {
 	name: "make",
@@ -21,6 +22,7 @@ type Arg = std.sdk.BuildEnvArg & {
 export let build = tg.target(async (arg?: Arg) => {
 	let {
 		autotools = [],
+		bootstrapMode,
 		build,
 		env: env_,
 		host,
@@ -35,12 +37,17 @@ export let build = tg.target(async (arg?: Arg) => {
 		configure,
 	};
 
-	let env = [env_, std.utils.env(arg), bootstrap.make.build(arg)];
+	let env: tg.Unresolved<Array<std.env.Arg>> = [];
+	if (bootstrapMode) {
+		env.push(prerequisites({ host }));
+	}
+	env.push(env_);
 
-	return std.utils.buildUtil(
+	return buildUtil(
 		{
 			...rest,
 			...tg.Triple.rotate({ build, host }),
+			bootstrapMode,
 			env,
 			phases,
 			source: source_ ?? source(),

--- a/packages/zlib/tangram.tg.ts
+++ b/packages/zlib/tangram.tg.ts
@@ -39,7 +39,6 @@ export let zlib = tg.target((arg?: Arg) => {
 		{
 			...rest,
 			...tg.Triple.rotate({ build, host }),
-			phases: { phases: { prepare: "echo 'hi!!' && env" } },
 			source: source_ ?? source(),
 		},
 		autotools,
@@ -50,13 +49,11 @@ export default zlib;
 
 export let test = tg.target(async () => {
 	let zlibArtifact = await zlib();
+	console.log("zlib", await zlibArtifact.id());
+	await std.assert.pkg({
+		directory: zlibArtifact,
+		docs: ["man/man3/zlib.3"],
+		pkgConfigName: "zlib",
+	});
 	return zlibArtifact;
-	// await std.assert.pkg({
-	// 	directory: zlibArtifact,
-	// 	docs: ["man/man3/zlib.3"],
-	// 	headers: ["zconf.h", "zlib.h"],
-	// 	libs: ["z"],
-	// 	pkgConfigName: "zlib",
-	// });
-	// return true;
 });


### PR DESCRIPTION
This PR limits the env returned by `std.sdk()` to contain only the `std.utils` set of tools and the requested compiler toolchain.  Previously, we also bundled all dependencies required to bootstrap the toolchain itself. This change keeps those dependencies internally scoped to `std`, pushing the responsibility for providing these tools, for example `m4` or `perl`, out to "real", post-std packages.

This change included adding the `bzip2`, `patch`, `make`, and `xz` packages to the `std.utils.env()` to provide a complete base set, and adding a new `perl` package for general use outside of `std`. These changes have the added benefit of simplifying the build graph when bootstrapping GCC.

Additional changes rolled in:

- cleaned up package tests
- corrected triple handling in GCC bootstrap process
- add elapsed per-phase times and total elapsed target build time to logs produced by the `std.phases` debug option.
- add a runtime option for configuring the max recursion depth in the `ld_proxy`
- rolled workspace forward
- version bumps: git 2.44, node 20.11.1, linux 6.7.8, libffi 3.4.6