### PR TITLE
feat: add post-std packages for all SDK dependencies

### DIFF
--- a/packages/acl/tangram.tg.ts
+++ b/packages/acl/tangram.tg.ts
@@ -43,7 +43,7 @@ export let acl = tg.target(async (arg?: Arg) => {
 	} = arg ?? {};
 
 	let configure = {
-		args: ["--disable-dependency-tracking"],
+		args: ["--disable-dependency-tracking", "--disable-rpath"],
 	};
 	let phases = { configure };
 

--- a/packages/acl/tangram.tg.ts
+++ b/packages/acl/tangram.tg.ts
@@ -1,0 +1,100 @@
+import attr from "tg:attr" with { path: "../attr" };
+import * as std from "tg:std" with { path: "../std" };
+
+export let metadata = {
+	name: "acl",
+	version: "2.3.2",
+};
+
+export let source = tg.target(async () => {
+	let { name, version } = metadata;
+	let checksum =
+		"sha256:5f2bdbad629707aa7d85c623f994aa8a1d2dec55a73de5205bac0bf6058a2f7c";
+	let unpackFormat = ".tar.gz" as const;
+	let packageName = std.download.packageArchive({
+		name,
+		version,
+		unpackFormat,
+	});
+	let url = `http://download.savannah.gnu.org/releases/${name}/${packageName}`;
+	let outer = tg.Directory.expect(
+		await std.download({ checksum, unpackFormat, url }),
+	);
+	return std.directory.unwrap(outer);
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: tg.Triple.Arg;
+	env?: std.env.Arg;
+	host?: tg.Triple.Arg;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let acl = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build,
+		env: env_,
+		host,
+		source: source_,
+		...rest
+	} = arg ?? {};
+
+	let configure = {
+		args: ["--disable-dependency-tracking"],
+	};
+	let phases = { configure };
+
+	let env = [attr(arg), env_];
+
+	let output = await std.autotools.build(
+		{
+			...rest,
+			...tg.Triple.rotate({ build, host }),
+			env,
+			phases,
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+
+	let libDir = tg.Directory.expect(await output.get("lib"));
+	let bins = await Promise.all(
+		["chacl", "getfacl", "setfacl"].map(async (bin) => {
+			return [
+				bin,
+				std.wrap(tg.File.expect(await output.get(`bin/${bin}`)), {
+					libraryPaths: [libDir],
+				}),
+			];
+		}),
+	);
+	for (let [binName, binFile] of bins) {
+		output = await tg.directory(output, { [`bin/${binName}`]: binFile });
+	}
+	return output;
+});
+
+export default acl;
+
+export let test = tg.target(async () => {
+	let directory = acl();
+	let binTest = (name: string) => {
+		return {
+			name,
+			testArgs: [],
+			testPredicate: (stdout: string) => stdout.includes("Usage:"),
+		};
+	};
+	let binaries = ["chacl", "getfacl", "setfacl"].map(binTest);
+
+	await std.assert.pkg({
+		binaries,
+		directory,
+		libs: ["acl"],
+		metadata,
+	});
+	return directory;
+});

--- a/packages/attr/tangram.tg.ts
+++ b/packages/attr/tangram.tg.ts
@@ -1,0 +1,89 @@
+import * as std from "tg:std" with { path: "../std" };
+
+export let metadata = {
+	name: "attr",
+	version: "2.5.2",
+};
+
+export let source = tg.target(async () => {
+	let { name, version } = metadata;
+	let unpackFormat = ".tar.xz" as const;
+	let packageArchive = std.download.packageArchive({
+		name,
+		version,
+		unpackFormat,
+	});
+	let checksum =
+		"sha256:f2e97b0ab7ce293681ab701915766190d607a1dba7fae8a718138150b700a70b";
+	let url = `https://mirrors.sarata.com/non-gnu/attr/${packageArchive}`;
+	let outer = tg.Directory.expect(
+		await std.download({ url, checksum, unpackFormat }),
+	);
+	return await std.directory.unwrap(outer);
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: tg.Triple.Arg;
+	env?: std.env.Arg;
+	host?: tg.Triple.Arg;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let attr = tg.target(async (arg?: Arg) => {
+	let { autotools = [], build, host, source: source_, ...rest } = arg ?? {};
+
+	let configure = {
+		args: ["--disable-dependency-tracking", "--disable-rpath", "--with-pic"],
+	};
+	let phases = { configure };
+
+	let output = await std.autotools.build(
+		{
+			...rest,
+			...tg.Triple.rotate({ build, host }),
+			phases,
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+
+	let libDir = tg.Directory.expect(await output.get("lib"));
+	let bins = await Promise.all(
+		["attr", "getfattr", "setfattr"].map(async (bin) => {
+			return [
+				bin,
+				std.wrap(tg.File.expect(await output.get(`bin/${bin}`)), {
+					libraryPaths: [libDir],
+				}),
+			];
+		}),
+	);
+	for (let [binName, binFile] of bins) {
+		output = await tg.directory(output, { [`bin/${binName}`]: binFile });
+	}
+	return output;
+});
+
+export default attr;
+
+export let test = tg.target(async () => {
+	let directory = attr();
+	let binTest = (name: string) => {
+		return {
+			name,
+			testArgs: [],
+			testPredicate: (stdout: string) => stdout.includes("Usage:"),
+		};
+	};
+	let binaries = ["attr", "getfattr", "setfattr"].map(binTest);
+
+	await std.assert.pkg({
+		binaries,
+		directory,
+		libs: ["attr"],
+		metadata,
+	});
+	return directory;
+});

--- a/packages/autoconf/tangram.tg.ts
+++ b/packages/autoconf/tangram.tg.ts
@@ -1,0 +1,209 @@
+import bison from "tg:bison" with { path: "../bison" };
+import m4 from "tg:m4" with { path: "../m4" };
+import perl from "tg:perl" with { path: "../perl" };
+import * as std from "tg:std" with { path: "../std" };
+import zlib from "tg:zlib" with { path: "../zlib" };
+
+export let metadata = {
+	homepage: "https://www.gnu.org/software/autoconf/",
+	license: "GPL-3.0-or-later",
+	name: "autoconf",
+	repository: "https://git.savannah.gnu.org/git/autoconf.git",
+	version: "2.72",
+};
+
+export let source = tg.target(() => {
+	let { name, version } = metadata;
+	let checksum =
+		"sha256:ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a";
+	let compressionFormat = ".xz" as const;
+	return std.download.fromGnu({ name, version, checksum, compressionFormat });
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: tg.Triple.Arg;
+	env?: std.env.Arg;
+	host?: tg.Triple.Arg;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let build = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build,
+		env: env_,
+		host,
+		source: source_,
+		...rest
+	} = arg ?? {};
+
+	let perlArtifact = await perl(arg);
+	let dependencies = [perlArtifact, bison(arg), m4(arg), zlib(arg)];
+	let env = [...dependencies, env_];
+
+	let autoconf = await std.autotools.build(
+		{
+			...rest,
+			...tg.Triple.rotate({ build, host }),
+			env,
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+
+	// Patch the autom4te.cfg file.
+	autoconf = await patchAutom4teCfg(autoconf, arg);
+
+	let shellSripts = ["autoconf"];
+
+	let perlScripts = [
+		"autoheader",
+		"autoreconf",
+		"autoscan",
+		"autoupdate",
+		"ifnames",
+	];
+
+	// Bundle the perl scripts.
+
+	let interpreter = await tg.symlink({
+		artifact: perlArtifact,
+		path: "bin/perl",
+	});
+
+	let binDirectory = tg.directory();
+
+	let autom4te = await std.wrap(
+		tg.symlink({
+			artifact: autoconf,
+			path: "bin/autom4te",
+		}),
+		{
+			interpreter,
+			args: ["-B", await tg`${autoconf}/share/autoconf`],
+			env: {
+				autom4te_perllibdir: tg`${autoconf}/share/autoconf`,
+				AC_MACRODIR: tg.Mutation.templateAppend(
+					tg`${autoconf}/share/autoconf`,
+					":",
+				),
+				M4PATH: tg.Mutation.templateAppend(tg`${autoconf}/share/autoconf`, ":"),
+				PERL5LIB: tg.Mutation.templateAppend(
+					tg`${autoconf}/share/autoconf`,
+					":",
+				),
+				AUTOM4TE_CFG: tg`${autoconf}/share/autoconf/autom4te.cfg`,
+			},
+			sdk: arg?.sdk,
+		},
+	);
+
+	binDirectory = tg.directory(binDirectory, { ["autom4te"]: autom4te });
+	for (let script of perlScripts) {
+		let wrappedScript = await std.wrap(
+			tg.File.expect(await autoconf.get(`bin/${script}`)),
+			{
+				interpreter,
+				env: {
+					AUTOM4TE: autom4te,
+					M4PATH: tg.Mutation.templateAppend(
+						tg`${autoconf}/share/autoconf`,
+						":",
+					),
+					AUTOM4TE_CFG: tg`${autoconf}/share/autoconf/autom4te.cfg`,
+					PERL5LIB: tg.Mutation.templateAppend(
+						tg`${autoconf}/share/autoconf`,
+						":",
+					),
+				},
+				sdk: arg?.sdk,
+			},
+		);
+
+		binDirectory = tg.directory(binDirectory, {
+			[script]: wrappedScript,
+		});
+	}
+
+	// Bundle the shell scripts.
+	for (let script of shellSripts) {
+		let wrappedScript = await std.wrap(
+			tg.File.expect(await autoconf.get(`bin/${script}`)),
+			{
+				env: {
+					trailer_m4: tg.Mutation.setIfUnset(
+						tg`${autoconf}/share/autoconf/autoconf/trailer.m4`,
+					),
+					AUTOM4TE: tg`${autoconf}/bin/autom4te`,
+					M4PATH: tg.Mutation.templateAppend(
+						tg`${autoconf}/share/autoconf`,
+						":",
+					),
+					PERL5LIB: tg.Mutation.templateAppend(
+						tg`${autoconf}/share/autoconf`,
+						":",
+					),
+					AUTOM4TE_CFG: tg`${autoconf}/share/autoconf/autom4te.cfg`,
+				},
+				sdk: arg?.sdk,
+			},
+		);
+
+		binDirectory = tg.directory(binDirectory, {
+			[script]: wrappedScript,
+		});
+	}
+
+	let output = tg.directory(autoconf, {
+		["bin"]: binDirectory,
+	});
+	return output;
+});
+
+export let patchAutom4teCfg = tg.target(
+	async (autoconf: tg.Directory, arg?: Arg): Promise<tg.Directory> => {
+		let autom4teCfg = await autoconf.get("share/autoconf/autom4te.cfg");
+		tg.assert(tg.File.is(autom4teCfg));
+
+		let lines = (await autom4teCfg.text()).split("\n");
+
+		let contents = tg``;
+		for (let line of lines) {
+			let newLine: Promise<tg.Template> | string = line;
+			if (line.includes("args: --prepend-include")) {
+				newLine = tg`args: -B '${autoconf}/share/autoconf'`;
+			}
+			contents = tg`${contents}${newLine}\n`;
+		}
+
+		let env = [arg?.env, std.sdk(arg?.sdk)];
+
+		let patchedAutom4teCfg = tg.File.expect(
+			await tg.build(
+				tg`
+			cat <<'EOF' | tee $OUTPUT
+			${contents}
+		`,
+				{ env: await std.env.object(env) },
+			),
+		);
+
+		return tg.directory(autoconf, {
+			["share/autoconf/autom4te.cfg"]: patchedAutom4teCfg,
+		});
+	},
+);
+
+export default build;
+
+export let test = tg.target(async () => {
+	let directory = build();
+	await std.assert.pkg({
+		directory,
+		binaries: ["autoconf"],
+		metadata,
+	});
+	return directory;
+});

--- a/packages/automake/tangram.tg.ts
+++ b/packages/automake/tangram.tg.ts
@@ -1,0 +1,133 @@
+import autoconf from "tg:autoconf" with { path: "../autoconf" };
+import bison from "tg:bison" with { path: "../bison" };
+import help2man from "tg:help2man" with { path: "../help2man" };
+import m4 from "tg:m4" with { path: "../m4" };
+import perl from "tg:perl" with { path: "../perl" };
+import pkgconfig from "tg:pkg-config" with { path: "../pkgconfig" };
+import * as std from "tg:std" with { path: "../std" };
+import zlib from "tg:zlib" with { path: "../zlib" };
+
+export let metadata = {
+	homepage: "https://www.gnu.org/software/automake/",
+	license: "GPL-2.0-or-later",
+	name: "automake",
+	repository: "https://git.savannah.gnu.org/git/automake.git",
+	version: "1.16.5",
+};
+
+export let source = tg.target(() => {
+	let { name, version } = metadata;
+	let compressionFormat = ".xz" as const;
+	let checksum =
+		"sha256:f01d58cd6d9d77fbdca9eb4bbd5ead1988228fdb73d6f7a201f5f8d6b118b469";
+	return std.download.fromGnu({ name, version, compressionFormat, checksum });
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: tg.Triple.Arg;
+	env?: std.env.Arg;
+	host?: tg.Triple.Arg;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let automake = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build,
+		env: env_,
+		host,
+		source: source_,
+		...rest
+	} = arg ?? {};
+
+	let perlArtifact = await perl(arg);
+
+	let perlInterpreter = await tg.symlink({
+		artifact: perlArtifact,
+		path: "bin/perl",
+	});
+	let scripts = ["automake", "aclocal"];
+
+	let version = "1.16";
+	let binDirectory = tg.directory({});
+	let dependencies = [
+		autoconf(arg),
+		bison(arg),
+		help2man(arg),
+		m4(arg),
+		pkgconfig(arg),
+		perlArtifact,
+		zlib(arg),
+	];
+
+	let env = [env_, std.utils.env(arg), ...dependencies];
+
+	let automake = await std.utils.buildUtil(
+		{
+			...rest,
+			...tg.Triple.rotate({ build, host }),
+			env,
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+
+	for (let script of scripts) {
+		let executable = tg.File.expect(
+			await automake.get(`bin/${script}-${version}`),
+		);
+		let wrappedScript = std.wrap(executable, {
+			interpreter: perlInterpreter,
+			env: {
+				PERL5LIB: tg.Mutation.templateAppend(
+					tg`${automake}/share/automake-${version}`,
+					":",
+				),
+				M4PATH: tg.Mutation.templateAppend(
+					tg`${automake}/share/aclocal-${version}`,
+					":",
+				),
+				ACLOCAL_PATH: tg.Mutation.templateAppend(
+					tg`${automake}/share/aclocal-${version}`,
+					":",
+				),
+				ACLOCAL_AUTOMAKE_DIR: tg.Mutation.templateAppend(
+					tg`${automake}/share/aclocal-${version}`,
+					":",
+				),
+				AUTOMAKE_LIBDIR: tg.Mutation.templateAppend(
+					tg`${automake}/share/automake-${version}`,
+					":",
+				),
+				AUTOMAKE_UNINSTALLED: "true",
+			},
+		});
+
+		binDirectory = tg.directory(binDirectory, {
+			[`${script}-${version}`]: wrappedScript,
+		});
+	}
+
+	binDirectory = tg.directory(binDirectory, {
+		["automake"]: tg.symlink(`automake-${version}`),
+		["aclocal"]: tg.symlink(`aclocal-${version}`),
+	});
+
+	return tg.directory({
+		["bin"]: binDirectory,
+	});
+});
+
+export default automake;
+
+export let test = tg.target(async () => {
+	let directory = automake();
+	await std.assert.pkg({
+		directory,
+		binaries: ["automake"],
+		metadata,
+	});
+	return directory;
+});

--- a/packages/bash/tangram.tg.ts
+++ b/packages/bash/tangram.tg.ts
@@ -1,8 +1,13 @@
+import gettext from "tg:gettext" with { path: "../gettext" };
+import ncurses from "tg:ncurses" with { path: "../ncurses" };
 import * as std from "tg:std" with { path: "../std" };
 
 export let metadata = {
+	homepage: "https://www.gnu.org/software/bash/",
+	license: "GPL-3.0-or-later",
 	name: "bash",
-	version: "5.2.15",
+	repository: "https://git.savannah.gnu.org/git/bash.git",
+	version: "5.2.21",
 };
 
 export let source = tg.target(async (arg?: Arg) => {
@@ -11,7 +16,7 @@ export let source = tg.target(async (arg?: Arg) => {
 	let env = std.env.object([std.sdk({ host: build }, arg?.sdk), arg?.env]);
 
 	let checksum =
-		"sha256:13720965b5f4fc3a0d4b61dd37e7565c741da9a5be24edc2ae00182fc1b3588c";
+		"sha256:c8e31bdc59b69aaffc5b36509905ba3e5cbb12747091d27b4b977f078560d5b8";
 	let source = std.download.fromGnu({ name, version, checksum });
 	// See https://lists.gnu.org/archive/html/bug-bash/2022-10/msg00000.html
 	// We don't have autoreconf available so we additionally manually resolve the configure script change. The m4 change isn't used, just here for completeness.
@@ -41,17 +46,28 @@ type Arg = {
 };
 
 export let bash = tg.target((arg?: Arg) => {
-	let { autotools = [], build, host, source: source_, ...rest } = arg ?? {};
+	let {
+		autotools = [],
+		build,
+		env: env_,
+		host,
+		source: source_,
+		...rest
+	} = arg ?? {};
 
 	let configure = {
-		args: ["--without-bash-malloc"],
+		args: ["--without-bash-malloc", "--with-curses"],
 	};
 	let phases = { configure };
+
+	let dependencies = [gettext(arg), ncurses(arg)];
+	let env = [...dependencies, env_];
 
 	return std.autotools.build(
 		{
 			...rest,
 			...tg.Triple.rotate({ build, host }),
+			env,
 			phases,
 			source: source_ ?? source(),
 		},
@@ -59,12 +75,28 @@ export let bash = tg.target((arg?: Arg) => {
 	);
 });
 
-export let test = tg.target(() => {
-	return std.build(tg`
-		mkdir -p $OUTPUT
-		echo "Checking that we can run bash scripts." > $OUTPUT/log.txt
-		${bash()}/bin/bash -c "echo 'Hello, world!' > $OUTPUT/hello.txt"
-	`);
-});
-
 export default bash;
+
+/** Wrap a shebang'd bash script to use this package's bach as the interpreter.. */
+export let wrapScript = async (script: tg.File) => {
+	let scriptMetadata = await std.file.executableMetadata(script);
+	if (
+		scriptMetadata?.format !== "shebang" ||
+		(scriptMetadata.interpreter !== "sh" &&
+			scriptMetadata.interpreter !== "bash")
+	) {
+		throw new Error("Expected a shebang sh or bash script");
+	}
+	let interpreter = tg.File.expect(await (await bash()).get("bin/bash"));
+	return std.wrap(script, { interpreter, identity: "executable" });
+};
+
+export let test = tg.target(async () => {
+	let directory = bash();
+	await std.assert.pkg({
+		directory,
+		binaries: ["bash"],
+		metadata,
+	});
+	return directory;
+});

--- a/packages/bash/tangram.tg.ts
+++ b/packages/bash/tangram.tg.ts
@@ -82,8 +82,7 @@ export let wrapScript = async (script: tg.File) => {
 	let scriptMetadata = await std.file.executableMetadata(script);
 	if (
 		scriptMetadata?.format !== "shebang" ||
-		(scriptMetadata.interpreter !== "sh" &&
-			scriptMetadata.interpreter !== "bash")
+		!scriptMetadata.interpreter.includes("sh")
 	) {
 		throw new Error("Expected a shebang sh or bash script");
 	}

--- a/packages/bc/tangram.tg.ts
+++ b/packages/bc/tangram.tg.ts
@@ -1,0 +1,91 @@
+import * as std from "tg:std" with { path: "../std" };
+
+export let metadata = {
+	homepage: "https://git.gavinhoward.com/gavin/bc",
+	name: "bc",
+	license: "BSD-2-Clause",
+	repository: "https://git.gavinhoward.com/gavin/bc",
+	version: "6.7.5",
+};
+
+export let source = tg.target(async () => {
+	let { name, version } = metadata;
+	let unpackFormat = ".tar.xz" as const;
+	let packageName = std.download.packageArchive({
+		name,
+		version,
+		unpackFormat,
+	});
+	let checksum =
+		"sha256:c3e02c948d51f3ca9cdb23e011050d2d3a48226c581e0749ed7cbac413ce5461";
+	let url = `https://git.gavinhoward.com/gavin/${name}/releases/download/${version}/${packageName}`;
+	let outer = tg.Directory.expect(
+		await std.download({
+			url,
+			checksum,
+			unpackFormat,
+		}),
+	);
+	return std.directory.unwrap(outer);
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: tg.Triple.Arg;
+	env?: std.env.Arg;
+	host?: tg.Triple.Arg;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let bc = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build: build_,
+		env: env_,
+		host: host_,
+		source: source_,
+		...rest
+	} = arg ?? {};
+
+	let host = await tg.Triple.host(host_);
+	let build = build_ ? tg.triple(build_) : host;
+
+	let sourceDir = source_ ?? source();
+
+	// Define phases
+	let configure = {
+		args: ["--disable-nls", "--opt=3"],
+	};
+
+	// Define environment.
+	let ccCommand = build.os == "darwin" ? "cc -D_DARWIN_C_SOURCE" : "cc";
+	let env = [{ CC: tg.Mutation.setIfUnset(ccCommand) }, env_];
+
+	let output = std.autotools.build(
+		{
+			...rest,
+			...tg.Triple.rotate({ build, host }),
+			buildInTree: true,
+			env,
+			opt: "3",
+			phases: { configure },
+			source: sourceDir,
+		},
+		autotools,
+	);
+
+	return output;
+});
+
+export default bc;
+
+export let test = tg.target(async () => {
+	let directory = bc();
+	await std.assert.pkg({
+		directory,
+		binaries: ["bc"],
+		metadata,
+	});
+	return directory;
+});

--- a/packages/file/tangram.tg.ts
+++ b/packages/file/tangram.tg.ts
@@ -1,0 +1,101 @@
+import bison from "tg:bison" with { path: "../bison" };
+import libseccomp from "tg:libseccomp" with { path: "../libseccomp" };
+import m4 from "tg:m4" with { path: "../m4" };
+import * as std from "tg:std" with { path: "../std" };
+import zlib from "tg:zlib" with { path: "../zlib" };
+
+export let metadata = {
+	homepage: "https://www.darwinsys.com/file/",
+	license: "https://github.com/file/file/blob/FILE5_45/COPYING",
+	name: "file",
+	repository: "https://github.com/file/file",
+	version: "5.45",
+};
+
+export let source = tg.target(async () => {
+	let { name, version } = metadata;
+	let unpackFormat = ".tar.gz" as const;
+	let packageArchive = std.download.packageArchive({
+		name,
+		version,
+		unpackFormat,
+	});
+	let checksum =
+		"sha256:fc97f51029bb0e2c9f4e3bffefdaf678f0e039ee872b9de5c002a6d09c784d82";
+	let url = `https://astron.com/pub/file/${packageArchive}`;
+	let outer = tg.Directory.expect(
+		await std.download({ url, checksum, unpackFormat }),
+	);
+	return await std.directory.unwrap(outer);
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: tg.Triple.Arg;
+	env?: std.env.Arg;
+	host?: tg.Triple.Arg;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let file = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build: build_,
+		env: env_,
+		host: host_,
+		source: source_,
+		...rest
+	} = arg ?? {};
+	let host = await tg.Triple.host(host_);
+	let build = build_ ? tg.triple(build_) : host;
+
+	let configure = {
+		args: [
+			"--disable-dependency-tracking",
+			"--disable-silent-rules",
+		],
+	};
+	let dependencies = [bison(arg), libseccomp(arg), m4(arg), zlib(arg)];
+	let env = [...dependencies, env_];
+
+	let output = await std.autotools.build(
+		{
+			...rest,
+			...tg.Triple.rotate({ build, host }),
+			env,
+			hardeningCFlags: false,
+			phases: { configure },
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+
+	// Always set MAGIC when using `file`.
+	let magic = tg.directory({
+		"magic.mgc": tg.File.expect(await output.get("share/misc/magic.mgc")),
+	});
+	let rawFile = tg.File.expect(await output.get("bin/file"));
+	let wrappedFile = std.wrap(rawFile, {
+		env: {
+			MAGIC: tg.Mutation.setIfUnset(tg`${magic}/magic.mgc`),
+		},
+		libraryPaths: [tg.Directory.expect(await output.get("lib"))],
+		sdk: arg?.sdk,
+	});
+	return tg.directory(output, {
+		"bin/file": wrappedFile,
+	});
+});
+
+export default file;
+
+export let test = tg.target(async () => {
+	let directory = file();
+	await std.assert.pkg({
+		directory,
+		binaries: ["file"],
+		metadata,
+	});
+	return directory;
+});

--- a/packages/flex/tangram.tg.ts
+++ b/packages/flex/tangram.tg.ts
@@ -1,24 +1,31 @@
+import help2man from "tg:help2man" with { path: "../help2man" };
+import m4 from "tg:m4" with { path: "../m4" };
 import * as std from "tg:std" with { path: "../std" };
+import texinfo from "tg:texinfo" with { path: "../texinfo" };
 
 export let metadata = {
+	homepage: "https://github.com/westes/flex",
+	license: "https://github.com/westes/flex/tree/master?tab=License-1-ov-file",
 	name: "flex",
+	repository: "https://github.com/westes/flex",
 	version: "2.6.4",
 };
 
-export let source = tg.target(async () => {
+export let source = tg.target(() => {
 	let { name, version } = metadata;
 	let checksum =
 		"sha256:e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995";
-	let unpackFormat = ".tar.gz" as const;
-	let url = `https://github.com/westes/${name}/releases/download/v${version}/${name}-${version}${unpackFormat}`;
-	let download = tg.Directory.expect(
-		await std.download({
-			checksum,
-			unpackFormat,
-			url,
-		}),
-	);
-	return std.directory.unwrap(download);
+	let owner = "westes";
+	let repo = name;
+	let tag = `v${version}`;
+	return std.download.fromGithub({
+		checksum,
+		owner,
+		repo,
+		tag,
+		release: true,
+		version,
+	});
 });
 
 type Arg = {
@@ -31,12 +38,23 @@ type Arg = {
 };
 
 export let flex = tg.target(async (arg?: Arg) => {
-	let { autotools = [], build, host, source: source_, ...rest } = arg ?? {};
+	let {
+		autotools = [],
+		build,
+		env: env_,
+		host,
+		source: source_,
+		...rest
+	} = arg ?? {};
+
+	let dependencies = [help2man(arg), m4(arg), texinfo(arg)];
+	let env = [...dependencies, env_];
 
 	return std.autotools.build(
 		{
 			...rest,
 			...tg.Triple.rotate({ build, host }),
+			env,
 			source: source_ ?? source(),
 		},
 		autotools,
@@ -45,9 +63,12 @@ export let flex = tg.target(async (arg?: Arg) => {
 
 export default flex;
 
-export let test = tg.target(() => {
-	return std.build(tg`
-		echo "Checking that we can run flex." | tee $OUTPUT
-		${flex()}/bin/flex --version | tee -a $OUTPUT
-	`);
+export let test = tg.target(async () => {
+	let directory = flex();
+	await std.assert.pkg({
+		directory,
+		binaries: ["flex"],
+		metadata,
+	});
+	return directory;
 });

--- a/packages/gcc/tangram.tg.ts
+++ b/packages/gcc/tangram.tg.ts
@@ -1,0 +1,163 @@
+import * as std from "tg:std" with { path = "../std" };
+
+export let metadata = {
+	name: "gcc",
+	version: "13.2.0",
+};
+
+/* This function produces a GCC source directory with the gmp, mpfr, isl, and mpc sources included. */
+export let source = tg.target(() =>
+	tg.directory(gccSource(), {
+		gmp: gmpSource(),
+		isl: islSource(),
+		mpfr: mpfrSource(),
+		mpc: mpcSource(),
+	}),
+);
+
+type Arg = std.sdk.BuildEnvArg & {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	source?: tg.Directory;
+	target?: tg.Triple.Arg;
+};
+
+/* Produce a GCC toolchain. */
+export let build = tg.target(async (arg: Arg) => {
+	let {
+		autotools = [],
+		build: build_,
+		env: env_,
+		host: host_,
+		source: source_,
+		target: target_,
+		...rest
+	} = arg ?? {};
+
+	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let build = build_ ? tg.triple(build_) : host;
+	let target = target_ ? tg.triple(target_) : host;
+
+	let buildString = tg.Triple.toString(build);
+	let hostString = tg.Triple.toString(host);
+	let targetString = tg.Triple.toString(target);
+
+	// Set up configuration common to all GCC builds.
+	let commonArgs = [
+		"--disable-dependency-tracking",
+		"--disable-nls",
+		"--disable-multilib",
+		"--enable-default-ssp",
+		"--enable-default-pie",
+		"--enable-initfini-array",
+		`--build=${buildString}`,
+		`--host=${hostString}`,
+		`--target=${targetString}`,
+	];
+
+	// Set up containers to collect additional arguments and environment variables for specific configurations.
+	let additionalArgs = [];
+	let additionalEnv: std.env.Arg = {
+		MAKEFLAGS: "--output-sync --silent",
+	};
+
+	// For Musl targets, disable libsanitizer regardless of build configuration. See https://wiki.musl-libc.org/open-issues.html
+	if (target.environment === "musl") {
+		additionalArgs.push("--disable-libsanitizer");
+		additionalArgs.push("--disable-libitm");
+		additionalArgs.push("--disable-libvtv");
+	}
+
+	// On GLIBC hosts, enable cxa_atexit.
+	if (host.environment === "gnu") {
+		additionalArgs.push("--enable-__cxa_atexit");
+	}
+
+	let configure = { args: [...commonArgs, ...additionalArgs] };
+
+	let phases = { prepare, configure };
+
+	let env = [additionalEnv, env_];
+
+	let result = await std.autotools.build(
+		{
+			...rest,
+			...tg.Triple.rotate({ build, host }),
+			env,
+			phases,
+			opt: "2",
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+
+	result = await mergeLibDirs(result);
+
+	// Add cc symlinks.
+	result = await tg.directory(result, {
+		[`bin/${targetPrefix}cc`]: tg.symlink(`./${targetPrefix}gcc`),
+	});
+	if (!isCross) {
+		result = await tg.directory(result, {
+			[`bin/${hostString}-cc`]: tg.symlink(`./${hostString}-gcc`),
+		});
+	}
+
+	return result;
+});
+
+export default build;
+
+export let gccSource = tg.target(async () => {
+	let { name, version } = metadata;
+	let unpackFormat = ".tar.gz" as const;
+	let checksum =
+		"sha256:8cb4be3796651976f94b9356fa08d833524f62420d6292c5033a9a26af315078";
+	let url = `https://ftp.gnu.org/gnu/${name}/${name}-${version}/${name}-${version}${unpackFormat}`;
+	let outer = tg.Directory.expect(
+		await std.download({ checksum, url, unpackFormat }),
+	);
+	return std.directory.unwrap(outer);
+});
+
+export let gmpSource = tg.target(async () => {
+	let name = "gmp";
+	let version = "6.2.1";
+	let unpackFormat = ".tar.xz" as const;
+	let checksum =
+		"sha256:fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2";
+	let url = `https://gmplib.org/download/gmp/${name}-${version}${unpackFormat}`;
+	let outer = tg.Directory.expect(
+		await std.download({ checksum, url, unpackFormat }),
+	);
+	return std.directory.unwrap(outer);
+});
+
+export let islSource = tg.target(async () => {
+	let name = "isl";
+	let version = "0.24";
+	let unpackFormat = ".tar.xz" as const;
+	let checksum =
+		"sha256:043105cc544f416b48736fff8caf077fb0663a717d06b1113f16e391ac99ebad";
+	let url = `https://libisl.sourceforge.io/${name}-${version}${unpackFormat}`;
+	let outer = tg.Directory.expect(
+		await std.download({ checksum, url, unpackFormat }),
+	);
+	return std.directory.unwrap(outer);
+});
+
+export let mpcSource = tg.target(() => {
+	let name = "mpc";
+	let version = "1.2.1";
+	let checksum =
+		"sha256:17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459";
+	return std.download.fromGnu({ checksum, name, version });
+});
+
+export let mpfrSource = tg.target(async () => {
+	let name = "mpfr";
+	let version = "4.1.0";
+	let checksum =
+		"sha256:feced2d430dd5a97805fa289fed3fc8ff2b094c02d05287fd6133e7f1f0ec926";
+	let compressionFormat = ".bz2" as const;
+	return std.download.fromGnu({ checksum, name, version, compressionFormat });
+});

--- a/packages/gperf/tangram.tg.ts
+++ b/packages/gperf/tangram.tg.ts
@@ -1,8 +1,11 @@
 import * as std from "tg:std" with { path: "../std" };
 
 export let metadata = {
+	homepage: "https://www.gnu.org/software/gperf/",
+	license: "GPL-3.0-or-later",
 	name: "gperf",
-	version: "3.11",
+	repository: "https://git.savannah.gnu.org/git/gperf.git",
+	version: "3.1",
 };
 
 export let source = tg.target(() => {
@@ -25,7 +28,7 @@ export let gperf = tg.target(async (arg?: Arg) => {
 	let { autotools = [], build, host, source: source_, ...rest } = arg ?? {};
 
 	let configure = {
-		args: ["--disable-dependency-tracking", "--disable-documentation"],
+		args: ["--disable-dependency-tracking"],
 	};
 	let phases = { configure };
 
@@ -43,8 +46,11 @@ export let gperf = tg.target(async (arg?: Arg) => {
 export default gperf;
 
 export let test = tg.target(async () => {
-	return std.build(tg`
-		echo "Checking that we can run gperf."
-		${gperf()}/bin/gperf --version
-	`);
+	let directory = gperf();
+	await std.assert.pkg({
+		directory,
+		binaries: ["gperf"],
+		metadata,
+	});
+	return directory;
 });

--- a/packages/help2man/tangram.tg.ts
+++ b/packages/help2man/tangram.tg.ts
@@ -1,0 +1,86 @@
+import autoconf from "tg:autoconf" with { path: "../autoconf" };
+import bison from "tg:bison" with { path: "../bison" };
+import gettext from "tg:gettext" with { path: "../gettext" };
+import m4 from "tg:m4" with { path: "../m4" };
+import perl from "tg:perl" with { path: "../perl" };
+import * as std from "tg:std" with { path: "../std" };
+import texinfo from "tg:texinfo" with { path: "../texinfo" };
+import zlib from "tg:zlib" with { path: "../zlib" };
+
+export let metadata = {
+	homepage: "https://www.gnu.org/software/help2man/",
+	license: "GPL-3.0-or-later",
+	name: "help2man",
+	repository: "https://git.savannah.gnu.org/git/help2man.git",
+	version: "1.49.3",
+};
+
+export let source = tg.target(() => {
+	let { name, version } = metadata;
+	let compressionFormat = ".xz" as const;
+	let checksum =
+		"sha256:4d7e4fdef2eca6afe07a2682151cea78781e0a4e8f9622142d9f70c083a2fd4f";
+	return std.download.fromGnu({ name, version, compressionFormat, checksum });
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: tg.Triple.Arg;
+	env?: std.env.Arg;
+	host?: tg.Triple.Arg;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let build = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build,
+		env: env_,
+		host,
+		source: source_,
+		...rest
+	} = arg ?? {};
+
+	let perlArtifact = await perl(arg);
+	let interpreter = tg.symlink({ artifact: perlArtifact, path: "bin/perl" });
+	let dependencies = [
+		autoconf(arg),
+		bison(arg),
+		gettext(arg),
+		m4(arg),
+		perlArtifact,
+		texinfo(arg),
+		zlib(arg),
+	];
+	let env = [...dependencies, env_];
+	let artifact = std.autotools.build(
+		{
+			...rest,
+			...tg.Triple.rotate({ build, host }),
+			env,
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+
+	let wrappedScript = std.wrap(tg.symlink({ artifact, path: "bin/help2man" }), {
+		interpreter,
+	});
+
+	return tg.directory({
+		["bin/help2man"]: wrappedScript,
+	});
+});
+
+export default build;
+
+export let test = tg.target(async () => {
+	let directory = build();
+	await std.assert.pkg({
+		directory,
+		binaries: ["help2man"],
+		metadata,
+	});
+	return directory;
+});

--- a/packages/libcap/tangram.tg.ts
+++ b/packages/libcap/tangram.tg.ts
@@ -1,0 +1,116 @@
+import attr from "tg:attr" with { path: "../attr" };
+import perl from "tg:perl" with { path: "../perl" };
+import * as std from "tg:std" with { path: "../std" };
+
+export let metadata = {
+	name: "libcap",
+	version: "2.24",
+};
+
+export let source = tg.target(async () => {
+	let { name, version } = metadata;
+	let unpackFormat = ".tar.xz" as const;
+	let packageName = std.download.packageArchive({
+		name,
+		version,
+		unpackFormat,
+	});
+	let checksum =
+		"sha256:cee4568f78dc851d726fc93f25f4ed91cc223b1fe8259daa4a77158d174e6c65";
+	let url = `https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/${packageName}`;
+	let outer = tg.Directory.expect(
+		await std.download({ checksum, unpackFormat, url }),
+	);
+	return std.directory.unwrap(outer);
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: tg.Triple.Arg;
+	env?: std.env.Arg;
+	host?: tg.Triple.Arg;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let libcap = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build,
+		env: env_,
+		host,
+		source: source_,
+		...rest
+	} = arg ?? {};
+
+	let install = tg.Mutation.set(`
+		mkdir -p $OUTPUT/bin $OUTPUT/lib/pkgconfig
+		bins="capsh getcap setcap getpcaps"
+		for bin in $bins; do
+			cp "progs/$bin" "$OUTPUT/bin"
+		done
+		cp -R libcap/include "$OUTPUT"
+		cp libcap/libcap.pc "$OUTPUT/lib/pkgconfig"
+		cp libcap/libcap.a "$OUTPUT/lib"
+		cp libcap/libcap.so.${metadata.version} "$OUTPUT/lib"
+		cd $OUTPUT/lib
+		ln -s libcap.so.${metadata.version} libcap.so.2
+		ln -s libcap.so.2 libcap.so
+	`);
+	let phases = { configure: tg.Mutation.unset(), install };
+
+	let attrArtifact = await attr(arg);
+	let dependencies = [attrArtifact, perl(arg)];
+	let env = [
+		...dependencies,
+		{
+			LDFLAGS: tg.Mutation.templatePrepend(`-L${attrArtifact}/lib`, " "),
+		},
+		env_,
+	];
+
+	let output = await std.autotools.build(
+		{
+			...rest,
+			...tg.Triple.rotate({ build, host }),
+			buildInTree: true,
+			env,
+			phases,
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+
+	let bins = ["capsh", "getcap", "setcap", "getpcaps"];
+	let libDir = tg.Directory.expect(await output.get("lib"));
+	let attrLibDir = tg.Directory.expect(await attrArtifact.get("lib"));
+	for (let bin of bins) {
+		let unwrappedBin = tg.File.expect(await output.get(`bin/${bin}`));
+		let wrappedBin = std.wrap(unwrappedBin, {
+			libraryPaths: [libDir, attrLibDir],
+		});
+		output = await tg.directory(output, { [`bin/${bin}`]: wrappedBin });
+	}
+	return output;
+});
+
+export default libcap;
+
+export let test = tg.target(async () => {
+	let directory = libcap();
+	let binTest = (name: string) => {
+		return {
+			name,
+			testArgs: [],
+			testPredicate: (stdout: string) => stdout.includes("usage:"),
+		};
+	};
+	let binaries = ["capsh", "getcap", "setcap", "getpcaps"].map(binTest);
+	await std.assert.pkg({
+		directory,
+		binaries,
+		libs: ["cap"],
+		metadata,
+	});
+	return directory;
+});

--- a/packages/libseccomp/tangram.tg.ts
+++ b/packages/libseccomp/tangram.tg.ts
@@ -1,0 +1,75 @@
+import gperf from "tg:gperf" with { path: "../gperf" };
+import * as std from "tg:std" with { path: "../std" };
+
+export let metadata = {
+	homepage: "https://github.com/seccomp/libseccomp",
+	license: "LGPLv2.1",
+	name: "libseccomp",
+	repository: "https://github.com/seccomp/libseccomp",
+	version: "2.5.5",
+};
+
+export let source = tg.target(async () => {
+	let { name, version } = metadata;
+	let owner = "seccomp";
+	let repo = name;
+	let tag = `v${version}`;
+	let checksum =
+		"sha256:248a2c8a4d9b9858aa6baf52712c34afefcf9c9e94b76dce02c1c9aa25fb3375";
+	return std.download.fromGithub({
+		checksum,
+		owner,
+		repo,
+		tag,
+		release: true,
+		version,
+	});
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: tg.Triple.Arg;
+	env?: std.env.Arg;
+	host?: tg.Triple.Arg;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let libseccomp = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build,
+		env: env_,
+		host,
+		source: source_,
+		...rest
+	} = arg ?? {};
+
+	let configure = {
+		args: ["--disable-dependency-tracking"],
+	};
+
+	let env = [gperf(arg), env_];
+
+	return std.autotools.build(
+		{
+			...rest,
+			...tg.Triple.rotate({ build, host }),
+			env,
+			phases: { configure },
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+});
+
+export default libseccomp;
+
+export let test = tg.target(async () => {
+	let directory = libseccomp();
+	await std.assert.pkg({
+		directory,
+		libs: ["seccomp"],
+	});
+	return directory;
+});

--- a/packages/libxcrypt/tangram.tg.ts
+++ b/packages/libxcrypt/tangram.tg.ts
@@ -1,0 +1,79 @@
+import perl from "tg:perl" with { path: "../perl" };
+import * as std from "tg:std" with { path: "../std" };
+
+export let metadata = {
+	homepage: "https://github.com/besser82/libxcrypt",
+	name: "libxcrypt",
+	license: "LGPL-2.1",
+	repository: "https://github.com/besser82/libxcrypt",
+	version: "4.4.36",
+};
+
+export let source = tg.target(() => {
+	let { name, version } = metadata;
+	let owner = "besser82";
+	let repo = name;
+	let tag = `v${version}`;
+	let compressionFormat = ".xz" as const;
+	let checksum =
+		"sha256:e5e1f4caee0a01de2aee26e3138807d6d3ca2b8e67287966d1fefd65e1fd8943";
+	return std.download.fromGithub({
+		checksum,
+		compressionFormat,
+		owner,
+		release: true,
+		repo,
+		tag,
+		version,
+	});
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: tg.Triple.Arg;
+	env?: std.env.Arg;
+	host?: tg.Triple.Arg;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let build = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build,
+		env: env_,
+		host,
+		source: source_,
+		...rest
+	} = arg ?? {};
+
+	let configure = {
+		args: ["--disable-dependency-tracking"],
+	};
+	let phases = { configure };
+
+	let dependencies = [perl(arg)];
+	let env = [...dependencies, env_];
+
+	return std.autotools.build(
+		{
+			...rest,
+			...tg.Triple.rotate({ build, host }),
+			env,
+			phases,
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+});
+
+export default build;
+
+export let test = tg.target(async () => {
+	let directory = build();
+	await std.assert.pkg({
+		directory,
+		libs: ["crypt"],
+	});
+	return directory;
+});

--- a/packages/perl/tangram.tg.ts
+++ b/packages/perl/tangram.tg.ts
@@ -155,6 +155,19 @@ export let perl = tg.target(async (arg?: Arg) => {
 
 export default perl;
 
+/** Wrap a shebang'd perl script to use this package's bach as the interpreter.. */
+export let wrapScript = async (script: tg.File) => {
+	let scriptMetadata = await std.file.executableMetadata(script);
+	if (
+		scriptMetadata?.format !== "shebang" ||
+		!scriptMetadata.interpreter.includes("perl")
+	) {
+		throw new Error("Expected a shebang sh or bash script");
+	}
+	let interpreter = tg.File.expect(await (await perl()).get("bin/bash"));
+	return std.wrap(script, { interpreter, identity: "executable" });
+};
+
 export let test = tg.target(async () => {
 	let directory = perl();
 	await std.assert.pkg({

--- a/packages/pkgconfig/tangram.tg.ts
+++ b/packages/pkgconfig/tangram.tg.ts
@@ -1,0 +1,139 @@
+import bison from "tg:bison" with { path: "../bison" };
+import libiconv from "tg:libiconv" with { path: "../libiconv" };
+import m4 from "tg:m4" with { path: "../m4" };
+import * as std from "tg:std" with { path: "../std" };
+import zlib from "tg:zlib" with { path: "../zlib" };
+
+export let metadata = {
+	homepage: "https://www.freedesktop.org/wiki/Software/pkg-config/",
+	license: "GPL-2.0-or-later",
+	name: "pkg-config",
+	repository: "https://gitlab.freedesktop.org/pkg-config/pkg-config",
+	version: "0.29.2",
+};
+
+export let source = tg.target(async () => {
+	let { name, version } = metadata;
+	let unpackFormat = ".tar.gz" as const;
+	let packageArchive = std.download.packageArchive({
+		name,
+		version,
+		unpackFormat,
+	});
+	let url = `https://pkgconfig.freedesktop.org/releases/${packageArchive}`;
+	let checksum =
+		"sha256:6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591";
+	let outer = tg.Directory.expect(
+		await std.download({ url, checksum, unpackFormat }),
+	);
+	return await std.directory.unwrap(outer);
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: tg.Triple.Arg;
+	env?: std.env.Arg;
+	host?: tg.Triple.Arg;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let pkgconfig = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build: build_,
+		env: env_,
+		host: host_,
+		source: source_,
+		...rest
+	} = arg ?? {};
+	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let build = build_ ? tg.triple(build_) : host;
+
+	let configure = {
+		args: ["--with-internal-glib", "--disable-dependency-tracking"],
+	};
+
+	let phases = { configure };
+	let dependencies: tg.Unresolved<Array<std.env.Arg>> = [
+		bison(arg),
+		m4(arg),
+		zlib(arg),
+	];
+	let additionalLibDirs = [];
+	if (build.os === "darwin") {
+		let libiconvArtifact = await libiconv(arg);
+		dependencies.push(libiconvArtifact);
+		additionalLibDirs.push(
+			tg.Directory.expect(await libiconvArtifact.get("lib")),
+		);
+		dependencies.push({
+			LDFLAGS: await tg.Mutation.templatePrepend(
+				tg`-L${libiconvArtifact}/lib`,
+				" ",
+			),
+		});
+	}
+	let env = [...dependencies, env_];
+	let pkgConfigBuild = await std.autotools.build(
+		{
+			...rest,
+			...tg.Triple.rotate({ build, host }),
+			env,
+			phases,
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+
+	// Bundle the resulting binary with the `--define-prefix` flag.
+	let wrappedBin = std.wrap(
+		tg.symlink({
+			artifact: pkgConfigBuild,
+			path: "bin/pkg-config",
+		}),
+		{
+			args: ["--define-prefix"],
+			libraryPaths: additionalLibDirs,
+		},
+	);
+
+	return tg.directory(pkgConfigBuild, {
+		["bin/pkg-config"]: wrappedBin,
+	});
+});
+
+export let path = tg.target(
+	async (
+		dependencies: Array<tg.Artifact>,
+	): Promise<tg.Template | undefined> => {
+		let standardPaths = [
+			"",
+			"/lib",
+			"/share",
+			"/lib/pkgconfig",
+			"/share/pkgconfig",
+		];
+
+		let allPaths: Array<tg.Template> = [];
+		for (let dependency of dependencies) {
+			for (let path of standardPaths) {
+				allPaths.push(await tg`${dependency}${path}`);
+			}
+		}
+
+		return tg.Template.join(":", ...allPaths);
+	},
+);
+
+export default pkgconfig;
+
+export let test = tg.target(async () => {
+	let directory = pkgconfig();
+	await std.assert.pkg({
+		directory,
+		binaries: ["pkg-config"],
+		metadata,
+	});
+	return directory;
+});

--- a/packages/std/sdk/dependencies/bc.tg.ts
+++ b/packages/std/sdk/dependencies/bc.tg.ts
@@ -2,26 +2,28 @@ import * as std from "../../tangram.tg.ts";
 
 export let metadata = {
 	name: "bc",
-	version: "6.6.0",
+	version: "6.7.5",
 };
 
-export let source = tg.target(() => {
+export let source = tg.target(async () => {
 	let { name, version } = metadata;
-	let owner = "gavinhoward";
-	let repo = name;
-	let tag = version;
-	let compressionFormat = ".xz" as const;
-	let checksum =
-		"sha256:309ef0faebf149376aa69446a496fac13c3ff483a100a51d9c67cea1a73b2906";
-	return std.download.fromGithub({
-		checksum,
-		compressionFormat,
-		owner,
-		repo,
-		tag,
-		release: true,
+	let unpackFormat = ".tar.xz" as const;
+	let packageName = std.download.packageArchive({
+		name,
 		version,
+		unpackFormat,
 	});
+	let checksum =
+		"sha256:c3e02c948d51f3ca9cdb23e011050d2d3a48226c581e0749ed7cbac413ce5461";
+	let url = `https://git.gavinhoward.com/gavin/${name}/releases/download/${version}/${packageName}`;
+	let outer = tg.Directory.expect(
+		await std.download({
+			url,
+			checksum,
+			unpackFormat,
+		}),
+	);
+	return std.directory.unwrap(outer);
 });
 
 type Arg = std.sdk.BuildEnvArg & {

--- a/packages/std/sdk/kernel_headers.tg.ts
+++ b/packages/std/sdk/kernel_headers.tg.ts
@@ -6,13 +6,13 @@ export let metadata = {
 	license: "GPLv2",
 	name: "linux",
 	repository: "https://git.kernel.org",
-	version: "6.7.8",
+	version: "6.8.1",
 };
 
 export let source = tg.target(async () => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:469ff46b98685df13b56c98417c64ba7a30f8a45baf34aa99f07935e1bf65c18";
+		"sha256:8d0c8936e3140a0fbdf511ad7a9f21121598f3656743898f47bb9052d37cff68";
 	let unpackFormat = ".tar.xz" as const;
 	let url = `https://cdn.kernel.org/pub/linux/kernel/v6.x/${name}-${version}${unpackFormat}`;
 	let source = tg.Directory.expect(

--- a/packages/std/utils.tg.ts
+++ b/packages/std/utils.tg.ts
@@ -44,10 +44,6 @@ export let env = tg.target(async (arg?: Arg) => {
 	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
 	let bootstrapMode = bootstrapMode_ ?? false;
 
-	if (bootstrapMode) {
-		await prerequisites({ host });
-	}
-
 	// Build bash and use it as the default shell.
 	let bashArtifact = await bash.build({
 		...rest,

--- a/packages/std/utils/attr.tg.ts
+++ b/packages/std/utils/attr.tg.ts
@@ -3,7 +3,7 @@ import { buildUtil, prerequisites } from "../utils.tg.ts";
 
 export let metadata = {
 	name: "attr",
-	version: "2.5.1",
+	version: "2.5.2",
 };
 
 export let source = tg.target(async () => {
@@ -15,7 +15,7 @@ export let source = tg.target(async () => {
 		unpackFormat,
 	});
 	let checksum =
-		"sha256:db448a626f9313a1a970d636767316a8da32aede70518b8050fa0de7947adc32";
+		"sha256:f2e97b0ab7ce293681ab701915766190d607a1dba7fae8a718138150b700a70b";
 	let url = `https://mirrors.sarata.com/non-gnu/attr/${packageArchive}`;
 	let outer = tg.Directory.expect(
 		await std.download({ url, checksum, unpackFormat }),

--- a/packages/texinfo/tangram.tg.ts
+++ b/packages/texinfo/tangram.tg.ts
@@ -1,44 +1,77 @@
+import * as bash from "tg:bash" with { path: "../bash" };
+import bison from "tg:bison" with { path: "../bison" };
+import m4 from "tg:m4" with { path: "../m4" };
+import ncurses from "tg:ncurses" with { path: "../ncurses" };
+import perl from "tg:perl" with { path: "../perl" };
 import * as std from "tg:std" with { path: "../std" };
-
-type Args = {
-	source?: tg.Artifact;
-	host?: tg.Triple.Arg;
-	target?: tg.Triple.Arg;
-};
+import zlib from "tg:zlib" with { path: "../zlib" };
 
 export let metadata = {
+	homepage: "https://www.gnu.org/software/texinfo/",
+	license: "GPL-3.0-or-later",
 	name: "texinfo",
-	version: "6.8",
-	checksum:
-		"sha256:8e09cf753ad1833695d2bac0f57dc3bd6bcbbfbf279450e1ba3bc2d7fb297d08",
+	repository: "https://git.savannah.gnu.org/git/texinfo.git",
+	version: "7.1",
 };
 
-export let source = tg.target(() => std.download.fromGnu(metadata));
+export let source = tg.target(() => {
+	let { name, version } = metadata;
+	let compressionFormat = ".xz" as const;
+	let checksum =
+		"sha256:deeec9f19f159e046fdf8ad22231981806dac332cc372f1c763504ad82b30953";
+	return std.download.fromGnu({ name, version, compressionFormat, checksum });
+});
 
-export let texinfo = tg.target(async (args?: Args) => {
-	let host = tg.Triple.host({ host: args?.host });
-	let target = tg.Triple.target({ host: args?.host, target: args?.target });
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: tg.Triple.Arg;
+	env?: std.env.Arg;
+	host?: tg.Triple.Arg;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
 
-	let build = await autotools.build({
-		source: args?.source ?? source(),
-		copySource: true,
+export let texinfo = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build,
+		env: env_,
 		host,
-		target,
-	});
+		source: source_,
+		...rest
+	} = arg ?? {};
 
-	let perl = tg.File.expect(
-		await (await autotools.perl.perl()).get("bin/perl"),
+	let perlArtifact = await perl(arg);
+	let dependencies = [
+		bison(arg),
+		m4(arg),
+		ncurses(arg),
+		perlArtifact,
+		zlib(arg),
+	];
+	let env = [...dependencies, env_];
+
+	let output = await std.autotools.build(
+		{
+			...rest,
+			...tg.Triple.rotate({ build, host }),
+			env,
+			source: source_ ?? source(),
+		},
+		autotools,
 	);
 
+	let interpreter = tg.File.expect(await perlArtifact.get("bin/perl"));
+
 	let binDir = tg.directory({
-		["bin/install-info"]: build.get("bin/install-info"),
+		["bin/install-info"]: output.get("bin/install-info"),
 		["bin/pod2texi"]: std.wrap({
-			executable: tg.File.expect(await build.get("bin/pod2texi")),
-			interpreter: perl,
+			executable: tg.File.expect(await output.get("bin/pod2texi")),
+			interpreter,
 		}),
 		["bin/texi2any"]: std.wrap({
-			executable: tg.File.expect(await build.get("bin/texi2any")),
-			interpreter: perl,
+			executable: tg.File.expect(await output.get("bin/texi2any")),
+			interpreter,
 		}),
 		["bin/makeinfo"]: tg.symlink("texi2any"),
 	});
@@ -46,30 +79,28 @@ export let texinfo = tg.target(async (args?: Args) => {
 	let shellScripts = ["pdftexi2dvi", "texi2dvi", "texi2pdf", "texindex"];
 
 	for (let script of shellScripts) {
-		let scriptFile = tg.File.expect(await build.get(`bin/${script}`));
+		let scriptFile = tg.File.expect(await output.get(`bin/${script}`));
 		binDir = tg.directory(binDir, {
-			[`bin/${script}`]: std.wrap(scriptFile),
+			[`bin/${script}`]: bash.wrapScript(scriptFile),
 		});
 	}
 
 	let perlLibPaths = [
-		tg`${build}/share/texinfo/lib/Text-Unidecode/lib`,
-		tg`${build}/share/texinfo/lib/Unicode-EastAsianWidth/lib`,
-		tg`${build}/share/texinfo/lib/libintl-perl/lib`,
-		tg`${build}/share/texinfo/Pod-Simple-Texinfo`,
-		tg`${build}/share/texinfo`,
+		tg`${output}/share/texinfo/lib/Text-Unidecode/lib`,
+		tg`${output}/share/texinfo/lib/Unicode-EastAsianWidth/lib`,
+		tg`${output}/share/texinfo/lib/libintl-perl/lib`,
+		tg`${output}/share/texinfo/Pod-Simple-Texinfo`,
+		tg`${output}/share/texinfo`,
 	];
 
 	return std.env(binDir, {
-		PERL5LIB: {
-			value: tg.Template.join(":", ...perlLibPaths),
-			kind: "append",
-			separator: ":",
-		},
-		TEXINDEX_SCRIPT: {
-			value: tg`${build}/share/texinfo/texindex.awk`,
-			kind: "set_if_unset",
-		},
+		PERL5LIB: tg.Mutation.templateAppend(
+			tg.Template.join(":", ...perlLibPaths),
+			":",
+		),
+		TEXINDEX_SCRIPT: tg.Mutation.setIfUnset(
+			tg`${output}/share/texinfo/texindex.awk`,
+		),
 	});
 });
 

--- a/packages/zstd/tangram.tg.ts
+++ b/packages/zstd/tangram.tg.ts
@@ -1,0 +1,67 @@
+import * as std from "tg:std" with { path: "../std" };
+
+export let metadata = {
+	homepage: "https://facebook.github.io/zstd/",
+	license: "BSD-3-Clause",
+	name: "zstd",
+	repository: "https://github.com/facebook/zstd",
+	version: "1.5.5",
+};
+
+export let source = tg.target(() => {
+	let { name, version } = metadata;
+	let compressionFormat = ".zst" as const;
+	let checksum =
+		"sha256:ce264bca60eb2f0e99e4508cffd0d4d19dd362e84244d7fc941e79fa69ccf673";
+	let owner = "facebook";
+	let repo = name;
+	let tag = `v${version}`;
+	return std.download.fromGithub({
+		checksum,
+		compressionFormat,
+		owner,
+		repo,
+		tag,
+		release: true,
+		version,
+	});
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: tg.Triple.Arg;
+	env?: std.env.Arg;
+	host?: tg.Triple.Arg;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let build = tg.target(async (arg?: Arg) => {
+	let { autotools = [], build, host, source: source_, ...rest } = arg ?? {};
+
+	let sourceDir = source_ ?? source();
+
+	let install = `make install PREFIX=$OUTPUT`;
+	let phases = { install };
+
+	return std.autotools.build({
+		...rest,
+		...tg.Triple.rotate({ build, host }),
+		buildInTree: true,
+		phases: { phases, order: ["prepare", "build", "install"] },
+		prefixArg: "none",
+		source: sourceDir,
+	});
+});
+
+export default build;
+
+export let test = tg.target(async () => {
+	let directory = build();
+	await std.assert.pkg({
+		directory,
+		binaries: ["zstd"],
+		libs: ["zstd"],
+	});
+	return directory;
+});


### PR DESCRIPTION
This PR ensures all packages used inside `std` to bootstrap the toolchain have a corresponding package outside `std` for general use.