### PR TITLE
fix(std): workspace/injection build toolchain

### DIFF
--- a/packages/autoconf/tangram.tg.ts
+++ b/packages/autoconf/tangram.tg.ts
@@ -96,7 +96,6 @@ export let build = tg.target(async (arg?: Arg) => {
 				),
 				AUTOM4TE_CFG: tg`${autoconf}/share/autoconf/autom4te.cfg`,
 			},
-			sdk: arg?.sdk,
 		},
 	);
 
@@ -118,7 +117,6 @@ export let build = tg.target(async (arg?: Arg) => {
 						":",
 					),
 				},
-				sdk: arg?.sdk,
 			},
 		);
 
@@ -147,7 +145,6 @@ export let build = tg.target(async (arg?: Arg) => {
 					),
 					AUTOM4TE_CFG: tg`${autoconf}/share/autoconf/autom4te.cfg`,
 				},
-				sdk: arg?.sdk,
 			},
 		);
 

--- a/packages/file/tangram.tg.ts
+++ b/packages/file/tangram.tg.ts
@@ -81,7 +81,6 @@ export let file = tg.target(async (arg?: Arg) => {
 			MAGIC: tg.Mutation.setIfUnset(tg`${magic}/magic.mgc`),
 		},
 		libraryPaths: [tg.Directory.expect(await output.get("lib"))],
-		sdk: arg?.sdk,
 	});
 	return tg.directory(output, {
 		"bin/file": wrappedFile,

--- a/packages/perl/tangram.tg.ts
+++ b/packages/perl/tangram.tg.ts
@@ -104,14 +104,12 @@ export let perl = tg.target(async (arg?: Arg) => {
 	let wrappedPerl = await std.wrap(
 		tg.symlink({ artifact: perlArtifact, path: "bin/perl" }),
 		{
-			identity: "wrapper",
 			env: {
 				PERL5LIB: tg.Mutation.templateAppend(
 					tg`${perlArtifact}/lib/perl5/${metadata.version}`,
 					":",
 				),
 			},
-			sdk: rest.sdk,
 		},
 	);
 
@@ -137,9 +135,7 @@ export let perl = tg.target(async (arg?: Arg) => {
 
 		// Wrap it.
 		let wrappedScript = std.wrap(scriptArtifact, {
-			identity: "interpreter",
 			interpreter: wrappedPerl,
-			sdk: rest.sdk,
 		});
 
 		// Replace in the original artifact.

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -119,24 +119,24 @@ dependencies = [
 
 [[package]]
 name = "async-recursion"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -186,9 +186,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "blake3"
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -446,7 +446,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -457,7 +457,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -520,7 +520,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "unicode-xid",
 ]
 
@@ -659,7 +659,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -732,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d030e59af851932b72ceebadf4a2b5986dba4c3b99dd2493f8273a0f151943"
+checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
 dependencies = [
  "bytes",
  "fnv",
@@ -1033,9 +1033,9 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lsp-types"
-version = "0.95.0"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158c1911354ef73e8fe42da6b10c0484cb65c7f1007f28022e847706c1ab6984"
+checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
 dependencies = [
  "bitflags 1.3.2",
  "serde",
@@ -1278,7 +1278,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1430,7 +1430,7 @@ version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1497,7 +1497,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1523,7 +1523,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1545,7 +1545,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1587,7 +1587,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1711,7 +1711,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=9dcf82ddd1351977ec0695c7cd9a2a2ad924e31e#9dcf82ddd1351977ec0695c7cd9a2a2ad924e31e"
+source = "git+https://github.com/tangramdotdev/tangram?rev=a0850905a6e72eff8a59ce9d35df7dfa29698c99#a0850905a6e72eff8a59ce9d35df7dfa29698c99"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -1768,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "tangram_error"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=9dcf82ddd1351977ec0695c7cd9a2a2ad924e31e#9dcf82ddd1351977ec0695c7cd9a2a2ad924e31e"
+source = "git+https://github.com/tangramdotdev/tangram?rev=a0850905a6e72eff8a59ce9d35df7dfa29698c99#a0850905a6e72eff8a59ce9d35df7dfa29698c99"
 dependencies = [
  "serde",
  "thiserror",
@@ -1797,7 +1797,7 @@ dependencies = [
 [[package]]
 name = "tangram_util"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=9dcf82ddd1351977ec0695c7cd9a2a2ad924e31e#9dcf82ddd1351977ec0695c7cd9a2a2ad924e31e"
+source = "git+https://github.com/tangramdotdev/tangram?rev=a0850905a6e72eff8a59ce9d35df7dfa29698c99#a0850905a6e72eff8a59ce9d35df7dfa29698c99"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1868,7 +1868,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1955,7 +1955,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2018,7 +2018,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -2141,9 +2141,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "atomic",
  "getrandom",
@@ -2197,7 +2197,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "wasm-bindgen-shared",
 ]
 
@@ -2219,7 +2219,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2439,7 +2439,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.53",
 ]
 
 [[package]]

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -19,8 +19,8 @@ itertools = "0.12"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "9dcf82ddd1351977ec0695c7cd9a2a2ad924e31e" }
-tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "9dcf82ddd1351977ec0695c7cd9a2a2ad924e31e" }
+tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "a0850905a6e72eff8a59ce9d35df7dfa29698c99" }
+tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "a0850905a6e72eff8a59ce9d35df7dfa29698c99" }
 tokio = { version = "1", default-features = false, features = [
   "rt",
   "macros",

--- a/packages/std/env.tg.ts
+++ b/packages/std/env.tg.ts
@@ -29,13 +29,16 @@ export async function env(...args: tg.Args<env.Arg>) {
 	let wrapEnv = wrapEnv_ ?? [];
 
 	// Include the standard utils unless bootstrap mode is set.
+	let buildToolchain = undefined;
 	if (!bootstrapMode) {
 		wrapEnv.push(await std.utils.env());
+	} else {
+		buildToolchain = await std.sdk({ bootstrapMode });
 	}
 
 	return std.wrap(gnuEnv(), {
+		buildToolchain,
 		env: wrapEnv,
-		sdk: { bootstrapMode },
 	});
 }
 

--- a/packages/std/packages/ld_proxy/src/main.rs
+++ b/packages/std/packages/ld_proxy/src/main.rs
@@ -399,17 +399,17 @@ async fn create_manifest<H: BuildHasher>(
 					.as_ref()
 					.expect("TANGRAM_LINKER_INTERPRETER_PATH must be set.");
 
-				// Check if this is a musl interpreter.  Follow the symlink, get the pathname.
+				// Check if this is a musl interpreter.
 				let is_musl = {
 					let canonical_interpreter = std::fs::canonicalize(path)
 						.expect("Failed to canonicalize the interpreter path.");
-					// Canonicalizing the musl interpreter will resolve to libc.so.  We check that the filename does NOT contain "ld-linux".
-					!canonical_interpreter
-						.file_name()
-						.expect("Failed to read the interpreter file name")
-						.to_str()
-						.expect("Invalid interpreter file name")
-						.starts_with("ld-linux")
+
+					// Check the help output for the string "musl".
+					let output = std::process::Command::new(canonical_interpreter)
+						.arg("--help")
+						.output()
+						.expect("Failed to run the interpreter help command.");
+					String::from_utf8_lossy(&output.stderr).contains("musl")
 				};
 
 				Some((path.clone(), is_musl))

--- a/packages/std/packages/wrapper/Cargo.toml
+++ b/packages/std/packages/wrapper/Cargo.toml
@@ -15,6 +15,9 @@ futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tangram_client = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
 xattr = { workspace = true }
+
+[features]
+tracing = ["dep:tracing", "dep:tracing-subscriber"]

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -542,9 +542,7 @@ export namespace sdk {
 				env,
 				key: "LIBRARY_PATH",
 			})) {
-				let ldsoPath = bootstrapMode
-					? bootstrap.interpreterName(host)
-					: libc.interpreterName(host);
+				let ldsoPath = libc.interpreterName(host);
 				let foundLdso = await dir.tryGet(ldsoPath);
 				if (foundLdso) {
 					ldso = tg.File.expect(foundLdso);

--- a/packages/std/sdk/dependencies/autoconf.tg.ts
+++ b/packages/std/sdk/dependencies/autoconf.tg.ts
@@ -74,6 +74,7 @@ export let build = tg.target(async (arg?: Arg) => {
 			path: "bin/autom4te",
 		}),
 		{
+			buildToolchain: env_,
 			interpreter,
 			args: ["-B", await tg`${autoconf}/share/autoconf`],
 			env: {
@@ -89,7 +90,6 @@ export let build = tg.target(async (arg?: Arg) => {
 				),
 				AUTOM4TE_CFG: tg`${autoconf}/share/autoconf/autom4te.cfg`,
 			},
-			sdk: arg?.sdk,
 		},
 	);
 
@@ -98,6 +98,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		let wrappedScript = await std.wrap(
 			tg.File.expect(await autoconf.get(`bin/${script}`)),
 			{
+				buildToolchain: env_,
 				interpreter,
 				env: {
 					AUTOM4TE: autom4te,
@@ -111,7 +112,6 @@ export let build = tg.target(async (arg?: Arg) => {
 						":",
 					),
 				},
-				sdk: arg?.sdk,
 			},
 		);
 
@@ -125,6 +125,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		let wrappedScript = await std.wrap(
 			tg.File.expect(await autoconf.get(`bin/${script}`)),
 			{
+				buildToolchain: env_,
 				env: {
 					trailer_m4: tg.Mutation.setIfUnset(
 						tg`${autoconf}/share/autoconf/autoconf/trailer.m4`,
@@ -140,7 +141,6 @@ export let build = tg.target(async (arg?: Arg) => {
 					),
 					AUTOM4TE_CFG: tg`${autoconf}/share/autoconf/autom4te.cfg`,
 				},
-				sdk: arg?.sdk,
 			},
 		);
 

--- a/packages/std/sdk/dependencies/autoconf.tg.ts
+++ b/packages/std/sdk/dependencies/autoconf.tg.ts
@@ -186,6 +186,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["autoconf"],
 		metadata,

--- a/packages/std/sdk/dependencies/automake.tg.ts
+++ b/packages/std/sdk/dependencies/automake.tg.ts
@@ -124,6 +124,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["automake"],
 		metadata,

--- a/packages/std/sdk/dependencies/automake.tg.ts
+++ b/packages/std/sdk/dependencies/automake.tg.ts
@@ -72,6 +72,7 @@ export let build = tg.target(async (arg?: Arg) => {
 			await automake.get(`bin/${script}-${version}`),
 		);
 		let wrappedScript = std.wrap(executable, {
+			buildToolchain: env_,
 			interpreter: perlInterpreter,
 			env: {
 				PERL5LIB: tg.Mutation.templateAppend(
@@ -96,7 +97,6 @@ export let build = tg.target(async (arg?: Arg) => {
 				),
 				AUTOMAKE_UNINSTALLED: "true",
 			},
-			sdk: arg?.sdk,
 		});
 
 		binDirectory = tg.directory(binDirectory, {

--- a/packages/std/sdk/dependencies/automake.tg.ts
+++ b/packages/std/sdk/dependencies/automake.tg.ts
@@ -71,8 +71,9 @@ export let build = tg.target(async (arg?: Arg) => {
 		let executable = tg.File.expect(
 			await automake.get(`bin/${script}-${version}`),
 		);
-		let wrappedScript = std.wrap(executable, {
+		let wrappedScript = std.wrap({
 			buildToolchain: env_,
+			executable,
 			interpreter: perlInterpreter,
 			env: {
 				PERL5LIB: tg.Mutation.templateAppend(

--- a/packages/std/sdk/dependencies/bc.tg.ts
+++ b/packages/std/sdk/dependencies/bc.tg.ts
@@ -80,6 +80,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["bc"],
 		metadata,

--- a/packages/std/sdk/dependencies/bison.tg.ts
+++ b/packages/std/sdk/dependencies/bison.tg.ts
@@ -65,6 +65,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["bison"],
 		metadata,

--- a/packages/std/sdk/dependencies/file.tg.ts
+++ b/packages/std/sdk/dependencies/file.tg.ts
@@ -94,6 +94,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["file"],
 		metadata,

--- a/packages/std/sdk/dependencies/file.tg.ts
+++ b/packages/std/sdk/dependencies/file.tg.ts
@@ -72,8 +72,9 @@ export let build = tg.target(async (arg?: Arg) => {
 		"magic.mgc": tg.File.expect(await output.get("share/misc/magic.mgc")),
 	});
 	let rawFile = tg.File.expect(await output.get("bin/file"));
-	let wrappedFile = std.wrap(rawFile, {
+	let wrappedFile = std.wrap({
 		buildToolchain: env_,
+		executable: rawFile,
 		env: {
 			MAGIC: tg.Mutation.setIfUnset(tg`${magic}/magic.mgc`),
 		},

--- a/packages/std/sdk/dependencies/file.tg.ts
+++ b/packages/std/sdk/dependencies/file.tg.ts
@@ -73,11 +73,11 @@ export let build = tg.target(async (arg?: Arg) => {
 	});
 	let rawFile = tg.File.expect(await output.get("bin/file"));
 	let wrappedFile = std.wrap(rawFile, {
+		buildToolchain: env_,
 		env: {
 			MAGIC: tg.Mutation.setIfUnset(tg`${magic}/magic.mgc`),
 		},
 		libraryPaths: [tg.Directory.expect(await output.get("lib"))],
-		sdk: arg?.sdk,
 	});
 	return tg.directory(output, {
 		"bin/file": wrappedFile,

--- a/packages/std/sdk/dependencies/flex.tg.ts
+++ b/packages/std/sdk/dependencies/flex.tg.ts
@@ -68,6 +68,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["flex"],
 		metadata,

--- a/packages/std/sdk/dependencies/gperf.tg.ts
+++ b/packages/std/sdk/dependencies/gperf.tg.ts
@@ -56,6 +56,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["gperf"],
 		metadata,

--- a/packages/std/sdk/dependencies/help2man.tg.ts
+++ b/packages/std/sdk/dependencies/help2man.tg.ts
@@ -54,8 +54,8 @@ export let build = tg.target(async (arg?: Arg) => {
 	);
 
 	let wrappedScript = std.wrap(tg.symlink({ artifact, path: "bin/help2man" }), {
+		buildToolchain: env_,
 		interpreter: interpreter,
-		sdk: arg?.sdk,
 	});
 
 	return tg.directory({

--- a/packages/std/sdk/dependencies/help2man.tg.ts
+++ b/packages/std/sdk/dependencies/help2man.tg.ts
@@ -73,6 +73,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["help2man"],
 		metadata,

--- a/packages/std/sdk/dependencies/help2man.tg.ts
+++ b/packages/std/sdk/dependencies/help2man.tg.ts
@@ -53,8 +53,9 @@ export let build = tg.target(async (arg?: Arg) => {
 		autotools,
 	);
 
-	let wrappedScript = std.wrap(tg.symlink({ artifact, path: "bin/help2man" }), {
+	let wrappedScript = std.wrap({
 		buildToolchain: env_,
+		executable: tg.symlink({ artifact, path: "bin/help2man" }),
 		interpreter: interpreter,
 	});
 

--- a/packages/std/sdk/dependencies/libffi.tg.ts
+++ b/packages/std/sdk/dependencies/libffi.tg.ts
@@ -68,6 +68,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		libs: ["ffi"],
 	});

--- a/packages/std/sdk/dependencies/libxcrypt.tg.ts
+++ b/packages/std/sdk/dependencies/libxcrypt.tg.ts
@@ -69,6 +69,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		libs: ["crypt"],
 	});

--- a/packages/std/sdk/dependencies/m4.tg.ts
+++ b/packages/std/sdk/dependencies/m4.tg.ts
@@ -57,6 +57,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["m4"],
 		metadata,

--- a/packages/std/sdk/dependencies/ncurses.tg.ts
+++ b/packages/std/sdk/dependencies/ncurses.tg.ts
@@ -85,6 +85,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		libs: ["ncursesw", "formw", "menuw", "panelw"],
 		metadata,

--- a/packages/std/sdk/dependencies/perl.tg.ts
+++ b/packages/std/sdk/dependencies/perl.tg.ts
@@ -97,6 +97,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		},
 		autotools,
 	);
+	console.log("perlArtifact", await perlArtifact.id());
 
 	let wrappedPerl = await std.wrap({
 		buildToolchain: env_,
@@ -109,6 +110,7 @@ export let build = tg.target(async (arg?: Arg) => {
 			),
 		},
 	});
+	console.log("wrappedPerl", await wrappedPerl.id());
 
 	let scripts = [];
 	let binDir = tg.Directory.expect(await perlArtifact.get("bin"));
@@ -131,12 +133,14 @@ export let build = tg.target(async (arg?: Arg) => {
 		);
 
 		// Wrap it.
-		let wrappedScript = std.wrap({
+		console.log("wrapping", script, await scriptArtifact.id());
+		let wrappedScript = await std.wrap({
 			buildToolchain: env_,
 			executable: scriptArtifact,
 			identity: "interpreter",
 			interpreter: wrappedPerl,
 		});
+		console.log("wrappedScript", await wrappedScript.id());
 
 		// Replace in the original artifact.
 		perlArtifact = await tg.directory(perlArtifact, {

--- a/packages/std/sdk/dependencies/perl.tg.ts
+++ b/packages/std/sdk/dependencies/perl.tg.ts
@@ -101,6 +101,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let wrappedPerl = await std.wrap(
 		tg.symlink({ artifact: perlArtifact, path: "bin/perl" }),
 		{
+			buildToolchain: env_,
 			identity: "wrapper",
 			env: {
 				PERL5LIB: tg.Mutation.templateAppend(
@@ -108,7 +109,6 @@ export let build = tg.target(async (arg?: Arg) => {
 					":",
 				),
 			},
-			sdk: rest.sdk,
 		},
 	);
 
@@ -134,9 +134,9 @@ export let build = tg.target(async (arg?: Arg) => {
 
 		// Wrap it.
 		let wrappedScript = std.wrap(scriptArtifact, {
+			buildToolchain: env_,
 			identity: "interpreter",
 			interpreter: wrappedPerl,
-			sdk: rest.sdk,
 		});
 
 		// Replace in the original artifact.

--- a/packages/std/sdk/dependencies/perl.tg.ts
+++ b/packages/std/sdk/dependencies/perl.tg.ts
@@ -97,14 +97,11 @@ export let build = tg.target(async (arg?: Arg) => {
 		},
 		autotools,
 	);
-	console.log("perlArtifact", await perlArtifact.id());
 
 	let unwrappedPerl = tg.File.expect(await perlArtifact.get("bin/perl"));
 
-	let wrappedPerl = await std.wrap({
+	let wrappedPerl = await std.wrap(unwrappedPerl, {
 		buildToolchain: env_,
-		executable: unwrappedPerl,
-		identity: "wrapper",
 		env: {
 			PERL5LIB: tg.Mutation.templatePrepend(
 				tg`${perlArtifact}/lib/perl5/${metadata.version}`,
@@ -112,7 +109,6 @@ export let build = tg.target(async (arg?: Arg) => {
 			),
 		},
 	});
-	console.log("wrappedPerl", await wrappedPerl.id());
 
 	let scripts = [];
 	let binDir = tg.Directory.expect(await perlArtifact.get("bin"));
@@ -135,14 +131,11 @@ export let build = tg.target(async (arg?: Arg) => {
 		);
 
 		// Wrap it.
-		console.log("wrapping", script, await scriptArtifact.id());
 		let wrappedScript = await std.wrap({
 			buildToolchain: env_,
 			executable: scriptArtifact,
-			identity: "interpreter",
 			interpreter: wrappedPerl,
 		});
-		console.log("wrappedScript", await wrappedScript.id());
 
 		// Replace in the original artifact.
 		perlArtifact = await tg.directory(perlArtifact, {
@@ -162,7 +155,6 @@ export let test = tg.target(async () => {
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = await build({ host, bootstrapMode, env: sdk });
-	console.log("directory", await directory.id());
 	await std.assert.pkg({
 		bootstrapMode,
 		directory,

--- a/packages/std/sdk/dependencies/perl.tg.ts
+++ b/packages/std/sdk/dependencies/perl.tg.ts
@@ -99,9 +99,11 @@ export let build = tg.target(async (arg?: Arg) => {
 	);
 	console.log("perlArtifact", await perlArtifact.id());
 
+	let unwrappedPerl = tg.File.expect(await perlArtifact.get("bin/perl"));
+
 	let wrappedPerl = await std.wrap({
 		buildToolchain: env_,
-		executable: tg.symlink({ artifact: perlArtifact, path: "bin/perl" }),
+		executable: unwrappedPerl,
 		identity: "wrapper",
 		env: {
 			PERL5LIB: tg.Mutation.templateAppend(
@@ -159,7 +161,8 @@ export let test = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await tg.Triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
-	let directory = build({ host, bootstrapMode, env: sdk });
+	let directory = await build({ host, bootstrapMode, env: sdk });
+	console.log("directory", await directory.id());
 	await std.assert.pkg({
 		directory,
 		binaries: ["perl"],

--- a/packages/std/sdk/dependencies/perl.tg.ts
+++ b/packages/std/sdk/dependencies/perl.tg.ts
@@ -164,6 +164,7 @@ export let test = tg.target(async () => {
 	let directory = await build({ host, bootstrapMode, env: sdk });
 	console.log("directory", await directory.id());
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["perl"],
 		metadata,

--- a/packages/std/sdk/dependencies/perl.tg.ts
+++ b/packages/std/sdk/dependencies/perl.tg.ts
@@ -106,7 +106,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		executable: unwrappedPerl,
 		identity: "wrapper",
 		env: {
-			PERL5LIB: tg.Mutation.templateAppend(
+			PERL5LIB: tg.Mutation.templatePrepend(
 				tg`${perlArtifact}/lib/perl5/${metadata.version}`,
 				":",
 			),

--- a/packages/std/sdk/dependencies/perl.tg.ts
+++ b/packages/std/sdk/dependencies/perl.tg.ts
@@ -98,19 +98,17 @@ export let build = tg.target(async (arg?: Arg) => {
 		autotools,
 	);
 
-	let wrappedPerl = await std.wrap(
-		tg.symlink({ artifact: perlArtifact, path: "bin/perl" }),
-		{
-			buildToolchain: env_,
-			identity: "wrapper",
-			env: {
-				PERL5LIB: tg.Mutation.templateAppend(
-					tg`${perlArtifact}/lib/perl5/${metadata.version}`,
-					":",
-				),
-			},
+	let wrappedPerl = await std.wrap({
+		buildToolchain: env_,
+		executable: tg.symlink({ artifact: perlArtifact, path: "bin/perl" }),
+		identity: "wrapper",
+		env: {
+			PERL5LIB: tg.Mutation.templateAppend(
+				tg`${perlArtifact}/lib/perl5/${metadata.version}`,
+				":",
+			),
 		},
-	);
+	});
 
 	let scripts = [];
 	let binDir = tg.Directory.expect(await perlArtifact.get("bin"));
@@ -133,8 +131,9 @@ export let build = tg.target(async (arg?: Arg) => {
 		);
 
 		// Wrap it.
-		let wrappedScript = std.wrap(scriptArtifact, {
+		let wrappedScript = std.wrap({
 			buildToolchain: env_,
+			executable: scriptArtifact,
 			identity: "interpreter",
 			interpreter: wrappedPerl,
 		});

--- a/packages/std/sdk/dependencies/pkg_config.tg.ts
+++ b/packages/std/sdk/dependencies/pkg_config.tg.ts
@@ -119,6 +119,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["pkg-config"],
 		metadata,

--- a/packages/std/sdk/dependencies/pkg_config.tg.ts
+++ b/packages/std/sdk/dependencies/pkg_config.tg.ts
@@ -72,17 +72,15 @@ export let build = tg.target(async (arg?: Arg) => {
 	);
 
 	// Bundle the resulting binary with the `--define-prefix` flag.
-	let wrappedBin = std.wrap(
-		tg.symlink({
+	let wrappedBin = std.wrap({
+		args: ["--define-prefix"],
+		executable: tg.symlink({
 			artifact: pkgConfigBuild,
 			path: "bin/pkg-config",
 		}),
-		{
-			args: ["--define-prefix"],
-			buildToolchain: env_,
-			libraryPaths: additionalLibDirs,
-		},
-	);
+		buildToolchain: env_,
+		libraryPaths: additionalLibDirs,
+	});
 
 	return tg.directory(pkgConfigBuild, {
 		["bin/pkg-config"]: wrappedBin,

--- a/packages/std/sdk/dependencies/pkg_config.tg.ts
+++ b/packages/std/sdk/dependencies/pkg_config.tg.ts
@@ -11,11 +11,6 @@ export let metadata = {
 export let source = tg.target(async () => {
 	let { name, version } = metadata;
 	let unpackFormat = ".tar.gz" as const;
-	let packageArchive = std.download.packageArchive({
-		name,
-		version,
-		unpackFormat,
-	});
 	// let url = `https://pkgconfig.freedesktop.org/releases/${packageArchive}`;
 	// let url = `http://fresh-center.net/linux/misc/pkg-config-0.29.2.tar.gz`;
 	let url =
@@ -84,8 +79,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		}),
 		{
 			args: ["--define-prefix"],
+			buildToolchain: env_,
 			libraryPaths: additionalLibDirs,
-			sdk: arg?.sdk,
 		},
 	);
 

--- a/packages/std/sdk/dependencies/python.tg.ts
+++ b/packages/std/sdk/dependencies/python.tg.ts
@@ -118,6 +118,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["python3"],
 		metadata,

--- a/packages/std/sdk/dependencies/texinfo.tg.ts
+++ b/packages/std/sdk/dependencies/texinfo.tg.ts
@@ -60,6 +60,7 @@ export let test = tg.target(async () => {
 		env: [sdk, { WATERMARK: "1" }],
 	});
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["makeinfo", "texi2any"],
 		metadata,

--- a/packages/std/sdk/dependencies/zlib.tg.ts
+++ b/packages/std/sdk/dependencies/zlib.tg.ts
@@ -62,6 +62,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		libs: ["z"],
 	});

--- a/packages/std/sdk/dependencies/zstd.tg.ts
+++ b/packages/std/sdk/dependencies/zstd.tg.ts
@@ -68,6 +68,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		libs: ["zstd"],
 	});

--- a/packages/std/sdk/proxy.tg.ts
+++ b/packages/std/sdk/proxy.tg.ts
@@ -73,7 +73,6 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 	let cxx: tg.File | tg.Symlink = cxx_;
 
 	if (proxyLinker) {
-		let buildString = tg.Triple.toString(build);
 		let hostString = tg.Triple.toString(host);
 
 		let isCross = !tg.Triple.eq(build, host);

--- a/packages/std/sdk/proxy.tg.ts
+++ b/packages/std/sdk/proxy.tg.ts
@@ -7,7 +7,13 @@ import * as llvmToolchain from "./llvm.tg.ts";
 
 /** This module provides the Tangram proxy tools, which are used in conjunction with compilers and linkers to produce Tangram-ready artifacts. */
 
-export type Arg = std.sdk.BuildEnvArg & {
+export type Arg = {
+	/** Relax checks of build toolchain, assumes it's the bootstrap. */
+	bootstrapMode?: boolean;
+	/** The build environment to use to produce components. */
+	buildToolchain: std.env.Arg;
+	/** The target triple of the build machine. */
+	build?: tg.Triple.Arg;
 	/** Should the compiler get proxied? Default: false. */
 	compiler?: boolean;
 	/** Should we expect an LLVM toolchain? */
@@ -17,7 +23,7 @@ export type Arg = std.sdk.BuildEnvArg & {
 	/** Optional linker to use. If omitted, the linker provided by the toolchain matching the requested arguments will be used. */
 	linkerExe?: tg.File | tg.Symlink;
 	/** The triple of the computer the toolchain being proxied produces binaries for. */
-	target?: tg.Triple.Arg;
+	host?: tg.Triple.Arg;
 };
 
 /** Add a proxy to an env that provides a toolchain. */
@@ -26,9 +32,11 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 		throw new Error("Cannot proxy an undefined env");
 	}
 
+	let bootstrapMode = arg.bootstrapMode ?? false;
 	let proxyCompiler = arg.compiler ?? false;
 	let proxyLinker = arg.linker ?? true;
 	let llvm = arg.llvm ?? false;
+	let buildToolchain = arg.buildToolchain;
 
 	if (!proxyCompiler && !proxyLinker) {
 		return;
@@ -42,45 +50,49 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 
 	let dirs = [];
 
+	let host = arg.host ? tg.triple(arg.host) : await tg.Triple.host();
+	let build = arg.build ? tg.triple(arg.build) : host;
+
 	let {
 		cc: cc_,
 		cxx: cxx_,
 		fortran,
 		directory,
 		flavor,
-		host,
 		ld,
 		ldso,
-		target,
 	} = await std.sdk.toolchainComponents({
-		env: arg.env,
+		bootstrapMode,
+		env: buildToolchain,
 		llvm,
-		target: arg.target,
+		host,
+		target: host,
 	});
 
 	let cc: tg.File | tg.Symlink = cc_;
 	let cxx: tg.File | tg.Symlink = cxx_;
 
 	if (proxyLinker) {
+		let buildString = tg.Triple.toString(build);
 		let hostString = tg.Triple.toString(host);
-		let targetString = tg.Triple.toString(target);
 
-		let isCross = !tg.Triple.eq(host, target);
-		let targetPrefix = isCross ? `${targetString}-` : ``;
+		let isCross = !tg.Triple.eq(build, host);
+		let prefix = isCross ? `${hostString}-` : ``;
 
 		// Construct the ld proxy.
 		let ldProxyArtifact = await ldProxy({
-			buildEnv: arg.env,
+			buildToolchain,
+			build,
 			linker: arg.linkerExe ?? (llvm ? await tg`${directory}/bin/ld.lld` : ld),
 			interpreter: ldso,
 			host,
-			target,
-			sdk: arg.sdk,
 		});
 
 		let linkerName = "ld";
 		if (llvm) {
-			cc = tg.File.expect(await directory.get(`bin/clang-${llvmToolchain.llvmMajorVersion()}`));
+			cc = tg.File.expect(
+				await directory.get(`bin/clang-${llvmToolchain.llvmMajorVersion()}`),
+			);
 			cxx = cc;
 		}
 		let ldProxyDir = tg.directory({
@@ -96,41 +108,41 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 		switch (flavor) {
 			case "gcc": {
 				let { ccArgs, cxxArgs, fortranArgs } = await gcc.wrapArgs({
-					host,
-					target,
+					host: build,
+					target: host,
 					toolchainDir: directory,
 				});
 				wrappedCC = await std.wrap(cc, {
-					identity: "wrapper",
 					args: [tg`-B${ldProxyDir}`, ...(ccArgs ?? [])],
-					sdk: arg.sdk,
+					buildToolchain,
+					identity: "wrapper",
 				});
 				wrappedCXX = await std.wrap(cxx, {
-					identity: "wrapper",
 					args: [tg`-B${ldProxyDir}`, ...(cxxArgs ?? [])],
-					sdk: arg.sdk,
+					buildToolchain,
+					identity: "wrapper",
 				});
 				if (fortran) {
 					wrappedGFortran = await std.wrap(fortran, {
-						identity: "wrapper",
 						args: [tg`-B${ldProxyDir}`, ...(fortranArgs ?? [])],
-						sdk: arg.sdk,
+						buildToolchain,
+						identity: "wrapper",
 					});
 				}
 
 				if (isCross) {
 					binDir = tg.directory({
 						bin: {
-							[`${targetString}-cc`]: tg.symlink(`${targetPrefix}gcc`),
-							[`${targetString}-c++`]: tg.symlink(`${targetPrefix}g++`),
-							[`${targetString}-gcc`]: wrappedCC,
-							[`${targetString}-g++`]: wrappedCXX,
+							[`${hostString}-cc`]: tg.symlink(`${prefix}gcc`),
+							[`${hostString}-c++`]: tg.symlink(`${prefix}g++`),
+							[`${hostString}-gcc`]: wrappedCC,
+							[`${hostString}-g++`]: wrappedCXX,
 						},
 					});
 					if (fortran) {
 						binDir = tg.directory(binDir, {
 							bin: {
-								[`${targetString}-gfortran`]: wrappedGFortran,
+								[`${hostString}-gfortran`]: wrappedGFortran,
 							},
 						});
 					}
@@ -160,19 +172,19 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 			}
 			case "llvm": {
 				let { clangArgs, clangxxArgs, env } = await llvmToolchain.wrapArgs({
-					host,
-					target,
+					host: build,
+					target: host,
 					toolchainDir: directory,
 				});
 				wrappedCC = std.wrap(cc, {
 					args: [tg`-B${ldProxyDir}`, ...clangArgs],
+					buildToolchain,
 					env,
-					sdk: arg.sdk,
 				});
 				wrappedCXX = std.wrap(cxx, {
 					args: [tg`-B${ldProxyDir}`, ...clangxxArgs],
+					buildToolchain,
 					env,
-					sdk: arg.sdk,
 				});
 				binDir = tg.directory({
 					bin: {
@@ -192,9 +204,9 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 	if (proxyCompiler) {
 		dirs.push(
 			ccProxy({
+				build,
+				buildToolchain,
 				host,
-				target,
-				sdk: arg.sdk,
 			}),
 		);
 	}
@@ -204,62 +216,68 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 
 export default env;
 
-type CcProxyArg = std.sdk.BuildEnvArg & {
-	target?: tg.Triple.Arg;
+type CcProxyArg = {
+	buildToolchain: std.env.Arg;
+	build?: tg.Triple.Arg;
+	host?: tg.Triple.Arg;
 };
 
 export let ccProxy = async (arg: CcProxyArg) => {
-	let host = await tg.Triple.host(arg.host);
-	let target = arg.target ? tg.triple(arg.target) : host;
+	let host = arg.host ? tg.triple(arg.host) : await tg.Triple.host();
+	let build = arg.build ? tg.triple(arg.build) : host;
+	let buildToolchain = arg.buildToolchain;
 	let tgcc = workspace.tgcc({
-		sdk: arg.sdk,
-		host: target,
+		buildToolchain,
+		build,
+		host,
 	});
 
-	let isCross = !tg.Triple.eq(host, target);
-	let targetPrefix = isCross ? `${tg.Triple.toString(target)}-` : ``;
+	let isCross = !tg.Triple.eq(build, host);
+	let prefix = isCross ? `${tg.Triple.toString(host)}-` : ``;
 
 	return tg.directory({
-		[`bin/${targetPrefix}cc`]: tgcc,
-		[`bin/${targetPrefix}gcc`]: tgcc,
-		[`bin/${targetPrefix}c++`]: tgcc,
-		[`bin/${targetPrefix}g++`]: tgcc,
+		[`bin/${prefix}cc`]: tgcc,
+		[`bin/${prefix}gcc`]: tgcc,
+		[`bin/${prefix}c++`]: tgcc,
+		[`bin/${prefix}g++`]: tgcc,
 	});
 };
 
 type LdProxyArg = {
-	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
-	buildEnv?: std.env.Arg;
-	linker: tg.File | tg.Symlink | tg.Template;
+	buildToolchain: std.env.Arg;
+	build?: tg.Triple.Arg;
 	interpreter?: tg.File;
 	interpreterArgs?: Array<tg.Template.Arg>;
-	host: tg.Triple.Arg;
-	target?: tg.Triple.Arg;
+	linker: tg.File | tg.Symlink | tg.Template;
+	host?: tg.Triple.Arg;
 };
 
 export let ldProxy = async (arg: LdProxyArg) => {
 	// Prepare the Tangram tools.
-	let host = tg.triple(arg.host);
-	let target = tg.triple(arg.target ?? host);
+	let host = arg.host ? tg.triple(arg.host) : await tg.Triple.host();
+	let build = arg.build ? tg.triple(arg.build) : host;
+	let buildToolchain = arg.buildToolchain;
 
 	// Obtain wrapper components.
 	let injectionLibrary = await injection({
-		env: arg.buildEnv,
-		host: target,
-		sdk: arg.sdk,
+		buildToolchain,
+		build,
+		host,
 	});
 	let tgld = await workspace.tgld({
-		host: target,
-		sdk: arg.sdk,
+		buildToolchain,
+		build,
+		host,
 	});
 	let wrapper = await workspace.wrapper({
-		host: target,
-		sdk: arg.sdk,
+		buildToolchain,
+		build,
+		host,
 	});
 
 	// Create the linker proxy.
 	let output = await std.wrap(tgld, {
-		identity: "wrapper",
+		buildToolchain,
 		env: {
 			TANGRAM_LINKER_COMMAND_PATH: tg.Mutation.setIfUnset<
 				tg.File | tg.Symlink | tg.Template
@@ -273,7 +291,7 @@ export let ldProxy = async (arg: LdProxyArg) => {
 			),
 			TANGRAM_LINKER_WRAPPER_PATH: tg.Mutation.setIfUnset(wrapper),
 		},
-		sdk: arg.sdk,
+		identity: "wrapper",
 	});
 
 	return output;

--- a/packages/std/tangram.tg.ts
+++ b/packages/std/tangram.tg.ts
@@ -90,7 +90,9 @@ export let testBootstrapMusl = tg.target(async () => {
 
 import * as utils from "./utils.tg.ts";
 export let testUtilsPrerequisites = tg.target(async () => {
-	return await utils.prerequisites();
+	return await utils.prerequisites({
+		host: bootstrap.toolchainTriple(await tg.Triple.host()),
+	});
 });
 
 export let testUtilsBash = tg.target(async () => {

--- a/packages/std/utils.tg.ts
+++ b/packages/std/utils.tg.ts
@@ -89,8 +89,6 @@ export let prerequisites = tg.target(async (arg?: tg.Triple.HostArg) => {
 	let makeArtifact = await bootstrap.make.build({ host });
 	components.push(makeArtifact);
 
-	console.log("prereq a");
-
 	// Add patched GNU coreutils.
 	let bootstrapMode = true;
 	let coreutilsArtifact = await coreutils({
@@ -100,8 +98,6 @@ export let prerequisites = tg.target(async (arg?: tg.Triple.HostArg) => {
 		usePrerequisites: false,
 	});
 	components.push(coreutilsArtifact);
-
-	console.log("prereq b");
 
 	// On Linux, build musl and use it for the runtime libc.
 	if (host.os === "linux" && host.environment === "musl") {

--- a/packages/std/utils.tg.ts
+++ b/packages/std/utils.tg.ts
@@ -89,6 +89,8 @@ export let prerequisites = tg.target(async (arg?: tg.Triple.HostArg) => {
 	let makeArtifact = await bootstrap.make.build({ host });
 	components.push(makeArtifact);
 
+	console.log("prereq a");
+
 	// Add patched GNU coreutils.
 	let bootstrapMode = true;
 	let coreutilsArtifact = await coreutils({
@@ -98,6 +100,8 @@ export let prerequisites = tg.target(async (arg?: tg.Triple.HostArg) => {
 		usePrerequisites: false,
 	});
 	components.push(coreutilsArtifact);
+
+	console.log("prereq b");
 
 	// On Linux, build musl and use it for the runtime libc.
 	if (host.os === "linux" && host.environment === "musl") {

--- a/packages/std/utils/attr.tg.ts
+++ b/packages/std/utils/attr.tg.ts
@@ -93,7 +93,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	for (let bin of bins) {
 		let unwrappedBin = tg.File.expect(await output.get(`bin/${bin}`));
 		let wrappedBin = std.wrap(unwrappedBin, {
-			buildToolchain: bootstrapMode ? env : undefined,
+			buildToolchain: bootstrapMode ? env_ : undefined,
 			libraryPaths: [tg.symlink(tg`${output}/lib`)],
 		});
 		output = await tg.directory(output, { [`bin/${bin}`]: wrappedBin });

--- a/packages/std/utils/attr.tg.ts
+++ b/packages/std/utils/attr.tg.ts
@@ -93,8 +93,8 @@ export let build = tg.target(async (arg?: Arg) => {
 	for (let bin of bins) {
 		let unwrappedBin = tg.File.expect(await output.get(`bin/${bin}`));
 		let wrappedBin = std.wrap(unwrappedBin, {
+			buildToolchain: bootstrapMode ? env : undefined,
 			libraryPaths: [tg.symlink(tg`${output}/lib`)],
-			sdk: arg?.sdk,
 		});
 		output = await tg.directory(output, { [`bin/${bin}`]: wrappedBin });
 	}

--- a/packages/std/utils/attr.tg.ts
+++ b/packages/std/utils/attr.tg.ts
@@ -120,6 +120,7 @@ export let test = tg.target(async () => {
 	let binaries = ["attr", "getfattr", "setfattr"].map(binTest);
 
 	await std.assert.pkg({
+		bootstrapMode,
 		binaries,
 		directory,
 		libs: ["attr"],

--- a/packages/std/utils/attr.tg.ts
+++ b/packages/std/utils/attr.tg.ts
@@ -92,8 +92,9 @@ export let build = tg.target(async (arg?: Arg) => {
 	let bins = ["attr", "getfattr", "setfattr"];
 	for (let bin of bins) {
 		let unwrappedBin = tg.File.expect(await output.get(`bin/${bin}`));
-		let wrappedBin = std.wrap(unwrappedBin, {
+		let wrappedBin = std.wrap({
 			buildToolchain: bootstrapMode ? env_ : undefined,
+			executable: unwrappedBin,
 			libraryPaths: [tg.symlink(tg`${output}/lib`)],
 		});
 		output = await tg.directory(output, { [`bin/${bin}`]: wrappedBin });

--- a/packages/std/utils/bash.tg.ts
+++ b/packages/std/utils/bash.tg.ts
@@ -118,6 +118,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["bash"],
 		metadata,

--- a/packages/std/utils/bzip2.tg.ts
+++ b/packages/std/utils/bzip2.tg.ts
@@ -96,6 +96,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: [{ name: "bzip2", testArgs: ["--help"] }],
 		libs: ["bz2"],

--- a/packages/std/utils/coreutils.tg.ts
+++ b/packages/std/utils/coreutils.tg.ts
@@ -169,6 +169,7 @@ export let test = tg.target(async () => {
 	let coreutils = await build({ host, bootstrapMode, env: sdk });
 
 	await std.assert.pkg({
+		bootstrapMode,
 		binaries: ["cp", "mkdir", "mv", "ls", "rm"],
 		directory: coreutils,
 		metadata,

--- a/packages/std/utils/coreutils.tg.ts
+++ b/packages/std/utils/coreutils.tg.ts
@@ -73,6 +73,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		dependencies.push(prerequisites({ host }));
 	}
 
+	console.log("coreutils a");
+
 	let attrArtifact;
 	if (os === "linux") {
 		attrArtifact = attr({
@@ -97,6 +99,7 @@ export let build = tg.target(async (arg?: Arg) => {
 			}),
 		);
 	}
+	console.log("coreutils b");
 	let env = [env_, ...dependencies];
 	if (staticBuild) {
 		env.push({ CC: "gcc -static" });
@@ -104,6 +107,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let configure = {
 		args: [
+			"--disable-acl",
 			"--disable-dependency-tracking",
 			"--disable-libcap",
 			"--disable-nls",
@@ -113,7 +117,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		],
 	};
 
-	let output = buildUtil(
+	let output = await buildUtil(
 		{
 			...rest,
 			...tg.Triple.rotate({ build, host }),
@@ -125,10 +129,11 @@ export let build = tg.target(async (arg?: Arg) => {
 		},
 		autotools,
 	);
+	console.log("coreutils c");
 
 	// On macOS, replace `install` with the Apple Open Source version that correctly handles xattrs.
 	if (os === "darwin") {
-		output = tg.directory(
+		output = await tg.directory(
 			output,
 			{ "bin/install": undefined },
 			macOsXattrCmds(arg),

--- a/packages/std/utils/coreutils.tg.ts
+++ b/packages/std/utils/coreutils.tg.ts
@@ -73,8 +73,6 @@ export let build = tg.target(async (arg?: Arg) => {
 		dependencies.push(prerequisites({ host }));
 	}
 
-	console.log("coreutils a");
-
 	let attrArtifact;
 	if (os === "linux") {
 		attrArtifact = attr({
@@ -99,7 +97,6 @@ export let build = tg.target(async (arg?: Arg) => {
 			}),
 		);
 	}
-	console.log("coreutils b");
 	let env = [env_, ...dependencies];
 	if (staticBuild) {
 		env.push({ CC: "gcc -static" });
@@ -129,7 +126,6 @@ export let build = tg.target(async (arg?: Arg) => {
 		},
 		autotools,
 	);
-	console.log("coreutils c");
 
 	// On macOS, replace `install` with the Apple Open Source version that correctly handles xattrs.
 	if (os === "darwin") {

--- a/packages/std/utils/diffutils.tg.ts
+++ b/packages/std/utils/diffutils.tg.ts
@@ -67,6 +67,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = await build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["cmp", "diff"],
 		metadata,

--- a/packages/std/utils/findutils.tg.ts
+++ b/packages/std/utils/findutils.tg.ts
@@ -84,6 +84,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["find", "xargs"],
 		metadata,

--- a/packages/std/utils/gawk.tg.ts
+++ b/packages/std/utils/gawk.tg.ts
@@ -67,6 +67,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["gawk"],
 		metadata,

--- a/packages/std/utils/grep.tg.ts
+++ b/packages/std/utils/grep.tg.ts
@@ -72,6 +72,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["grep"],
 		metadata,

--- a/packages/std/utils/gzip.tg.ts
+++ b/packages/std/utils/gzip.tg.ts
@@ -80,6 +80,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["gzip"],
 		metadata,

--- a/packages/std/utils/libiconv.tg.ts
+++ b/packages/std/utils/libiconv.tg.ts
@@ -67,6 +67,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ bootstrapMode, host });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		libs: [{ name: "iconv", staticlib: false }],
 	});

--- a/packages/std/utils/make.tg.ts
+++ b/packages/std/utils/make.tg.ts
@@ -63,6 +63,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let makeArtifact = await build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory: makeArtifact,
 		binaries: ["make"],
 		metadata,

--- a/packages/std/utils/patch.tg.ts
+++ b/packages/std/utils/patch.tg.ts
@@ -63,6 +63,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["patch"],
 		metadata,

--- a/packages/std/utils/sed.tg.ts
+++ b/packages/std/utils/sed.tg.ts
@@ -66,6 +66,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["sed"],
 		metadata,

--- a/packages/std/utils/tar.tg.ts
+++ b/packages/std/utils/tar.tg.ts
@@ -80,6 +80,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory,
 		binaries: ["tar"],
 		metadata,

--- a/packages/std/utils/xz.tg.ts
+++ b/packages/std/utils/xz.tg.ts
@@ -80,8 +80,9 @@ export let build = tg.target(async (arg?: Arg) => {
 	let libDir = tg.Directory.expect(await output.get("lib"));
 	for (let bin of bins) {
 		let unwrappedBin = tg.File.expect(await output.get(`bin/${bin}`));
-		let wrappedBin = std.wrap(unwrappedBin, {
+		let wrappedBin = std.wrap({
 		 	buildToolchain: bootstrapMode ? env_ : undefined,
+			executable: unwrappedBin,
 			libraryPaths: [libDir],
 		});
 		output = await tg.directory(output, { [`bin/${bin}`]: wrappedBin });

--- a/packages/std/utils/xz.tg.ts
+++ b/packages/std/utils/xz.tg.ts
@@ -81,8 +81,8 @@ export let build = tg.target(async (arg?: Arg) => {
 	for (let bin of bins) {
 		let unwrappedBin = tg.File.expect(await output.get(`bin/${bin}`));
 		let wrappedBin = std.wrap(unwrappedBin, {
+		 	buildToolchain: bootstrapMode ? env : undefined,
 			libraryPaths: [libDir],
-			sdk: arg?.sdk,
 		});
 		output = await tg.directory(output, { [`bin/${bin}`]: wrappedBin });
 	}

--- a/packages/std/utils/xz.tg.ts
+++ b/packages/std/utils/xz.tg.ts
@@ -98,6 +98,7 @@ export let test = tg.target(async () => {
 	let sdk = std.sdk({ host, bootstrapMode });
 	let xzArtifact = build({ host, bootstrapMode, env: sdk });
 	await std.assert.pkg({
+		bootstrapMode,
 		directory: xzArtifact,
 		binaries: ["xz"],
 		libs: ["lzma"],

--- a/packages/std/utils/xz.tg.ts
+++ b/packages/std/utils/xz.tg.ts
@@ -81,7 +81,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	for (let bin of bins) {
 		let unwrappedBin = tg.File.expect(await output.get(`bin/${bin}`));
 		let wrappedBin = std.wrap(unwrappedBin, {
-		 	buildToolchain: bootstrapMode ? env : undefined,
+		 	buildToolchain: bootstrapMode ? env_ : undefined,
 			libraryPaths: [libDir],
 		});
 		output = await tg.directory(output, { [`bin/${bin}`]: wrappedBin });

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -10,22 +10,23 @@ import * as workspace from "./wrap/workspace.tg.ts";
 /** Wrap an executable. */
 export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 	type Apply = {
+		buildToolchain: std.env.Arg;
 		host: tg.Triple.Arg;
 		identity: wrap.Identity;
-		interpreter?:
+		interpreter:
 			| tg.File
 			| tg.Symlink
 			| wrap.Interpreter
 			| wrap.Manifest.Interpreter
 			| undefined;
-		libraryPaths?: Array<string | tg.Artifact | tg.Template>;
+		libraryPaths: Array<string | tg.Artifact | tg.Template>;
 		executable: tg.File | tg.Symlink | wrap.Manifest.Executable;
 		env: Array<std.env.Arg>;
 		manifestArgs: Array<wrap.Manifest.Template>;
-		sdkArgs: Array<std.sdk.Arg>;
 	};
 
 	let {
+		buildToolchain: buildToolchain_,
 		host: host_,
 		identity: identity_,
 		libraryPaths,
@@ -33,7 +34,6 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 		executable: executable_,
 		env: env_,
 		manifestArgs,
-		sdkArgs,
 	} = await tg.Args.apply<wrap.Arg, Apply>(args, async (arg) => {
 		if (arg === undefined) {
 			return {};
@@ -88,6 +88,9 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 			};
 		} else if (isArgObject(arg)) {
 			let object: tg.MutationMap<Apply> = {};
+			if (arg.buildToolchain !== undefined) {
+				object.buildToolchain = arg.buildToolchain;
+			}
 			if (arg.executable !== undefined) {
 				if (
 					tg.Template.is(arg.executable) ||
@@ -98,8 +101,13 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 						value: await manifestTemplateFromArg(arg.executable),
 					};
 					if (!arg.interpreter) {
-						let defaultShell = await defaultShellInterpreter();
-						object.interpreter = await manifestInterpreterFromArg(defaultShell);
+						let defaultShell = await defaultShellInterpreter(
+							object.buildToolchain,
+						);
+						object.interpreter = await manifestInterpreterFromArg(
+							defaultShell,
+							object.buildToolchain,
+						);
 					}
 					if (!arg.identity) {
 						object.identity = "executable";
@@ -131,7 +139,10 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 					} else {
 						let executable = await manifestExecutableFromArg(file);
 						let manifestInterpreter =
-							await manifestInterpreterFromExecutableArg(file);
+							await manifestInterpreterFromExecutableArg(
+								file,
+								object.buildToolchain,
+							);
 						object.executable = executable;
 						if (manifestInterpreter) {
 							object.interpreter = manifestInterpreter;
@@ -147,18 +158,13 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 			if (arg.identity !== undefined) {
 				object.identity = arg.identity ?? "executable";
 			}
-			if (arg.sdk !== undefined) {
-				object.sdkArgs = tg.Mutation.is(arg.sdk)
-					? arg.sdk
-					: await tg.Mutation.arrayAppend(arg.sdk);
-			}
 			if (arg.libraryPaths !== undefined) {
 				if (arg.libraryPaths !== undefined) {
 					object.libraryPaths = tg.Mutation.is(arg.libraryPaths)
 						? arg.libraryPaths
 						: await tg.Mutation.arrayAppend(
 								arg.libraryPaths.map(manifestTemplateFromArg),
-						  );
+							);
 				}
 			}
 			if (arg.interpreter !== undefined) {
@@ -172,7 +178,7 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 					? arg.args
 					: await tg.Mutation.arrayAppend(
 							(arg.args ?? []).map(manifestTemplateFromArg),
-					  );
+						);
 			}
 			if (arg.host !== undefined) {
 				object.host = tg.triple(arg.host);
@@ -237,9 +243,14 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 
 	// Get the wrapper executable.
 	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let buildToolchain = buildToolchain_
+		? buildToolchain_
+		: host.os === "linux"
+			? await gcc.toolchain({ host })
+			: await bootstrap.sdk.env({ host });
 	let wrapper = await workspace.wrapper({
+		buildToolchain,
 		host,
-		sdk: sdkArgs || { bootstrapMode: true },
 	});
 
 	// Write the manifest to the wrapper and return.
@@ -253,6 +264,18 @@ export namespace wrap {
 	export type Arg = string | tg.Template | tg.File | tg.Symlink | ArgObject;
 
 	export type ArgObject = {
+		/** Command line arguments to bind to the wrapper. If the executable is wrapped, they will be merged. */
+		args?: Array<tg.Template.Arg>;
+
+		/** The build toolchain to use to produce components. Will use the default for the system if not provided. */
+		buildToolchain?: std.env.Arg;
+
+		/** Environment variables to bind to the wrapper. If the executable is wrapped, they will be merged. */
+		env?: std.env.Arg;
+
+		/** The executable to wrap. */
+		executable?: tg.File | tg.Symlink;
+
 		/** The host system to produce a wrapper for. */
 		host?: tg.Triple.Arg;
 
@@ -264,18 +287,6 @@ export namespace wrap {
 
 		/** Library paths to include. If the executable is wrapped, they will be merged. */
 		libraryPaths?: Array<tg.Directory | tg.Symlink>;
-
-		/** The executable to wrap. */
-		executable?: tg.File | tg.Symlink;
-
-		/** Environment variables to bind to the wrapper. If the executable is wrapped, they will be merged. */
-		env?: std.env.Arg;
-
-		/** Command line arguments to bind to the wrapper. If the executable is wrapped, they will be merged. */
-		args?: Array<tg.Template.Arg>;
-
-		/** Arguments for the SDK used to compile the wrapper and any other components used. */
-		sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	};
 
 	export type Identity = "wrapper" | "interpreter" | "executable";
@@ -461,7 +472,7 @@ export namespace wrap {
 										.flatten([mutationArgs])
 										.filter((arg) => arg !== undefined)
 										.map(normalizeEnvVarValue),
-							  );
+								);
 						return [key, mutations];
 					}),
 				),
@@ -1107,6 +1118,7 @@ let isManifestExecutable = (arg: unknown): arg is wrap.Manifest.Executable => {
 
 let manifestInterpreterFromArg = async (
 	arg: tg.File | tg.Symlink | wrap.Interpreter | wrap.Manifest.Interpreter,
+	buildToolchainArg?: std.env.Arg,
 ): Promise<wrap.Manifest.Interpreter> => {
 	if (isManifestInterpreter(arg)) {
 		return arg;
@@ -1132,7 +1144,7 @@ let manifestInterpreterFromArg = async (
 					arg.libraryPaths.map(async (arg) =>
 						manifestSymlinkFromArg(await tg.template(arg)),
 					),
-			  )
+				)
 			: undefined;
 
 		// Build an injection dylib to match the interpreter.
@@ -1150,8 +1162,13 @@ let manifestInterpreterFromArg = async (
 			);
 		}
 		let arch = interpreterMetadata.arch;
+		let host = tg.triple(`${arch}-unknown-linux-gnu`);
+		let buildToolchain = buildToolchainArg
+			? buildToolchainArg
+			: gcc.toolchain({ host });
 		let injectionLibrary = await injection.default({
-			host: `${arch}-unknown-linux-gnu`,
+			buildToolchain,
+			host,
 		});
 
 		// Combine the injection with any additional preloads specified by the caller.
@@ -1161,7 +1178,7 @@ let manifestInterpreterFromArg = async (
 					arg.preloads?.map(async (arg) =>
 						manifestSymlinkFromArg(await tg.template(arg)),
 					),
-			  )
+				)
 			: [];
 		preloads = preloads.concat(additionalPreloads);
 		let args = arg.args
@@ -1182,7 +1199,7 @@ let manifestInterpreterFromArg = async (
 					arg.libraryPaths.map(async (arg) =>
 						manifestSymlinkFromArg(await tg.template(arg)),
 					),
-			  )
+				)
 			: undefined;
 
 		// Build an injection dylib to match the interpreter.
@@ -1200,8 +1217,13 @@ let manifestInterpreterFromArg = async (
 			);
 		}
 		let arch = interpreterMetadata.arch;
+		let host = tg.triple(`${arch}-linux-musl`);
+		let buildToolchain = buildToolchainArg
+			? buildToolchainArg
+			: gcc.toolchain({ host });
 		let injectionLibrary = await injection.default({
-			host: `${arch}-linux-musl`,
+			buildToolchain,
+			host,
 		});
 
 		// Combine the injection with any additional preloads specified by the caller.
@@ -1211,7 +1233,7 @@ let manifestInterpreterFromArg = async (
 					arg.preloads?.map(async (arg) =>
 						manifestSymlinkFromArg(await tg.template(arg)),
 					),
-			  )
+				)
 			: [];
 		preloads = preloads.concat(additionalPreloads);
 
@@ -1232,11 +1254,16 @@ let manifestInterpreterFromArg = async (
 					arg.libraryPaths.map(async (arg) =>
 						manifestSymlinkFromArg(await tg.template(arg)),
 					),
-			  )
+				)
 			: undefined;
 		// Select the universal machO injecton dylib.  Either arch will produce the same result, so just pick one.
+		let host = await tg.Triple.host();
+		let buildToolchain = buildToolchainArg
+			? buildToolchainArg
+			: gcc.toolchain({ host });
 		let injectionLibrary = await injection.default({
-			host: `aarch64-apple-darwin`,
+			buildToolchain,
+			host,
 		});
 		let preloads = [await manifestSymlinkFromArg(injectionLibrary)];
 		let additionalPreloads = arg.preloads
@@ -1244,7 +1271,7 @@ let manifestInterpreterFromArg = async (
 					arg.preloads?.map(async (arg) =>
 						manifestSymlinkFromArg(await tg.template(arg)),
 					),
-			  )
+				)
 			: [];
 		preloads = preloads.concat(additionalPreloads);
 		return {
@@ -1281,6 +1308,7 @@ let isManifestInterpreter = (
 
 let manifestInterpreterFromExecutableArg = async (
 	arg: tg.File | tg.Symlink,
+	buildToolchainArg?: std.env.Arg,
 ): Promise<wrap.Manifest.Interpreter | undefined> => {
 	// Resolve the arg to a file if it is a symlink.
 	if (tg.Symlink.is(arg)) {
@@ -1300,15 +1328,18 @@ let manifestInterpreterFromExecutableArg = async (
 		case "mach-o": {
 			let arch = metadata.arches[0] as tg.Triple.Arch;
 			tg.assert(arch);
-			let triple = tg.triple({ os: "darwin", arch });
+			let host = tg.triple({ os: "darwin", arch });
+			let buildToolchain = buildToolchainArg
+				? buildToolchainArg
+				: bootstrap.sdk.env(host);
 			return {
 				kind: "dyld",
 				libraryPaths: undefined,
 				preloads: [
 					await manifestSymlinkFromArg(
 						await injection.default({
-							host: triple,
-							sdk: { bootstrapMode: true },
+							buildToolchain,
+							host,
 						}),
 					),
 				],
@@ -1316,7 +1347,9 @@ let manifestInterpreterFromExecutableArg = async (
 		}
 		case "shebang": {
 			if (metadata.interpreter === undefined) {
-				return manifestInterpreterFromArg(await defaultShellInterpreter());
+				return manifestInterpreterFromArg(
+					await defaultShellInterpreter(buildToolchainArg),
+				);
 			} else {
 				return undefined;
 			}
@@ -1343,9 +1376,11 @@ let manifestInterpreterFromElf = async (
 		arch: metadata.arch,
 		environment: libc,
 	});
+	let buildToolchain =
+		libc === "musl" ? bootstrap.sdk.env(host) : gcc.toolchain({ host });
 
 	// Obtain injection library.
-	let injectionLib = await injection.default({ host });
+	let injectionLib = await injection.default({ buildToolchain, host });
 
 	// Handle each interpreter type.
 	if (metadata.interpreter?.includes("ld-linux")) {
@@ -1383,13 +1418,19 @@ let manifestInterpreterFromElf = async (
 	}
 };
 
-export let defaultShellInterpreter = async () => {
+export let defaultShellInterpreter = async (
+	buildToolchainArg?: std.env.Arg,
+) => {
 	// Provide bash for the detected host system.
-	let shellArtifact = await std.utils.bash.build();
+	let buildArg = undefined;
+	if (buildToolchainArg) {
+		buildArg = { bootstrapMode: true, env: buildToolchainArg };
+	}
+	let shellArtifact = await std.utils.bash.build(buildArg);
 	let shellExecutable = tg.File.expect(await shellArtifact.get("bin/bash"));
 
 	//  Add the standard utils.
-	let env = await std.utils.env();
+	let env = await std.utils.env(buildArg);
 
 	let bash = wrap(shellExecutable, {
 		identity: "wrapper",

--- a/packages/std/wrap/injection.tg.ts
+++ b/packages/std/wrap/injection.tg.ts
@@ -152,7 +152,6 @@ export let dylib = async (arg: DylibArg): Promise<tg.File> => {
 				-mtune=generic                               \
 				-pipe                                        \
 				-Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3    \
-				-fasynchronous-unwind-tables                 \
 				-fno-omit-frame-pointer                      \
 				-mno-omit-leaf-frame-pointer                 \
 				-fstack-protector-strong                     \

--- a/packages/std/wrap/injection.tg.ts
+++ b/packages/std/wrap/injection.tg.ts
@@ -152,6 +152,7 @@ export let dylib = async (arg: DylibArg): Promise<tg.File> => {
 				-mtune=generic                               \
 				-pipe                                        \
 				-Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3    \
+				-fasynchronous-unwind-tables                 \
 				-fno-omit-frame-pointer                      \
 				-mno-omit-leaf-frame-pointer                 \
 				-fstack-protector-strong                     \

--- a/packages/std/wrap/workspace.tg.ts
+++ b/packages/std/wrap/workspace.tg.ts
@@ -203,10 +203,10 @@ export let build = async (arg: BuildArg) => {
 
 	// Set up common environemnt.
 	let certFile = tg`${std.caCertificates()}/cacert.pem`;
-	//let prefix = ``;
-	//if (isCross) {
-	//	prefix = `${targetString}-`;
- //}
+	let prefix = ``;
+	if (isCross) {
+		prefix = `${targetString}-`;
+ }
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [
 		arg.buildToolchain,
@@ -216,11 +216,11 @@ export let build = async (arg: BuildArg) => {
 			CARGO_HTTP_CAINFO: certFile,
 			RUST_TARGET: tg.Triple.toString(target),
 			CARGO_REGISTRIES_CRATES_IO_PROTOCOL: "sparse",
-			//RUSTFLAGS: `-C target-feature=+crt-static`, // cross only?
-			//[`CARGO_TARGET_${tripleToEnvVar(target, true)}_LINKER`]: `${prefix}gcc`,
-			//[`AR_${tripleToEnvVar(target)}`]: `${prefix}ar`,
-			//[`CC_${tripleToEnvVar(target)}`]: `${prefix}gcc`,
-			//[`CXX_${tripleToEnvVar(target)}`]: `${prefix}g++`,
+			RUSTFLAGS: `-C target-feature=+crt-static`,
+			[`CARGO_TARGET_${tripleToEnvVar(target, true)}_LINKER`]: `${prefix}cc`,
+			[`AR_${tripleToEnvVar(target)}`]: `${prefix}ar`,
+			[`CC_${tripleToEnvVar(target)}`]: `${prefix}cc`,
+			[`CXX_${tripleToEnvVar(target)}`]: `${prefix}c++`,
 		},
 	];
 

--- a/packages/std/wrap/workspace.tg.ts
+++ b/packages/std/wrap/workspace.tg.ts
@@ -197,14 +197,16 @@ export let build = async (arg: BuildArg) => {
 
 	// Get the toolchain directory.
 	let bootstrapMode =
-		os === "darwin" ||
-		(os === "linux" && host_.vendor === undefined && host.arch === target.arch);
+		os === "darwin" || (os === "linux" && host.arch === target.arch);
 	let { ldso, libDir } = await std.sdk.toolchainComponents({
 		bootstrapMode,
 		env: arg.buildToolchain,
 		host: host_,
 		target: target_,
 	});
+	let buildToolchain = bootstrapMode
+		? bootstrap.sdk.env(host)
+		: arg.buildToolchain;
 
 	// Get the Rust toolchain.
 	let rustToolchain = await rust({ target });
@@ -217,7 +219,7 @@ export let build = async (arg: BuildArg) => {
 	}
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [
-		arg.buildToolchain,
+		buildToolchain,
 		rustToolchain,
 		shellArtifact,
 		utilsArtifact,

--- a/packages/std/wrap/workspace.tg.ts
+++ b/packages/std/wrap/workspace.tg.ts
@@ -272,10 +272,9 @@ export let build = async (arg: BuildArg) => {
 	];
 	if (release) {
 		args.push(`--release`);
-	}
-	//} else {
+	} else {
 		args.push(`--features tracing`);
-	//}
+	}
 
 	let build = {
 		command: tg`${cargo} build`,

--- a/packages/std/wrap/workspace.tg.ts
+++ b/packages/std/wrap/workspace.tg.ts
@@ -206,7 +206,7 @@ export let build = async (arg: BuildArg) => {
 	let prefix = ``;
 	if (isCross) {
 		prefix = `${targetString}-`;
- }
+	}
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [
 		arg.buildToolchain,
@@ -272,9 +272,10 @@ export let build = async (arg: BuildArg) => {
 	];
 	if (release) {
 		args.push(`--release`);
-	} else {
-		args.push(`--features tracing`);
 	}
+	//} else {
+		args.push(`--features tracing`);
+	//}
 
 	let build = {
 		command: tg`${cargo} build`,

--- a/packages/std/wrap/workspace.tg.ts
+++ b/packages/std/wrap/workspace.tg.ts
@@ -203,10 +203,10 @@ export let build = async (arg: BuildArg) => {
 
 	// Set up common environemnt.
 	let certFile = tg`${std.caCertificates()}/cacert.pem`;
-	let prefix = ``;
-	if (isCross) {
-		prefix = `${targetString}-`;
-	}
+	//let prefix = ``;
+	//if (isCross) {
+	//	prefix = `${targetString}-`;
+ //}
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [
 		arg.buildToolchain,
@@ -216,11 +216,11 @@ export let build = async (arg: BuildArg) => {
 			CARGO_HTTP_CAINFO: certFile,
 			RUST_TARGET: tg.Triple.toString(target),
 			CARGO_REGISTRIES_CRATES_IO_PROTOCOL: "sparse",
-			RUSTFLAGS: `-C target-feature=+crt-static`,
-			[`CARGO_TARGET_${tripleToEnvVar(target, true)}_LINKER`]: `${prefix}gcc`,
-			[`AR_${tripleToEnvVar(target)}`]: `${prefix}ar`,
-			[`CC_${tripleToEnvVar(target)}`]: `${prefix}gcc`,
-			[`CXX_${tripleToEnvVar(target)}`]: `${prefix}g++`,
+			//RUSTFLAGS: `-C target-feature=+crt-static`, // cross only?
+			//[`CARGO_TARGET_${tripleToEnvVar(target, true)}_LINKER`]: `${prefix}gcc`,
+			//[`AR_${tripleToEnvVar(target)}`]: `${prefix}ar`,
+			//[`CC_${tripleToEnvVar(target)}`]: `${prefix}gcc`,
+			//[`CXX_${tripleToEnvVar(target)}`]: `${prefix}g++`,
 		},
 	];
 

--- a/packages/std/wrap/workspace.tg.ts
+++ b/packages/std/wrap/workspace.tg.ts
@@ -191,20 +191,15 @@ export let build = async (arg: BuildArg) => {
 	let isCross = !tg.Triple.eq(host, target);
 
 	// Get the toolchain directory.
-	let { directory, ldso, libDir } = await std.sdk.toolchainComponents({
+	let { ldso, libDir } = await std.sdk.toolchainComponents({
 		bootstrapMode: true,
 		env: arg.buildToolchain,
 		host,
 		target,
 	});
-	let buildToolchain = isCross ? directory : bootstrap.sdk.env(host);
 
 	// Get the Rust toolchain.
 	let rustToolchain = await rust({ target });
-
-	// Use the bootstrap utils to avoid unnecessary rebuilds;
-	let shell = bootstrap.shell({ host });
-	let utils = bootstrap.utils({ host });
 
 	// Set up common environemnt.
 	let certFile = tg`${std.caCertificates()}/cacert.pem`;
@@ -214,12 +209,9 @@ export let build = async (arg: BuildArg) => {
 	}
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [
-		buildToolchain,
+		arg.buildToolchain,
 		rustToolchain,
-		shell,
-		utils,
 		{
-			SHELL: tg`${shell}/bin/sh`,
 			SSL_CERT_FILE: certFile,
 			CARGO_HTTP_CAINFO: certFile,
 			RUST_TARGET: tg.Triple.toString(target),


### PR DESCRIPTION
This PR changes the build definitions for the Rust workspace and the injection library to expect their build toolchains to be passed explicitly by the caller, allowing tighter control over which compilers are used at which points in the bootstrapping process.

Additionally, this PR threads through a new optional `buildToolchain` argument to `std.wrap()`, which is similarly used to specify which toolchain to use when producing wrappers, allowing us to stop using the bootstrap toolchain earlier in the process to handle `std.wrap()` calls.

Additional changes:

- Drop `sdk` arg from `std.wrap` in favor of `buildToolchain`.
- Correctly disambiguate the interpreter flavor on Linux in `ld_proxy`.
- Feature-gate `tracing` in the wrapper, not enabled in release mode.
- Correctly handle build environments that have already been proxied in `std.sdk.toolchainComponents`.
- Correct some inconsistent usage of `build`/`host`/`target`.
- Specify SDK component package assertions should run in bootstrap mode.