### PR TITLE
refactor: triple

### DIFF
--- a/packages/acl/tangram.tg.ts
+++ b/packages/acl/tangram.tg.ts
@@ -25,9 +25,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -52,7 +52,7 @@ export let acl = tg.target(async (arg?: Arg) => {
 	let output = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: source_ ?? source(),

--- a/packages/attr/tangram.tg.ts
+++ b/packages/attr/tangram.tg.ts
@@ -24,9 +24,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -42,7 +42,7 @@ export let attr = tg.target(async (arg?: Arg) => {
 	let output = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			phases,
 			source: source_ ?? source(),
 		},

--- a/packages/autoconf/tangram.tg.ts
+++ b/packages/autoconf/tangram.tg.ts
@@ -22,9 +22,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -46,7 +46,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let autoconf = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 		},

--- a/packages/automake/tangram.tg.ts
+++ b/packages/automake/tangram.tg.ts
@@ -25,9 +25,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -67,7 +67,7 @@ export let automake = tg.target(async (arg?: Arg) => {
 	let automake = await std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 		},

--- a/packages/bash/tangram.tg.ts
+++ b/packages/bash/tangram.tg.ts
@@ -12,7 +12,7 @@ export let metadata = {
 
 export let source = tg.target(async (arg?: Arg) => {
 	let { name, version } = metadata;
-	let build = arg?.build ? tg.triple(arg?.build) : await tg.Triple.host();
+	let build = arg?.build ? tg.triple(arg?.build) : await std.triple.host();
 	let env = std.env.object([std.sdk({ host: build }, arg?.sdk), arg?.env]);
 
 	let checksum =
@@ -30,7 +30,7 @@ export let source = tg.target(async (arg?: Arg) => {
 	let patchedSource = tg.Directory.expect(
 		await tg.build(script, {
 			env,
-			host: tg.Triple.archAndOs(build),
+			host: std.triple.archAndOs(build),
 		}),
 	);
 	return patchedSource;
@@ -38,9 +38,9 @@ export let source = tg.target(async (arg?: Arg) => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -66,7 +66,7 @@ export let bash = tg.target((arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: source_ ?? source(),

--- a/packages/bc/tangram.tg.ts
+++ b/packages/bc/tangram.tg.ts
@@ -31,9 +31,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -48,7 +48,7 @@ export let bc = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = await tg.Triple.host(host_);
+	let host = await std.triple.host(host_);
 	let build = build_ ? tg.triple(build_) : host;
 
 	let sourceDir = source_ ?? source();
@@ -65,7 +65,7 @@ export let bc = tg.target(async (arg?: Arg) => {
 	let output = std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			buildInTree: true,
 			env,
 			opt: "3",

--- a/packages/bc/tangram.tg.ts
+++ b/packages/bc/tangram.tg.ts
@@ -49,7 +49,7 @@ export let bc = tg.target(async (arg?: Arg) => {
 	} = arg ?? {};
 
 	let host = await std.triple.host(host_);
-	let build = build_ ? tg.triple(build_) : host;
+	let build = build_ ?? host;
 
 	let sourceDir = source_ ?? source();
 

--- a/packages/bison/tangram.tg.ts
+++ b/packages/bison/tangram.tg.ts
@@ -19,9 +19,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -51,7 +51,7 @@ export let bison = tg.target((arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: source_ ?? source(),

--- a/packages/bzip2/tangram.tg.ts
+++ b/packages/bzip2/tangram.tg.ts
@@ -29,9 +29,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -44,9 +44,9 @@ export let bzip2 = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = await tg.Triple.host(host_);
+	let host = await std.triple.host(host_);
 
-	let os = tg.Triple.os(tg.Triple.archAndOs(host));
+	let os = std.triple.os(std.triple.archAndOs(host));
 
 	let sourceDir = source_ ?? source();
 
@@ -87,7 +87,7 @@ export let bzip2 = tg.target(async (arg?: Arg) => {
 	let output = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			buildInTree: true,
 			source: sourceDir,
 			phases,

--- a/packages/coreutils/tangram.tg.ts
+++ b/packages/coreutils/tangram.tg.ts
@@ -28,9 +28,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -51,7 +51,7 @@ export let coreutils = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 		},

--- a/packages/demo/tangram.tg.ts
+++ b/packages/demo/tangram.tg.ts
@@ -8,9 +8,9 @@ export let metadata = {
 };
 
 type Arg = {
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 };
 
@@ -39,7 +39,7 @@ export let test = tg.target(() => {
 });
 
 export let testGccMusl = tg.target(async () => {
-	let host = await tg.Triple.host();
+	let host = await std.triple.host();
 	if (host.os !== "linux") {
 		throw new Error("Musl-based SDKs are only available on Linux");
 	}
@@ -48,7 +48,7 @@ export let testGccMusl = tg.target(async () => {
 });
 
 export let testGccMold = tg.target(async () => {
-	let host = await tg.Triple.host();
+	let host = await std.triple.host();
 	if (host.os !== "linux") {
 		throw new Error("Mold SDKs are only available on Linux");
 	}
@@ -61,7 +61,7 @@ export let testLlvm = tg.target(async () => {
 });
 
 export let testLlvmMusl = tg.target(async () => {
-	let host = await tg.Triple.host();
+	let host = await std.triple.host();
 	if (host.os !== "linux") {
 		throw new Error("Musl-based SDKs are only available on Linux");
 	}
@@ -70,7 +70,7 @@ export let testLlvmMusl = tg.target(async () => {
 });
 
 export let testLlvmMold = tg.target(async () => {
-	let host = await tg.Triple.host();
+	let host = await std.triple.host();
 	if (host.os !== "linux") {
 		throw new Error("Mold SDKs are only available on Linux");
 	}
@@ -78,12 +78,12 @@ export let testLlvmMold = tg.target(async () => {
 });
 
 export let testLinuxCross = tg.target(async () => {
-	let build = await tg.Triple.host();
+	let build = await std.triple.host();
 	if (build.os !== "linux") {
 		throw new Error("Linux cross-compilation is only available on Linux");
 	}
 	let detectedArch = build.arch;
-	let crossArch: tg.Triple.Arch =
+	let crossArch: std.triple.Arch =
 		detectedArch === "x86_64" ? "aarch64" : "x86_64";
 	let host = tg.triple({ ...build, arch: crossArch });
 
@@ -91,7 +91,7 @@ export let testLinuxCross = tg.target(async () => {
 });
 
 export let testLinuxToDarwinCross = tg.target(async () => {
-	let build = await tg.Triple.host();
+	let build = await std.triple.host();
 	if (build.os !== "linux") {
 		throw new Error("Linux cross-compilation is only available on Linux");
 	}

--- a/packages/diffutils/tangram.tg.ts
+++ b/packages/diffutils/tangram.tg.ts
@@ -15,9 +15,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -28,7 +28,7 @@ export let diffutils = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 		},
 		autotools,

--- a/packages/docformatter/tangram.tg.ts
+++ b/packages/docformatter/tangram.tg.ts
@@ -25,8 +25,8 @@ export let source = tg.target(() => {
 
 type Arg = {
 	source?: tg.Directory;
-	host?: tg.Triple.Arg;
-	target?: tg.Triple.Arg;
+	host?: string;
+	target?: string;
 };
 
 export let docformatter = tg.target(async (arg?: Arg) => {

--- a/packages/elfutils/tangram.tg.ts
+++ b/packages/elfutils/tangram.tg.ts
@@ -29,9 +29,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -45,7 +45,7 @@ export let elfutils = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = await tg.Triple.host(host_);
+	let host = await std.triple.host(host_);
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -65,8 +65,8 @@ export let elfutils = tg.target(async (arg?: Arg) => {
 		],
 	};
 
-	if (!tg.Triple.eq(build, host)) {
-		configure.args.push(`--host=${tg.Triple.toString(host)}`);
+	if (!std.triple.eq(build, host)) {
+		configure.args.push(`--host=${std.triple.toString(host)}`);
 	}
 
 	let phases = { configure };
@@ -80,7 +80,7 @@ export let elfutils = tg.target(async (arg?: Arg) => {
 	let result = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: source_ ?? source(),

--- a/packages/elfutils/tangram.tg.ts
+++ b/packages/elfutils/tangram.tg.ts
@@ -46,7 +46,7 @@ export let elfutils = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 	let host = await std.triple.host(host_);
-	let build = build_ ? tg.triple(build_) : host;
+	let build = build_ ?? host;
 
 	let configure = {
 		args: [

--- a/packages/eslint/tangram.tg.ts
+++ b/packages/eslint/tangram.tg.ts
@@ -24,7 +24,7 @@ export let source = tg.target(async () => {
 
 export type Arg = {
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	nodejs?: tg.MaybeNestedArray<node.Arg>;
 	source?: tg.Directory;
 };

--- a/packages/file/tangram.tg.ts
+++ b/packages/file/tangram.tg.ts
@@ -48,7 +48,7 @@ export let file = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 	let host = await std.triple.host(host_);
-	let build = build_ ? tg.triple(build_) : host;
+	let build = build_ ?? host;
 
 	let configure = {
 		args: [

--- a/packages/file/tangram.tg.ts
+++ b/packages/file/tangram.tg.ts
@@ -31,9 +31,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -47,7 +47,7 @@ export let file = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = await tg.Triple.host(host_);
+	let host = await std.triple.host(host_);
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -62,7 +62,7 @@ export let file = tg.target(async (arg?: Arg) => {
 	let output = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			hardeningCFlags: false,
 			phases: { configure },

--- a/packages/findutils/tangram.tg.ts
+++ b/packages/findutils/tangram.tg.ts
@@ -14,9 +14,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -27,7 +27,7 @@ export let findutils = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 		},
 		autotools,

--- a/packages/flex/tangram.tg.ts
+++ b/packages/flex/tangram.tg.ts
@@ -30,9 +30,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -53,7 +53,7 @@ export let flex = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 		},

--- a/packages/fzf/tangram.tg.ts
+++ b/packages/fzf/tangram.tg.ts
@@ -20,10 +20,10 @@ export let source = tg.target((): Promise<tg.Directory> => {
 });
 
 export type Arg = {
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
 	go?: tg.MaybeNestedArray<go.Arg>;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -34,7 +34,7 @@ export let fzf = tg.target(async (arg?: Arg) => {
 	return go.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 		},
 		goArg,

--- a/packages/gawk/tangram.tg.ts
+++ b/packages/gawk/tangram.tg.ts
@@ -14,9 +14,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -27,7 +27,7 @@ export let gawk = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 		},
 		autotools,

--- a/packages/gcc/tangram.tg.ts
+++ b/packages/gcc/tangram.tg.ts
@@ -33,13 +33,13 @@ export let build = tg.target(async (arg: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? await std.triple.host();
+	let build = build_ ?? host;
 	let target = target_ ? tg.triple(target_) : host;
 
-	let buildString = std.triple.toString(build);
-	let hostString = std.triple.toString(host);
-	let targetString = std.triple.toString(target);
+	let build = std.triple.toString(build);
+	let host = std.triple.toString(host);
+	let target = std.triple.toString(target);
 
 	// Set up configuration common to all GCC builds.
 	let commonArgs = [
@@ -49,9 +49,9 @@ export let build = tg.target(async (arg: Arg) => {
 		"--enable-default-ssp",
 		"--enable-default-pie",
 		"--enable-initfini-array",
-		`--build=${buildString}`,
-		`--host=${hostString}`,
-		`--target=${targetString}`,
+		`--build=${build}`,
+		`--host=${host}`,
+		`--target=${target}`,
 	];
 
 	// Set up containers to collect additional arguments and environment variables for specific configurations.
@@ -98,7 +98,7 @@ export let build = tg.target(async (arg: Arg) => {
 	});
 	if (!isCross) {
 		result = await tg.directory(result, {
-			[`bin/${hostString}-cc`]: tg.symlink(`./${hostString}-gcc`),
+			[`bin/${host}-cc`]: tg.symlink(`./${host}-gcc`),
 		});
 	}
 

--- a/packages/gcc/tangram.tg.ts
+++ b/packages/gcc/tangram.tg.ts
@@ -18,7 +18,7 @@ export let source = tg.target(() =>
 type Arg = std.sdk.BuildEnvArg & {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
 	source?: tg.Directory;
-	target?: tg.Triple.Arg;
+	target?: string;
 };
 
 /* Produce a GCC toolchain. */
@@ -33,13 +33,13 @@ export let build = tg.target(async (arg: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 	let target = target_ ? tg.triple(target_) : host;
 
-	let buildString = tg.Triple.toString(build);
-	let hostString = tg.Triple.toString(host);
-	let targetString = tg.Triple.toString(target);
+	let buildString = std.triple.toString(build);
+	let hostString = std.triple.toString(host);
+	let targetString = std.triple.toString(target);
 
 	// Set up configuration common to all GCC builds.
 	let commonArgs = [
@@ -81,7 +81,7 @@ export let build = tg.target(async (arg: Arg) => {
 	let result = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			opt: "2",

--- a/packages/gettext/tangram.tg.ts
+++ b/packages/gettext/tangram.tg.ts
@@ -20,9 +20,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -54,7 +54,7 @@ export let gettext = tg.target(async (arg?: Arg) => {
 	let output = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: source_ ?? source(),

--- a/packages/gh/tangram.tg.ts
+++ b/packages/gh/tangram.tg.ts
@@ -20,10 +20,10 @@ export let source = tg.target(() => {
 });
 
 type Arg = {
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
 	go?: tg.MaybeNestedArray<go.Arg>;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -33,7 +33,7 @@ export let gh = tg.target(async (arg?: Arg) => {
 	return go.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 			install: {
 				command: tg`

--- a/packages/git/tangram.tg.ts
+++ b/packages/git/tangram.tg.ts
@@ -29,9 +29,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -65,7 +65,7 @@ export let git = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: sourceDir,

--- a/packages/gmp/tangram.tg.ts
+++ b/packages/gmp/tangram.tg.ts
@@ -23,9 +23,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -36,7 +36,7 @@ export let gmp = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			doCheck: true,
 			source: source_ ?? source(),
 		},

--- a/packages/gnugrep/tangram.tg.ts
+++ b/packages/gnugrep/tangram.tg.ts
@@ -14,9 +14,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -32,7 +32,7 @@ export let gnugrep = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			phases,
 			source: source_ ?? source(),
 		},

--- a/packages/gnuhello/tangram.tg.ts
+++ b/packages/gnuhello/tangram.tg.ts
@@ -14,9 +14,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -32,7 +32,7 @@ export let hello = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 			phases,
 		},

--- a/packages/gnumake/tangram.tg.ts
+++ b/packages/gnumake/tangram.tg.ts
@@ -14,9 +14,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -27,7 +27,7 @@ export let make = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 		},
 		autotools,

--- a/packages/gnused/tangram.tg.ts
+++ b/packages/gnused/tangram.tg.ts
@@ -14,9 +14,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -32,7 +32,7 @@ export let sed = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 			phases,
 		},

--- a/packages/gnutls/tangram.tg.ts
+++ b/packages/gnutls/tangram.tg.ts
@@ -26,9 +26,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -59,7 +59,7 @@ export let gnutls = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: source_ ?? source(),

--- a/packages/go/tangram.tg.ts
+++ b/packages/go/tangram.tg.ts
@@ -188,7 +188,7 @@ export let build = async (...args: tg.Args<Arg>): Promise<tg.Directory> => {
 			return object;
 		}
 	});
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
+	let host = host_ ?? await std.triple.host();
 	let system = std.triple.archAndOs(host);
 	let target = target_ ? tg.triple(target_) : host;
 	tg.assert(source, "Must provide a source directory.");

--- a/packages/go/tangram.tg.ts
+++ b/packages/go/tangram.tg.ts
@@ -30,13 +30,13 @@ let RELEASES = {
 };
 
 type ToolchainArg = {
-	host?: tg.Triple.Arg;
+	host?: string;
 };
 
 export let toolchain = tg.target(
 	async (arg?: ToolchainArg): Promise<tg.Directory> => {
-		let host = arg?.host ? tg.triple(arg.host) : await tg.Triple.host();
-		let system = tg.Triple.archAndOs(host);
+		let host = arg?.host ? tg.triple(arg.host) : await std.triple.host();
+		let system = std.triple.archAndOs(host);
 		tg.assert(
 			system in RELEASES,
 			`${system} is not supported in the Go toolchain.`,
@@ -117,10 +117,10 @@ export type Arg = {
 	cgo?: boolean;
 
 	/** The machine that will run the compilation. */
-	host?: tg.Triple.Arg;
+	host?: string;
 
 	/** The machine the produced artifacts will run on. */
-	target?: tg.Triple.Arg;
+	target?: string;
 
 	/** Any required SDK customization. */
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
@@ -131,11 +131,11 @@ export let build = async (...args: tg.Args<Arg>): Promise<tg.Directory> => {
 		cgo: boolean;
 		env: Array<std.env.Arg>;
 		generate: boolean | { command: tg.Template.Arg };
-		host: tg.Triple.Arg;
+		host: string;
 		install: { command: tg.Template.Arg };
 		sdkArgs: Array<std.sdk.Arg>;
 		source: tg.Directory;
-		target: tg.Triple.Arg;
+		target: string;
 		vendor: boolean | { command: tg.Template.Arg };
 	};
 
@@ -188,8 +188,8 @@ export let build = async (...args: tg.Args<Arg>): Promise<tg.Directory> => {
 			return object;
 		}
 	});
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
-	let system = tg.Triple.archAndOs(host);
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
+	let system = std.triple.archAndOs(host);
 	let target = target_ ? tg.triple(target_) : host;
 	tg.assert(source, "Must provide a source directory.");
 

--- a/packages/gperf/tangram.tg.ts
+++ b/packages/gperf/tangram.tg.ts
@@ -17,9 +17,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -35,7 +35,7 @@ export let gperf = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			phases,
 			source: source_ ?? source(),
 		},

--- a/packages/help2man/tangram.tg.ts
+++ b/packages/help2man/tangram.tg.ts
@@ -25,9 +25,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -57,7 +57,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let artifact = std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 		},

--- a/packages/hey/tangram.tg.ts
+++ b/packages/hey/tangram.tg.ts
@@ -23,10 +23,10 @@ export let source = tg.target(() => {
 });
 
 export type Arg = {
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
 	go?: tg.MaybeNestedArray<go.Arg>;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -36,7 +36,7 @@ export let hey = tg.target(async (arg?: Arg) => {
 	return go.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 		},
 		goArg,

--- a/packages/http-server/tangram.tg.ts
+++ b/packages/http-server/tangram.tg.ts
@@ -25,7 +25,7 @@ export let source = tg.target(() => {
 
 export type Arg = {
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	nodejs?: tg.MaybeNestedArray<nodejs.Arg>;
 	source?: tg.Directory;
 };

--- a/packages/httpie/tangram.tg.ts
+++ b/packages/httpie/tangram.tg.ts
@@ -25,10 +25,10 @@ export let source = tg.target(async () => {
 });
 
 type Arg = {
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
 	python?: tg.MaybeNestedArray<python.Arg>;
-	host?: tg.Triple.Arg;
+	host?: string;
 	source?: tg.Directory;
 };
 

--- a/packages/isort/tangram.tg.ts
+++ b/packages/isort/tangram.tg.ts
@@ -24,8 +24,8 @@ export let source = tg.target(() => {
 
 type Arg = {
 	source?: tg.Directory;
-	host?: tg.Triple.Arg;
-	target?: tg.Triple.Arg;
+	host?: string;
+	target?: string;
 };
 
 export let isort = tg.target(async (arg?: Arg) => {

--- a/packages/jq/tangram.tg.ts
+++ b/packages/jq/tangram.tg.ts
@@ -23,9 +23,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -40,7 +40,7 @@ export let jq = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 			phases,
 		},

--- a/packages/libarchive/tangram.tg.ts
+++ b/packages/libarchive/tangram.tg.ts
@@ -44,7 +44,7 @@ export let libarchive = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 	let host = await std.triple.host(host_);
-	let build = build_ ? tg.triple(build_) : host;
+	let build = build_ ?? host;
 
 	let configure = {
 		args: [

--- a/packages/libarchive/tangram.tg.ts
+++ b/packages/libarchive/tangram.tg.ts
@@ -25,9 +25,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -43,7 +43,7 @@ export let libarchive = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = await tg.Triple.host(host_);
+	let host = await std.triple.host(host_);
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -58,8 +58,8 @@ export let libarchive = tg.target(async (arg?: Arg) => {
 		],
 	};
 
-	if (!tg.Triple.eq(build, host)) {
-		configure.args.push(`--host=${tg.Triple.toString(host)}`);
+	if (!std.triple.eq(build, host)) {
+		configure.args.push(`--host=${std.triple.toString(host)}`);
 	}
 
 	let phases = { configure };
@@ -70,7 +70,7 @@ export let libarchive = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 			phases,

--- a/packages/libcap/tangram.tg.ts
+++ b/packages/libcap/tangram.tg.ts
@@ -26,9 +26,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -72,7 +72,7 @@ export let libcap = tg.target(async (arg?: Arg) => {
 	let output = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			buildInTree: true,
 			env,
 			phases,

--- a/packages/libffi/tangram.tg.ts
+++ b/packages/libffi/tangram.tg.ts
@@ -24,9 +24,9 @@ export let source = tg.target(async (): Promise<tg.Directory> => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: std.triple.Arg;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -45,7 +45,7 @@ export let libffi = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			phases: { configure },
 			source: source_ ?? source(),
 		},

--- a/packages/libiconv/tangram.tg.ts
+++ b/packages/libiconv/tangram.tg.ts
@@ -14,9 +14,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -27,7 +27,7 @@ export let libiconv = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 		},
 		autotools,

--- a/packages/libseccomp/tangram.tg.ts
+++ b/packages/libseccomp/tangram.tg.ts
@@ -28,9 +28,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -54,7 +54,7 @@ export let libseccomp = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases: { configure },
 			source: source_ ?? source(),

--- a/packages/libsigsegv/tangram.tg.ts
+++ b/packages/libsigsegv/tangram.tg.ts
@@ -15,9 +15,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -28,7 +28,7 @@ export let libsigsegv = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 		},
 		autotools,

--- a/packages/libxcrypt/tangram.tg.ts
+++ b/packages/libxcrypt/tangram.tg.ts
@@ -30,9 +30,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -58,7 +58,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: source_ ?? source(),

--- a/packages/libyaml/tangram.tg.ts
+++ b/packages/libyaml/tangram.tg.ts
@@ -23,9 +23,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -36,7 +36,7 @@ export let libyaml = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 		},
 		autotools,

--- a/packages/m4/tangram.tg.ts
+++ b/packages/m4/tangram.tg.ts
@@ -14,9 +14,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -31,7 +31,7 @@ export let m4 = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			phases: { configure },
 			source: source_ ?? source(),
 		},

--- a/packages/ncurses/tangram.tg.ts
+++ b/packages/ncurses/tangram.tg.ts
@@ -29,8 +29,8 @@ export let ncurses = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? await std.triple.host();
+	let build = build_ ?? host;
 
 	let configure = {
 		args: [

--- a/packages/ncurses/tangram.tg.ts
+++ b/packages/ncurses/tangram.tg.ts
@@ -14,9 +14,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -29,7 +29,7 @@ export let ncurses = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -67,7 +67,7 @@ export let ncurses = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			phases,
 			source: source_ ?? source(),
 		},

--- a/packages/nettle/tangram.tg.ts
+++ b/packages/nettle/tangram.tg.ts
@@ -15,9 +15,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -46,7 +46,7 @@ export let nettle = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: source_ ?? source(),

--- a/packages/nodejs/tangram.tg.ts
+++ b/packages/nodejs/tangram.tg.ts
@@ -53,13 +53,13 @@ let source = async (): Promise<tg.Directory> => {
 	};
 
 	// Get the NodeJS release.
-	let targetString = std.triple.toString(target);
+	let target = std.triple.toString(target);
 	tg.assert(
-		targetString in releases,
-		`Unsupported target system: ${targetString}.`,
+		target in releases,
+		`Unsupported target system: ${target}.`,
 	);
 
-	let release = releases[targetString];
+	let release = releases[target];
 	tg.assert(release, "Unsupported target");
 	let { url, checksum, unpackFormat } = release;
 

--- a/packages/nodejs/tangram.tg.ts
+++ b/packages/nodejs/tangram.tg.ts
@@ -8,8 +8,8 @@ export let metadata = {
 type ToolchainArg = {
 	/** An optional openssl.cnf file. Empty by default. */
 	opensslCnf?: tg.File | tg.Symlink;
-	host?: tg.Triple.Arg;
-	target?: tg.Triple.Arg;
+	host?: string;
+	target?: string;
 };
 
 // URLs taken from https://nodejs.org/dist/v${version}/.
@@ -17,7 +17,7 @@ type ToolchainArg = {
 let source = async (): Promise<tg.Directory> => {
 	// Known versions of NodeJS.
 	let version = metadata.version;
-	let target = await tg.Triple.host();
+	let target = await std.triple.host();
 
 	let releases: {
 		[key: string]: {
@@ -53,7 +53,7 @@ let source = async (): Promise<tg.Directory> => {
 	};
 
 	// Get the NodeJS release.
-	let targetString = tg.Triple.toString(target);
+	let targetString = std.triple.toString(target);
 	tg.assert(
 		targetString in releases,
 		`Unsupported target system: ${targetString}.`,
@@ -119,9 +119,9 @@ type PackageJson = {
 export default nodejs;
 
 export type Arg = {
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	packageLock?: tg.File;
 	phases?: tg.MaybeNestedArray<std.phases.Arg>;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
@@ -130,9 +130,9 @@ export type Arg = {
 
 export let build = async (...args: tg.Args<Arg>) => {
 	type Apply = {
-		build?: tg.Triple.Arg;
+		build?: string;
 		env: Array<std.env.Arg>;
-		host?: tg.Triple.Arg;
+		host?: string;
 		packageLock?: tg.File;
 		phases?: Array<std.phases.Arg>;
 		sdkArg: Array<std.sdk.Arg>;
@@ -183,7 +183,7 @@ export let build = async (...args: tg.Args<Arg>) => {
 	});
 	tg.assert(source, "Must provide a source");
 
-	let host = await tg.Triple.host(hostArg);
+	let host = await std.triple.host(hostArg);
 	let build = buildArg ?? host;
 
 	let node = nodejs({

--- a/packages/openssl/tangram.tg.ts
+++ b/packages/openssl/tangram.tg.ts
@@ -25,9 +25,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -41,7 +41,7 @@ export let openssl = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = await tg.Triple.host(host_);
+	let host = await std.triple.host(host_);
 
 	let sourceDir = source_ ?? source();
 
@@ -67,7 +67,7 @@ export let openssl = tg.target(async (arg?: Arg) => {
 	let openssl = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: sourceDir,

--- a/packages/patch/tangram.tg.ts
+++ b/packages/patch/tangram.tg.ts
@@ -14,9 +14,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -27,7 +27,7 @@ export let patch = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 		},
 		autotools,

--- a/packages/pcre2/tangram.tg.ts
+++ b/packages/pcre2/tangram.tg.ts
@@ -24,9 +24,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -37,7 +37,7 @@ export let pcre2 = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 		},
 		autotools,
@@ -54,7 +54,7 @@ export let test = tg.target(async () => {
 		`),
 	});
 
-	let host = await tg.Triple.host();
+	let host = await std.triple.host();
 	let hostArch = host.arch;
 
 	let output = tg.File.expect(
@@ -71,10 +71,10 @@ export let test = tg.target(async () => {
 	tg.assert(metadata.arch === hostArch);
 
 	// // On Linux, test cross-compilation.
-	// let os = tg.Triple.os(tg.Triple.archAndOs(host));
+	// let os = std.triple.os(std.triple.archAndOs(host));
 	// if (os === "linux") {
 	// 	// Determine the target triple with differing architecture from the host.
-	// 	let targetArch: tg.Triple.Arch =
+	// 	let targetArch: std.triple.Arch =
 	// 		hostArch === "x86_64" ? "aarch64" : "x86_64";
 	// 	let target = tg.triple({
 	// 		arch: targetArch,
@@ -88,7 +88,7 @@ export let test = tg.target(async () => {
 	// 		await std.build(
 	// 			tg`
 	// 				echo "Checking if we can link against a cross-compiled libpcre2."
-	// 				${tg.Triple.toString(target)}-cc ${source}/main.c -o $OUTPUT -L${pcre2({
+	// 				${std.triple.toString(target)}-cc ${source}/main.c -o $OUTPUT -L${pcre2({
 	// 					host,
 	// 				})}/lib -lpcre2-8
 	// 			`,

--- a/packages/perl/tangram.tg.ts
+++ b/packages/perl/tangram.tg.ts
@@ -50,9 +50,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -92,7 +92,7 @@ export let perl = tg.target(async (arg?: Arg) => {
 	let perlArtifact = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			prefixArg: "-Dprefix=",

--- a/packages/pkgconfig/tangram.tg.ts
+++ b/packages/pkgconfig/tangram.tg.ts
@@ -31,9 +31,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -47,7 +47,7 @@ export let pkgconfig = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -78,7 +78,7 @@ export let pkgconfig = tg.target(async (arg?: Arg) => {
 	let pkgConfigBuild = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: source_ ?? source(),

--- a/packages/pkgconfig/tangram.tg.ts
+++ b/packages/pkgconfig/tangram.tg.ts
@@ -47,8 +47,8 @@ export let pkgconfig = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? await std.triple.host();
+	let build = build_ ?? host;
 
 	let configure = {
 		args: ["--with-internal-glib", "--disable-dependency-tracking"],

--- a/packages/poetry/tangram.tg.ts
+++ b/packages/poetry/tangram.tg.ts
@@ -28,8 +28,8 @@ export let source = tg.target(() => {
 
 export type Arg = {
 	source?: tg.Directory;
-	host?: tg.Triple.Arg;
-	target?: tg.Triple.Arg;
+	host?: std.triple.Arg;
+	target?: std.triple.Arg;
 };
 
 // In order to bootstrap poetry, we need to have poetry. Internally, poetry works by bootstrapping with the most recent version published to pypi.org. To mock this, we use a known 'good' requirements.txt created with pip-compile to install a version of poetry from the pypi registry safely.
@@ -55,10 +55,10 @@ export type BuildArgs = {
 	lockfile: tg.File;
 
 	/** The host system to build upon. */
-	host?: tg.Triple.Arg;
+	host?: std.triple.Arg;
 
 	/** The target system to compile for. */
-	target?: tg.Triple.Arg;
+	target?: std.triple.Arg;
 
 	// TODO: groups, preferWheel vs sdist
 };

--- a/packages/postgresql/tangram.tg.ts
+++ b/packages/postgresql/tangram.tg.ts
@@ -29,9 +29,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -71,7 +71,7 @@ export let postgresql = tg.target(async (arg?: Arg) => {
 	let output = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			hardeningCFlags: false,
 			phases,

--- a/packages/python/tangram.tg.ts
+++ b/packages/python/tangram.tg.ts
@@ -53,10 +53,10 @@ type ToolchainArg = {
 	requirements?: requirements.Arg;
 
 	/** The system to build python upon. */
-	build?: tg.Triple.Arg;
+	build?: string;
 
 	/** The system to use python. Currently must be the same as build. */
-	host?: tg.Triple.Arg;
+	host?: string;
 
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 };
@@ -90,7 +90,7 @@ export let python = tg.target(async (arg?: ToolchainArg) => {
 	let output = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: source_ ?? (await source()),
@@ -181,8 +181,8 @@ let isPythonScript = (metadata: std.file.ExecutableMetadata): boolean => {
 };
 
 export type Arg = {
-	build?: tg.Triple.Arg;
-	host?: tg.Triple.Arg;
+	build?: string;
+	host?: string;
 
 	/** An optional pyproject.toml. */
 	pyprojectToml?: tg.File;
@@ -196,8 +196,8 @@ export type Arg = {
 
 export let build = async (...args: tg.Args<Arg>) => {
 	type Apply = {
-		buildTriple?: tg.Triple.Arg;
-		host?: tg.Triple.Arg;
+		buildTriple?: string;
+		host?: string;
 		pythonArg?: Array<ToolchainArg>;
 		pyprojectToml: tg.File;
 		source: tg.Directory;
@@ -233,7 +233,7 @@ export let build = async (...args: tg.Args<Arg>) => {
 			return object;
 		}
 	});
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let buildTriple = buildTriple_ ? tg.triple(buildTriple_) : host;
 
 	tg.assert(source, "Must specify a source directory.");

--- a/packages/python/tangram.tg.ts
+++ b/packages/python/tangram.tg.ts
@@ -233,7 +233,7 @@ export let build = async (...args: tg.Args<Arg>) => {
 			return object;
 		}
 	});
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
+	let host = host_ ?? await std.triple.host();
 	let buildTriple = buildTriple_ ? tg.triple(buildTriple_) : host;
 
 	tg.assert(source, "Must specify a source directory.");

--- a/packages/readline/tangram.tg.ts
+++ b/packages/readline/tangram.tg.ts
@@ -15,9 +15,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -37,7 +37,7 @@ export let readline = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 		},

--- a/packages/ripgrep/tangram.tg.ts
+++ b/packages/ripgrep/tangram.tg.ts
@@ -23,12 +23,12 @@ export let source = tg.target(async () => {
 });
 
 type Arg = {
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
 	rust?: tg.MaybeNestedArray<rust.Arg>;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
-	host?: tg.Triple.Arg;
+	host?: string;
 };
 
 export let ripgrep = tg.target(async (arg?: Arg) => {
@@ -46,7 +46,7 @@ export let ripgrep = tg.target(async (arg?: Arg) => {
 	return rust.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			features: ["pcre2"],
 			source: source_ ?? source(),
@@ -66,12 +66,12 @@ export let test = tg.target(async () => {
 	});
 
 	// // On Linux, test cross-compiling.
-	// let host = await tg.Triple.host();
-	// let os = tg.Triple.os(tg.Triple.archAndOs(host));
+	// let host = await std.triple.host();
+	// let os = std.triple.os(std.triple.archAndOs(host));
 	// if (os === "linux") {
 	// 	// Determine the target triple with differing architecture from the host.
 	// 	let hostArch = host.arch;
-	// 	let targetArch: tg.Triple.Arch =
+	// 	let targetArch: std.triple.Arch =
 	// 		hostArch === "x86_64" ? "aarch64" : "x86_64";
 	// 	let target = tg.triple({
 	// 		arch: targetArch,

--- a/packages/ruby/bootstrap.tg.ts
+++ b/packages/ruby/bootstrap.tg.ts
@@ -13,7 +13,7 @@ export let source = tg.target(async () => {
 });
 
 /** Returns an older version of Ruby that is only used to bootstrap it. */
-export let ruby = tg.target(async (host: tg.Triple) => {
+export let ruby = tg.target(async (host: std.triple) => {
 	let build = await std.build(
 		tg`
 			${source()}/configure --prefix $OUTPUT

--- a/packages/ruby/tangram.tg.ts
+++ b/packages/ruby/tangram.tg.ts
@@ -91,7 +91,7 @@ export let ruby = async (...args: tg.Args<Arg>) => {
 
 	// Generate the host and target.
 	let host = await std.triple.host(host_);
-	let build = build_ ? tg.triple(build_) : host;
+	let build = build_ ?? host;
 
 	let env_ = [
 		libffi({ host }),

--- a/packages/ruby/tangram.tg.ts
+++ b/packages/ruby/tangram.tg.ts
@@ -30,8 +30,8 @@ type Arg = {
 	env: std.env.Arg;
 	phases: tg.MaybeNestedArray<std.phases.Arg>;
 	source?: tg.Directory;
-	build?: tg.Triple.Arg;
-	host?: tg.Triple.Arg;
+	build?: string;
+	host?: string;
 };
 
 export let ruby = async (...args: tg.Args<Arg>) => {
@@ -39,8 +39,8 @@ export let ruby = async (...args: tg.Args<Arg>) => {
 		envs: std.env.Arg;
 		phases: tg.MaybeNestedArray<std.phases.Arg>;
 		source: tg.Directory;
-		build: tg.Triple.Arg;
-		host: tg.Triple.Arg;
+		build: string;
+		host: string;
 	};
 	let {
 		envs,
@@ -90,7 +90,7 @@ export let ruby = async (...args: tg.Args<Arg>) => {
 	});
 
 	// Generate the host and target.
-	let host = await tg.Triple.host(host_);
+	let host = await std.triple.host(host_);
 	let build = build_ ? tg.triple(build_) : host;
 
 	let env_ = [
@@ -119,7 +119,7 @@ export let ruby = async (...args: tg.Args<Arg>) => {
 				pre: "find ./bin -empty -delete",
 			},
 		},
-		...tg.Triple.rotate({ build, host }),
+		...std.triple.rotate({ build, host }),
 	});
 
 	// Create the RUBYLIB environment variable.

--- a/packages/rust/tangram.tg.ts
+++ b/packages/rust/tangram.tg.ts
@@ -15,21 +15,21 @@ let PROFILE = "minimal" as const;
 
 type ToolchainArg = {
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
-	target?: tg.Triple;
-	targets?: Array<tg.Triple>;
+	target?: string
+	targets?: Array<std.triple>;
 };
 
 export let rust = tg.target(async (arg?: ToolchainArg) => {
 	// Determine the list of target triples to support other than the inferred host.
-	let detectedHost = await tg.Triple.host();
+	let detectedHost = await std.triple.host();
 	let host = rustTriple(detectedHost);
 	let targets = [];
-	if (arg?.target && !tg.Triple.eq(arg.target, host)) {
+	if (arg?.target && !std.triple.eq(arg.target, host)) {
 		targets.push(arg.target);
 	}
 	if (arg?.targets) {
 		for (let target of arg?.targets) {
-			if (!tg.Triple.eq(target, host)) {
+			if (!std.triple.eq(target, host)) {
 				targets.push(target);
 			}
 		}
@@ -48,7 +48,7 @@ export let rust = tg.target(async (arg?: ToolchainArg) => {
 	)) as RustupManifestV2;
 
 	// Get the system metadata.
-	let hostTripleString = tg.Triple.toString(host);
+	let hostTripleString = std.triple.toString(host);
 
 	// Get all the available packages for the selected profile and target.
 	let packageNames = manifest.profiles[PROFILE];
@@ -66,7 +66,7 @@ export let rust = tg.target(async (arg?: ToolchainArg) => {
 	// Add any additionally requested rust-std targets.
 	for (let target of targets) {
 		let name = "rust-std";
-		let targetTripleString = tg.Triple.toString(target);
+		let targetTripleString = std.triple.toString(target);
 		let data = manifest.pkg[name];
 		let pkg = data?.target[targetTripleString];
 		if (pkg?.available === true) {
@@ -143,11 +143,11 @@ export default rust;
 export type Arg = {
 	env?: std.env.Arg;
 	features?: Array<string>;
-	host?: tg.Triple.Arg;
+	host?: string;
 	proxy?: boolean;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Artifact;
-	target?: tg.Triple.Arg;
+	target?: string;
 	useCargoVendor?: boolean;
 };
 
@@ -155,11 +155,11 @@ export let build = async (...args: tg.Args<Arg>) => {
 	type Apply = {
 		env: Array<std.env.Arg>;
 		features: Array<string>;
-		host: tg.Triple.Arg;
+		host: string;
 		proxy: boolean;
 		sdk: Array<std.sdk.Arg>;
 		source: tg.Artifact;
-		target: tg.Triple.Arg;
+		target: string;
 		useCargoVendor: boolean;
 	};
 	let {
@@ -204,11 +204,11 @@ export let build = async (...args: tg.Args<Arg>) => {
 		}
 	});
 
-	let host = rustTriple(host_ ? tg.triple(host_) : await tg.Triple.host());
+	let host = rustTriple(host_ ? tg.triple(host_) : await std.triple.host());
 	let target = target_ ? rustTriple(tg.triple(target_)) : host;
 
 	// Check if we're cross-compiling.
-	let crossCompiling = !tg.Triple.eq(target, host);
+	let crossCompiling = !std.triple.eq(target, host);
 
 	// Obtain handles to the SDK and Rust artifacts.
 	// NOTE - pulls an SDK assuming the selected target is the intended host.
@@ -216,7 +216,7 @@ export let build = async (...args: tg.Args<Arg>) => {
 	let rustArtifact = rust({ target });
 
 	// Compute some necessary metadata.
-	let targetTriple = tg.Triple.toString(target);
+	let targetTriple = std.triple.toString(target);
 
 	// Download the dependencies using the cargo vendor.
 	tg.assert(source, "Must provide a source directory.");
@@ -286,7 +286,7 @@ export let build = async (...args: tg.Args<Arg>) => {
 				...additionalEnv,
 			},
 			proxyEnv,
-			{ TANGRAM_HOST: tg.Triple.toString(tg.Triple.archAndOs(host)) },
+			{ TANGRAM_HOST: std.triple.toString(std.triple.archAndOs(host)) },
 			env,
 		),
 	});
@@ -321,7 +321,7 @@ export let build = async (...args: tg.Args<Arg>) => {
 };
 
 export type VendoredSourcesArg = {
-	rustTarget?: tg.Triple.Arg;
+	rustTarget?: string;
 	source: tg.Artifact;
 	useCargoVendor?: boolean;
 };
@@ -330,8 +330,8 @@ let vendoredSources = async (arg: VendoredSourcesArg): Promise<tg.Template> => {
 	let { rustTarget: rustTarget_, source, useCargoVendor = false } = arg;
 	let rustTarget = rustTarget_
 		? tg.triple(rustTarget_)
-		: await tg.Triple.host();
-	let rustTargetString = tg.Triple.toString(rustTarget);
+		: await std.triple.host();
+	let rustTargetString = std.triple.toString(rustTarget);
 	if (useCargoVendor) {
 		// Run cargo vendor
 		let certFile = tg`${std.caCertificates()}/cacert.pem`;
@@ -512,11 +512,11 @@ type RustupManifestV2 = {
 	};
 };
 
-let rustTriple = (triple: tg.Triple): tg.Triple => {
-	let normalized = tg.Triple.normalized(triple);
+let rustTriple = (triple: std.triple): std.triple => {
+	let normalized = std.triple.normalized(triple);
 	tg.assert(
 		normalized,
-		`Could not convert triple to Rust triple: ${tg.Triple.toString(triple)}`,
+		`Could not convert triple to Rust triple: ${std.triple.toString(triple)}`,
 	);
 	let base = tg.triple(normalized);
 	if (base.os === "darwin") {
@@ -537,8 +537,8 @@ let rustTriple = (triple: tg.Triple): tg.Triple => {
 	}
 };
 
-let tripleToEnvVar = (triple: tg.Triple, upcase?: boolean) => {
-	let tripleString = tg.Triple.toString(triple);
+let tripleToEnvVar = (triple: std.triple, upcase?: boolean) => {
+	let tripleString = std.triple.toString(triple);
 	let allCaps = upcase ?? false;
 	let result = tripleString.replace(/-/g, "_");
 	if (allCaps) {
@@ -549,7 +549,7 @@ let tripleToEnvVar = (triple: tg.Triple, upcase?: boolean) => {
 
 export let test = tg.target(async () => {
 	let tests = [testHost()];
-	let os = tg.Triple.os(await tg.Triple.host());
+	let os = std.triple.os(await std.triple.host());
 	if (os === "linux") {
 		tests.push(testCross());
 	}
@@ -571,11 +571,11 @@ export let testHost = tg.target(async () => {
 
 export let testCross = tg.target(async () => {
 	// Detect the host triple.
-	let host = await tg.Triple.host();
+	let host = await std.triple.host();
 
 	// Determine the target triple with differing architecture from the host.
 	let hostArch = host.arch;
-	let targetArch: tg.Triple.Arch = hostArch === "x86_64" ? "aarch64" : "x86_64";
+	let targetArch: std.triple.Arch = hostArch === "x86_64" ? "aarch64" : "x86_64";
 	let target = tg.triple({
 		arch: targetArch,
 		vendor: "unknown",

--- a/packages/sphinx/tangram.tg.ts
+++ b/packages/sphinx/tangram.tg.ts
@@ -28,10 +28,10 @@ export let source = tg.target(() => {
 });
 
 type Arg = {
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
 	python?: tg.MaybeNestedArray<python.Arg>;
-	host?: tg.Triple.Arg;
+	host?: string;
 	source?: tg.Directory;
 };
 

--- a/packages/sqlite/tangram.tg.ts
+++ b/packages/sqlite/tangram.tg.ts
@@ -35,9 +35,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -54,7 +54,7 @@ export let sqlite = tg.target((arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 		},

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -125,18 +125,18 @@ checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.78"
+version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -147,15 +147,15 @@ checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -247,9 +247,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
  "serde",
 ]
@@ -471,7 +471,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -482,7 +482,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -545,7 +545,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "unicode-xid",
 ]
 
@@ -587,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "filetime"
@@ -684,7 +684,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -773,7 +773,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -971,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -982,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inout"
@@ -1006,9 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
@@ -1310,7 +1310,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1408,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1471,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
 dependencies = [
  "log",
  "ring",
@@ -1485,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
+checksum = "868e20fada228fefaf6b652e00cc73623d54f8171e7352c18bb281571f2d92da"
 
 [[package]]
 name = "rustls-webpki"
@@ -1529,7 +1529,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1555,14 +1555,14 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -1577,7 +1577,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1602,7 +1602,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.5",
+ "indexmap 2.2.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1619,7 +1619,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1739,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1764,7 +1764,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=cd045c48d932b552e0de93f64d83ee8aa82473c9#cd045c48d932b552e0de93f64d83ee8aa82473c9"
+source = "git+https://github.com/tangramdotdev/tangram?rev=07f25990f9d9d1310e8209fc63a27075dc184230#07f25990f9d9d1310e8209fc63a27075dc184230"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -1821,7 +1821,7 @@ dependencies = [
 [[package]]
 name = "tangram_error"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=cd045c48d932b552e0de93f64d83ee8aa82473c9#cd045c48d932b552e0de93f64d83ee8aa82473c9"
+source = "git+https://github.com/tangramdotdev/tangram?rev=07f25990f9d9d1310e8209fc63a27075dc184230#07f25990f9d9d1310e8209fc63a27075dc184230"
 dependencies = [
  "crossterm",
  "glob",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "tangram_util"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=cd045c48d932b552e0de93f64d83ee8aa82473c9#cd045c48d932b552e0de93f64d83ee8aa82473c9"
+source = "git+https://github.com/tangramdotdev/tangram?rev=07f25990f9d9d1310e8209fc63a27075dc184230#07f25990f9d9d1310e8209fc63a27075dc184230"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -1924,7 +1924,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2011,7 +2011,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2074,7 +2074,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -2253,7 +2253,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "wasm-bindgen-shared",
 ]
 
@@ -2275,7 +2275,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2495,7 +2495,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.55",
 ]
 
 [[package]]

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -19,8 +19,8 @@ itertools = "0.12"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "cd045c48d932b552e0de93f64d83ee8aa82473c9" }
-tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "cd045c48d932b552e0de93f64d83ee8aa82473c9" }
+tangram_client = { git = "https://github.com/tangramdotdev/tangram", rev = "07f25990f9d9d1310e8209fc63a27075dc184230" }
+tangram_error = { git = "https://github.com/tangramdotdev/tangram", rev = "07f25990f9d9d1310e8209fc63a27075dc184230" }
 tokio = { version = "1", default-features = false, features = [
   "rt",
   "macros",

--- a/packages/std/assert.tg.ts
+++ b/packages/std/assert.tg.ts
@@ -325,7 +325,7 @@ export let linkableLib = async (arg: LibraryArg) => {
 		}
 	}
 
-	let hostOs = tg.Triple.os(await tg.Triple.host());
+	let hostOs = std.triple.os(await std.triple.host());
 	let dylibExtension = hostOs === "darwin" ? "dylib" : "so";
 
 	let dylibName = (name: string) => `lib${name}.${dylibExtension}`;

--- a/packages/std/bootstrap.tg.ts
+++ b/packages/std/bootstrap.tg.ts
@@ -211,13 +211,13 @@ export let remoteComponent = tg.target(async (componentName: string) => {
 export let componentList = async (arg?: Arg) => {
 	let { host } = await configureComponent(arg);
 
-	let linuxComponents = (host: string) => {
-		let hostString = host.replace("-", "_");
+	let linuxComponents = (hostTriple: string) => {
+		let host = hostTriple.replace("-", "_");
 		return [
-			`dash_${hostString}`,
-			`env_${hostString}`,
-			`toolchain_${hostString}`,
-			`utils_${hostString}`,
+			`dash_${host}`,
+			`env_${host}`,
+			`toolchain_${host}`,
+			`utils_${host}`,
 		];
 	};
 	let darwinComponents = [

--- a/packages/std/bootstrap/make.tg.ts
+++ b/packages/std/bootstrap/make.tg.ts
@@ -15,7 +15,9 @@ export let source = tg.target(() => {
 	return std.download.fromGnu({ name, version, checksum });
 });
 
-export let build = tg.target(async (arg?: tg.Triple.HostArg) => {
+export let build = tg.target(async (arg?: string) => {
+	let host = arg ?? await std.triple.host();
+
 	let configure = {
 		args: ["--disable-dependency-tracking"],
 	};
@@ -37,7 +39,7 @@ export let build = tg.target(async (arg?: tg.Triple.HostArg) => {
 	};
 
 	let output = std.autotools.build({
-		host: tg.Triple.host(arg),
+		host,
 		opt: "s",
 		phases,
 		prefixArg: "none",

--- a/packages/std/bootstrap/musl.tg.ts
+++ b/packages/std/bootstrap/musl.tg.ts
@@ -32,8 +32,8 @@ export let source = tg.target(async () => {
 });
 
 export let build = tg.target(async (arg?: std.sdk.BuildEnvArg) => {
-	let host = await tg.Triple.host(arg);
-	let hostSystem = tg.Triple.archAndOs(host);
+	let host = arg?.host ?? await std.triple.host();
+	let hostSystem = std.triple.archAndOs(host);
 
 	let configure = { args: [`--enable-debug`, `--enable-optimize=*`] };
 
@@ -47,8 +47,8 @@ export let build = tg.target(async (arg?: std.sdk.BuildEnvArg) => {
 	};
 
 	let env = [
-		bootstrap.sdk.env(arg),
-		bootstrap.make.build(arg),
+		bootstrap.sdk.env(host),
+		bootstrap.make.build(host),
 		{
 			CPATH: tg.Mutation.unset(),
 		},
@@ -73,17 +73,15 @@ export let build = tg.target(async (arg?: std.sdk.BuildEnvArg) => {
 
 export default build;
 
-export let interpreterPath = (triple: tg.Triple.Arg) =>
+export let interpreterPath = (triple: string) =>
 	`lib/${interpreterName(triple)}`;
 
-export let interpreterName = (triple: tg.Triple.Arg) => {
-	let arch = tg.Triple.arch(tg.Triple.archAndOs(tg.triple(triple)));
+export let interpreterName = (triple: string) => {
+	let arch = std.triple.arch(triple);
 	return `ld-musl-${arch}.so.1`;
 };
 
-export let linkerPath = (tripleArg: tg.Triple.Arg) => {
-	let triple = tg.triple(tripleArg);
-	triple.environment = "musl";
-	let tripleString = tg.Triple.toString(triple);
-	return `${tripleString}/bin/ld`;
+export let linkerPath = (triple: string) => {
+	std.triple.assert(triple);
+	return `${triple}/bin/ld`;
 };

--- a/packages/std/bootstrap/sdk.tg.ts
+++ b/packages/std/bootstrap/sdk.tg.ts
@@ -2,8 +2,8 @@ import * as bootstrap from "../bootstrap.tg.ts";
 import * as std from "../tangram.tg.ts";
 
 /** Get a build environment containing only the components from the pre-built bootstrap artifacts with no proxying. Instead of using this env directly, consider using `std.sdk({ bootstrapMode: true })`, which can optionally include the linker and/or cc proxies. */
-export let env = async (arg?: tg.Triple.HostArg): Promise<std.env.Arg> => {
-	let host = await tg.Triple.host(arg);
+export let env = async (arg?: string): Promise<std.env.Arg> => {
+	let host = await std.triple.host(arg);
 	let toolchain = await prepareBootstrapToolchain({ host });
 	let bootstrapHost = bootstrap.toolchainTriple(host);
 	let utils = await prepareBootstrapUtils(bootstrapHost);
@@ -25,13 +25,13 @@ export let env = async (arg?: tg.Triple.HostArg): Promise<std.env.Arg> => {
 export default env;
 
 /** Get the bootstrap components as a single directory, for use before SDK. */
-export let prepareBootstrapToolchain = async (arg?: tg.Triple.HostArg) => {
+export let prepareBootstrapToolchain = async (arg?: string) => {
 	// Detect the host triple if not provided.
-	let host = await tg.Triple.host(arg);
+	let host = arg?.host ?? await std.triple.host();
 
 	// Obtain the bootstrap toolchain and triple for the detected host to construct the env.
 	let bootstrapToolchain = await bootstrap.toolchain({ host });
-	let bootstrapTripleString = tg.Triple.toString(
+	let bootstrapTripleString = std.triple.toString(
 		bootstrap.toolchainTriple(host),
 	);
 
@@ -68,7 +68,7 @@ export let prepareBootstrapToolchain = async (arg?: tg.Triple.HostArg) => {
 };
 
 /** Combine the busybox/toybox artifact with the dash shell from the bootstrap. */
-export let prepareBootstrapUtils = async (hostArg: tg.Triple.Arg) => {
+export let prepareBootstrapUtils = async (hostArg: string) => {
 	let host = tg.triple(hostArg);
 	let shell = await bootstrap.shell({ host });
 	let shellFile = tg.File.expect(await shell.get("bin/dash"));
@@ -101,7 +101,7 @@ export let prefixBins = async (
 
 export let test = tg.target(async () => {
 	let sdk = await env();
-	let detectedHost = await tg.Triple.host();
+	let detectedHost = await std.triple.host();
 	let expectedHost = bootstrap.toolchainTriple(detectedHost);
 	await std.sdk.assertValid(sdk, { host: expectedHost, bootstrapMode: true });
 	return sdk;

--- a/packages/std/build.tg.ts
+++ b/packages/std/build.tg.ts
@@ -5,7 +5,7 @@ export async function build(
 	...args: tg.Args<build.Arg>
 ): Promise<tg.Artifact | undefined> {
 	type Apply = {
-		system: tg.Triple;
+		system: string;
 		checksum: tg.Checksum;
 	};
 	let { system, checksum } = await tg.Args.apply<build.Arg, Apply>(
@@ -26,13 +26,13 @@ export async function build(
 	let executable = await std.wrap(...args);
 
 	// If the system was not set in the args, then get it from the executable or the host.
-	let host = await tg.Triple.host();
+	let host = await std.triple.host();
 	if (!system) {
 		let executableTriples = await std.file.executableTriples(executable);
 		let hostSystem = executableTriples?.includes(host)
 			? host
 			: executableTriples?.at(0);
-		system = tg.Triple.archAndOs(hostSystem ?? host);
+		system = std.triple.archAndOs(hostSystem ?? host);
 	}
 	system = system ?? host;
 
@@ -50,7 +50,7 @@ export namespace build {
 	export type Arg = string | tg.Template | tg.File | tg.Symlink | ArgObject;
 
 	export type ArgObject = std.wrap.ArgObject & {
-		system?: tg.Triple;
+		system?: string;
 		unsafe?: boolean;
 		checksum?: tg.Checksum;
 		network?: boolean;

--- a/packages/std/file.tg.ts
+++ b/packages/std/file.tg.ts
@@ -58,10 +58,10 @@ export let executableMetadata = async (
 /** Attempt to determine the systems an executable is able to run on. */
 export let executableTriples = async (
 	file: tg.File,
-): Promise<Array<std.triple> | undefined> => {
+): Promise<Array<string> | undefined> => {
 	let metadata = await executableMetadata(file);
 	let arches: Array<string>;
-	let os: std.triple.Os;
+	let os: string;
 	if (metadata.format === "elf") {
 		arches = [metadata.arch];
 		os = "linux";
@@ -71,7 +71,7 @@ export let executableTriples = async (
 	} else {
 		return undefined;
 	}
-	return arches.map((arch) => tg.triple({ arch, os }));
+	return arches.map((arch) => std.triple.create({ arch, os }));
 };
 
 type ExecutableKind = "elf" | "mach-o" | "shebang" | "unknown";
@@ -313,8 +313,8 @@ let MACHO_MAGIC_64_LE = [0xcf, 0xfa, 0xed, 0xfe];
 
 let machoExecutableMetadata = (
 	bytes: Uint8Array,
-): { arches: Array<std.triple.Arch> } => {
-	let arches: Set<std.triple.Arch> = new Set();
+): { arches: Array<string> } => {
+	let arches: Set<string> = new Set();
 	let data = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
 
 	// Read the arches.

--- a/packages/std/file.tg.ts
+++ b/packages/std/file.tg.ts
@@ -58,10 +58,10 @@ export let executableMetadata = async (
 /** Attempt to determine the systems an executable is able to run on. */
 export let executableTriples = async (
 	file: tg.File,
-): Promise<Array<tg.Triple> | undefined> => {
+): Promise<Array<std.triple> | undefined> => {
 	let metadata = await executableMetadata(file);
 	let arches: Array<string>;
-	let os: tg.Triple.Os;
+	let os: std.triple.Os;
 	if (metadata.format === "elf") {
 		arches = [metadata.arch];
 		os = "linux";
@@ -313,8 +313,8 @@ let MACHO_MAGIC_64_LE = [0xcf, 0xfa, 0xed, 0xfe];
 
 let machoExecutableMetadata = (
 	bytes: Uint8Array,
-): { arches: Array<tg.Triple.Arch> } => {
-	let arches: Set<tg.Triple.Arch> = new Set();
+): { arches: Array<std.triple.Arch> } => {
+	let arches: Set<std.triple.Arch> = new Set();
 	let data = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
 
 	// Read the arches.

--- a/packages/std/image.tg.ts
+++ b/packages/std/image.tg.ts
@@ -90,7 +90,7 @@ export let testBasicRootfs = tg.target(async () => {
 });
 
 export let testOciBasicEnv = tg.target(async () => {
-	let detectedHost = await tg.Triple.host();
+	let detectedHost = await std.triple.host();
 	let host = bootstrap.toolchainTriple(detectedHost);
 	let utils = await std.utils.env({ host, sdk: { bootstrapMode: true } });
 	let basicEnv = await std.env(
@@ -104,7 +104,7 @@ export let testOciBasicEnv = tg.target(async () => {
 export let testBasicEnvImage = tg.target(async () => {
 	let basicEnv = await testOciBasicEnv();
 	let imageFile = await image(basicEnv, {
-		 cmd: ["bash"],
+		cmd: ["bash"],
 	});
 	return imageFile;
 });

--- a/packages/std/image/oci.tg.ts
+++ b/packages/std/image/oci.tg.ts
@@ -18,7 +18,7 @@ import * as std from "../tangram.tg.ts";
 
 export type Arg = (ExecutableArg | RootFsArg) & {
 	/** The image should target a specific system. If not provided, will detect the host. */
-	system?: tg.Triple.Arg;
+	system?: string;
 };
 
 type ExecutableArg = {
@@ -43,7 +43,7 @@ export let image = async (...args: tg.Args<Arg>): Promise<tg.File> => {
 		entrypointArtifact: tg.File;
 		entrypointString: Array<string>;
 		rootDir: Array<tg.Directory>;
-		system: tg.Triple.Arg;
+		system: string;
 	};
 	let {
 		cmdString,
@@ -105,7 +105,7 @@ export let image = async (...args: tg.Args<Arg>): Promise<tg.File> => {
 			if (arg.system) {
 				object.system = tg.Mutation.is(arg.system)
 					? arg.system
-					: tg.Triple.archAndOs(tg.triple(arg.system));
+					: std.triple.archAndOs(tg.triple(arg.system));
 			}
 			return object;
 		} else {
@@ -114,7 +114,7 @@ export let image = async (...args: tg.Args<Arg>): Promise<tg.File> => {
 	});
 
 	// Fill in defaults.
-	let system = await tg.Triple.host(system_);
+	let system = await std.triple.host(system_);
 
 	// Combine all root dirs.
 	let rootDir =
@@ -287,8 +287,8 @@ export type Platform = {
 	features?: Array<string>;
 };
 
-export let platform = (system: tg.Triple.Arg): Platform => {
-	switch (tg.Triple.toString(tg.triple(system))) {
+export let platform = (system: string): Platform => {
+	switch (std.triple.toString(tg.triple(system))) {
 		case "x86_64-linux":
 			return {
 				architecture: "amd64",

--- a/packages/std/image/oci.tg.ts
+++ b/packages/std/image/oci.tg.ts
@@ -105,7 +105,7 @@ export let image = async (...args: tg.Args<Arg>): Promise<tg.File> => {
 			if (arg.system) {
 				object.system = tg.Mutation.is(arg.system)
 					? arg.system
-					: std.triple.archAndOs(tg.triple(arg.system));
+					: std.triple.archAndOs(arg.system);
 			}
 			return object;
 		} else {
@@ -114,7 +114,7 @@ export let image = async (...args: tg.Args<Arg>): Promise<tg.File> => {
 	});
 
 	// Fill in defaults.
-	let system = await std.triple.host(system_);
+	let system = system_ ?? (await std.triple.host());
 
 	// Combine all root dirs.
 	let rootDir =
@@ -288,7 +288,7 @@ export type Platform = {
 };
 
 export let platform = (system: string): Platform => {
-	switch (std.triple.toString(tg.triple(system))) {
+	switch (std.triple.archAndOs(system)) {
 		case "x86_64-linux":
 			return {
 				architecture: "amd64",

--- a/packages/std/packages/cc_proxy/src/main.rs
+++ b/packages/std/packages/cc_proxy/src/main.rs
@@ -345,8 +345,7 @@ async fn main_inner() -> Result<()> {
 
 	// Create the target.
 	let target = tg::Target::with_object(tg::target::Object {
-		host: tg::Triple::host()
-			.map_err(|error| error!(source = error, "failed to get tg::Triple::host()"))?,
+		host: host().to_string(),
 		executable,
 		lock: None,
 		name: Some("tangram_cc".into()),
@@ -598,6 +597,25 @@ async fn check_in_source_tree(
 		})
 		.collect();
 	Ok(templates)
+}
+
+fn host() -> &'static str {
+	#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+	{
+		"aarch64-darwin"
+	}
+	#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+	{
+		"aarch64-linux"
+	}
+	#[cfg(all(target_arch = "x86_64", target_os = "macos"))]
+	{
+		"x86_64-darwin"
+	}
+	#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+	{
+		"x86_64-linux"
+	}
 }
 
 const DRIVER_SH: &str = include_str!("driver.sh");

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -78,11 +78,12 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 
 	// If we're in bootstrap mode, stop here and return the bootstrap SDK.
 	let bootstrapMode = (bootstrapMode_ ?? []).some((mode) => mode);
+	let detectedHost = await std.triple.host();
 	let host = bootstrapMode
-		? bootstrap.toolchainTriple(await std.triple.host())
-		: normalizeTriple(host_ ? tg.triple(host_) : await std.triple.host());
+		? bootstrap.toolchainTriple(detectedHost)
+		: canonicalTriple(host_ ?? detectedHost);
 	if (bootstrapMode) {
-		let bootstrapSDK = bootstrap.sdk.env({ host });
+		let bootstrapSDK = bootstrap.sdk.env(host);
 		let proxyEnv = proxy.env({
 			...proxyArg,
 			bootstrapMode,
@@ -91,22 +92,23 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 		});
 		return std.env.object(bootstrapSDK, proxyEnv);
 	}
+	let hostComponents = std.triple.components(host);
 
 	// Collect target array.
-	let targets = (targets_ ?? []).map((t) => normalizeTriple(tg.triple(t)));
+	let targets = (targets_ ?? []).map((t) => canonicalTriple(t));
 	if (targets.length === 0) {
 		targets = [host];
 	}
 
-	if (linker && host.os === "darwin") {
+	if (linker && hostComponents.os === "darwin") {
 		return tg.unimplemented(
 			"Linker swapping is currently unsupported on macOS.",
 		);
 	}
 
-	if (host.os === "darwin") {
+	if (hostComponents.os === "darwin") {
 		// Build the utils using the bootstrap SDK and add them to the env.
-		let bootstrapSDK = await bootstrap.sdk.env({ host });
+		let bootstrapSDK = await bootstrap.sdk.env(host);
 		let proxyEnv = await proxy.env({
 			...proxyArg,
 			buildToolchain: bootstrapSDK,
@@ -122,14 +124,13 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 		});
 	}
 
-	let toolchain = toolchain_ ?? (host.vendor === "apple" ? "llvm" : "gcc");
+	let toolchain =
+		toolchain_ ?? (hostComponents.vendor === "apple" ? "llvm" : "gcc");
 	for (let target of targets) {
-		if (!std.triple.eq(host, target)) {
-			let hostString = std.triple.toString(host);
-			let targetString = std.triple.toString(target);
+		if (!(host === target)) {
 			tg.assert(
 				validateCrossTarget({ host, target }),
-				`Cross-compiling from ${hostString} to ${targetString} is not supported.`,
+				`Cross-compiling from ${host} to ${target} is not supported.`,
 			);
 		}
 	}
@@ -142,10 +143,9 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 		let directory = toolchain;
 		let allCrossTargets = await sdk.supportedTargets(directory);
 		// For each requested target not already present in a provided SDK, add a proxy.
-		let alreadyProxied: Array<std.triple> = [];
+		let alreadyProxied: Array<string> = [];
 		let newTargets = allCrossTargets.filter(
-			(target) =>
-				!alreadyProxied.some((triple) => std.triple.eq(triple, target)),
+			(target) => !alreadyProxied.some((triple) => triple === target),
 		);
 
 		// Ensure the directory provides a toolchain configured with the correct host.
@@ -154,28 +154,19 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 			env: directory,
 			target: checkTarget,
 		});
-		let hostString = std.triple.toString(host);
-		let detectedHostString = std.triple.toString(detectedHost);
 		tg.assert(
-			std.triple.eq(detectedHost, host),
-			`Detected toolchain host ${detectedHostString} does not match requested host ${hostString}`,
+			detectedHost === host,
+			`Detected toolchain host ${detectedHost} does not match requested host ${host}`,
 		);
 		env.push(directory);
 
 		for await (let requestedTarget of targets) {
-			if (
-				alreadyProxied.some((triple) => std.triple.eq(triple, requestedTarget))
-			) {
+			if (alreadyProxied.some((triple) => triple === requestedTarget)) {
 				continue;
 			}
-			if (
-				!allCrossTargets.some((triple) =>
-					std.triple.eq(triple, requestedTarget),
-				)
-			) {
-				let targetString = std.triple.toString(requestedTarget);
+			if (!allCrossTargets.some((triple) => triple === requestedTarget)) {
 				throw new Error(
-					`Provided toolchain does not provide a ${hostString} -> ${targetString} toolchain.`,
+					`Provided toolchain does not provide a ${host} -> ${checkTarget} toolchain.`,
 				);
 			}
 			env.push(
@@ -218,7 +209,7 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 		// Add any requested cross-compilers, without packages.
 		let crossEnvs = [];
 		for await (let target of targets) {
-			if (std.triple.eq(host, target)) {
+			if (host === target) {
 				continue;
 			}
 			let crossToolchain = await gcc.toolchain({ host, target });
@@ -361,15 +352,15 @@ export namespace sdk {
 			llvm = false,
 			target: target_,
 		} = arg;
-		let host = host_ ? tg.triple(host_) : await std.triple.host();
-		let target = target_ ? tg.triple(target_) : host;
-		let isCross = !std.triple.eq(host, target);
+		let host = host_ ?? (await std.triple.host());
+		let target = target_ ?? host;
+		let isCross = host !== target;
 		// Provides binutils, cc/c++.
 		let targetPrefix = ``;
 		if (isCross && !bootstrapMode) {
-			let os = tg.triple(target).os;
+			let os = std.triple.os(target);
 			if (os !== "darwin") {
-				targetPrefix = `${std.triple.toString(target)}-`;
+				targetPrefix = `${target}-`;
 			}
 		}
 		let llvmPrefix = llvm ? "llvm-" : "";
@@ -400,9 +391,9 @@ export namespace sdk {
 		let { env, target } = arg;
 		let targetPrefix = ``;
 		if (target) {
-			let os = tg.triple(target).os;
+			let os = std.triple.os(target);
 			if (os !== "darwin") {
-				targetPrefix = `${std.triple.toString(tg.triple(target))}-`;
+				targetPrefix = `${target}-`;
 			}
 		}
 		if (arg.llvm) {
@@ -440,11 +431,10 @@ export namespace sdk {
 			target: targetTriple,
 		});
 		let host = await getHost({ env, host: host_, llvm });
-		let os = host.os;
-		let target = targetTriple ? tg.triple(targetTriple) : host;
-		let isCross = !std.triple.eq(host, target);
-		let targetString = std.triple.toString(target);
-		let targetPrefix = isCross && !bootstrapMode ? `${targetString}-` : ``;
+		let os = std.triple.os(host);
+		let target = targetTriple ?? host;
+		let isCross = host !== target;
+		let targetPrefix = isCross && !bootstrapMode ? `${target}-` : ``;
 
 		// Set the default flavor for the os at first, to confirm later.
 		let flavor: "gcc" | "llvm" = os === "linux" ? "gcc" : "llvm";
@@ -599,47 +589,51 @@ export namespace sdk {
 	export let supportsTarget = async (
 		arg: ToolchainEnvArg,
 	): Promise<boolean> => {
-		let target = arg.target ? tg.triple(arg.target) : await std.triple.host();
-		if ((await std.triple.host()).os === "darwin" && target.os === "darwin") {
+		let detectedHost = await std.triple.host();
+		let target = arg.target ?? detectedHost;
+		if (
+			std.triple.os(detectedHost) === "darwin" &&
+			std.triple.os(target) === "darwin"
+		) {
 			return true;
 		}
 
 		let allTargets = await supportedTargets(arg.env);
-		return allTargets.some((t) => std.triple.eq(t, target));
+		return allTargets.some((t) => t === target);
 	};
 
 	/** Retreive the full range of targets an SDK supports. */
 	export let supportedTargets = async (
 		sdk: std.env.Arg,
-	): Promise<Array<std.triple>> => {
+	): Promise<Array<string>> => {
 		// Collect all available `*cc` binaries.
-		let foundTargets: Set<std.triple> = new Set();
+		let foundTargets: Set<string> = new Set();
 
 		for await (let [name, _] of std.env.binsInPath({
 			env: sdk,
 			predicate: (name) => name.endsWith("-cc"),
 		})) {
-			let tripleString = name.slice(0, -3);
-			foundTargets.add(tg.triple(tripleString));
+			let triple = name.slice(0, -3);
+			foundTargets.add(triple);
 		}
 		return Array.from(foundTargets);
 	};
 
 	/** Obtain the host system for the compilers provided by this env. Throws an error if no compiler is found. */
-	export let getHost = async (arg: ToolchainEnvArg): Promise<std.triple> => {
-		let { env, host: host_, target } = arg;
-		let detectedHost = host_ ? tg.triple(host_) : await std.triple.host();
+	export let getHost = async (arg: ToolchainEnvArg): Promise<string> => {
+		let { env, host: host_, target: target_ } = arg;
+		let detectedHost = host_ ?? (await std.triple.host());
 
-		if (detectedHost.os === "darwin") {
+		if (std.triple.os(detectedHost) === "darwin") {
 			return detectedHost;
 		}
 
 		// Locate the C compiler using the CC variable if set, falling back to "cc" in PATH if not.
-		let targetString = target ? std.triple.toString(tg.triple(target)) : "";
-		let ccEnvVar = target ? `CC_${targetString.replace(/-/g, "_")}` : "CC";
+		let target = target_ ?? "";
+		let ccEnvVar = target ? `CC_${target.replace(/-/g, "_")}` : "CC";
 		let cmd = `$${ccEnvVar}`;
 		let foundCC = await std.env.tryGetArtifactByKey({ env, key: ccEnvVar });
-		let targetPrefix = target ? `${targetString}-` : "";
+		let targetPrefix = target ? `${target}-` : "";
 		if (!foundCC) {
 			let name = arg?.llvm ? "clang" : `${targetPrefix}cc`;
 			foundCC = await std.env.tryWhich({ env, name });
@@ -665,8 +659,9 @@ export namespace sdk {
 			} else if (metadata.format === "mach-o") {
 				detectedArch = metadata.arches[0] ?? "aarch64";
 			}
-			let os: std.triple.Os = metadata.format === "elf" ? "linux" : "darwin";
-			detectedHost = tg.triple({ arch: detectedArch ?? "x86_64", os });
+			let os = metadata.format === "elf" ? "linux" : "darwin";
+			let arch = detectedArch ?? "x86_64";
+			detectedHost = `${arch}-${os}`;
 		}
 
 		// Actually run the compiler on the detected system to ask what host triple it's configured for.
@@ -677,19 +672,20 @@ export namespace sdk {
 			}),
 		);
 		let host = (await output.text()).trim();
-		return tg.triple(host);
+		std.triple.assert(host);
+		return host;
 	};
 
 	export let resolveHostAndTarget = async (
 		arg?: HostAndTargetsOptions,
 	): Promise<HostAndTargets> => {
-		let host = arg?.host ? tg.triple(arg.host) : await std.triple.host();
+		let host = arg?.host ?? (await std.triple.host());
 		let targets = [];
 		if (arg?.target) {
-			targets.push(tg.triple(arg.target));
+			targets.push(arg.target);
 		}
 		if (arg?.targets) {
-			targets = targets.concat(arg.targets.map((t) => tg.triple(t)));
+			targets = targets.concat(arg.targets);
 		}
 		// If empty, set to host.
 		if (targets.length === 0) {
@@ -712,8 +708,8 @@ export namespace sdk {
 		tg.assert(expectedTarget);
 
 		// Determine compiler target prefix, if any.
-		let isCross = !std.triple.eq(expectedHost, expectedTarget);
-		let targetPrefix = isCross ? `${std.triple.toString(expectedTarget)}-` : ``;
+		let isCross = expectedHost !== expectedTarget;
+		let targetPrefix = isCross ? `${expectedTarget}-` : ``;
 
 		// Set up test parameters.
 		let { lang, testProgram, expectedOutput } = arg.parameters;
@@ -747,7 +743,7 @@ export namespace sdk {
 		);
 
 		// Assert the resulting program was compiled for the expected target.
-		let expectedArch = expectedTarget.arch;
+		let expectedArch = std.triple.arch(expectedTarget);
 		let metadata = await std.file.executableMetadata(compiledProgram);
 		if (metadata.format === "elf") {
 			let actualArch = metadata.arch;
@@ -808,11 +804,12 @@ export namespace sdk {
 			actualHostOs === expectedHostOs,
 			`Given env provides an SDK with host os ${actualHostOs} instead of expected ${expectedHostOs}.`,
 		);
-		if (expected.host.environment) {
+		let expectedHostEnvironment = std.triple.tryEnvironment(expected.host);
+		if (expectedHostEnvironment) {
 			let actualHostEnvironment = std.triple.environment(actualHost);
 			tg.assert(
-				actualHostEnvironment === expected.host.environment,
-				`Given env provides an SDK with host environment ${actualHostEnvironment} instead of expected ${expected.host.environment}.`,
+				actualHostEnvironment === expectedHostEnvironment,
+				`Given env provides an SDK with host environment ${actualHostEnvironment} instead of expected ${expectedHostEnvironment}.`,
 			);
 		}
 
@@ -827,7 +824,7 @@ export namespace sdk {
 
 		// Assert it can compile and wrap for all requested targets.
 		let allTargets =
-			actualHost.os === "linux" && arg?.toolchain !== "llvm"
+			std.triple.os(actualHost) === "linux" && arg?.toolchain !== "llvm"
 				? await sdk.supportedTargets(env)
 				: [actualHost];
 		await Promise.all(
@@ -858,7 +855,7 @@ export namespace sdk {
 				});
 
 				// Test Fortran.
-				if (target.os !== "darwin" && arg?.toolchain !== "llvm") {
+				if (std.triple.os(target) !== "darwin" && arg?.toolchain !== "llvm") {
 					await assertProxiedCompiler({
 						parameters: testFortranParameters,
 						sdk: env,
@@ -878,7 +875,7 @@ export namespace sdk {
 
 	export type HostAndTargets = {
 		host: string;
-		targets: Array<std.triple>;
+		targets: Array<string>;
 	};
 
 	export type LinkerKind = "bfd" | "lld" | "mold" | tg.Symlink | tg.File;
@@ -893,21 +890,23 @@ type ValidateCrossTargetArg = {
 };
 
 let validateCrossTarget = (arg: ValidateCrossTargetArg) => {
-	let host = arg.host;
-	let target = arg.target;
+	let { host, target } = arg;
 
 	// All triples can compile for themselves.
-	if (std.triple.eq(host, target)) {
+	if (host === target) {
 		return true;
 	}
 
+	let hostOs = std.triple.os(host);
+	let targetOs = std.triple.os(target);
+
 	// The default darwin toolchain supports cross-compiling to other darwin architectures.
-	if (host.os === "darwin" && target.os === "darwin") {
+	if (hostOs === "darwin" && targetOs === "darwin") {
 		return true;
 	}
 
 	// Linux supports cross compiling to other linux architectures.
-	if (host.os === "linux" && target.os === "linux") {
+	if (hostOs === "linux" && targetOs === "linux") {
 		return true;
 	}
 
@@ -952,29 +951,22 @@ export let mergeLibDirs = async (dir: tg.Directory) => {
 };
 
 /** Produce the canonical version of the triple used by the toolchain. */
-export let normalizeTriple = (triple: std.triple): std.triple => {
-	let normalized = std.triple.normalized(triple);
-	tg.assert(normalized, "Expected the detected host to normalize correctly");
-	let base = tg.triple(normalized);
-	if (base.os === "linux") {
-		return tg.triple({
-			arch: base.arch,
-			vendor: base.vendor,
-			os: base.os,
-			environment: std.triple.environment(base) ?? "gnu",
+export let canonicalTriple = (triple: string): string => {
+	let components = std.triple.components(std.triple.normalize(triple));
+	if (components.os === "linux") {
+		return std.triple.create({
+			...components,
+			environment: components.environment ?? "gnu",
 		});
-	} else if (base.os === "darwin") {
-		return tg.triple({
-			arch: base.arch,
+	} else if (components.os === "darwin") {
+		return std.triple.create({
+			...components,
 			vendor: "apple",
-			os: base.os,
 		});
 	} else {
-		throw new Error(`Unsupported OS ${base.os}`);
+		throw new Error(`Unsupported OS ${components.os}`);
 	}
 };
-
-/** Resolve an optional host arg to a concrete host, falling back to the detected host if not present. */
 
 //////// TESTS
 
@@ -1029,7 +1021,7 @@ type ProxyTestArg = {
 
 export let testMoldSdk = tg.target(async () => {
 	let detectedHost = await std.triple.host();
-	if (detectedHost.os !== "linux") {
+	if (std.triple.os(detectedHost) !== "linux") {
 		throw new Error(`mold is only available on Linux`);
 	}
 
@@ -1068,10 +1060,10 @@ export let testMoldSdk = tg.target(async () => {
 
 export let testMuslSdk = tg.target(async () => {
 	let host = await std.triple.host();
-	if (host.os !== "linux") {
+	if (std.triple.os(host) !== "linux") {
 		throw new Error(`musl is only available on Linux`);
 	}
-	let muslHost = tg.triple({ ...host, environment: "musl" });
+	let muslHost = std.triple.create(host, { environment: "musl" });
 	let sdkArg = { host: muslHost };
 	let env = await sdk(sdkArg);
 	await sdk.assertValid(env, sdkArg);
@@ -1086,7 +1078,7 @@ export let testLLVMSdk = tg.target(async () => {
 
 export let testLLVMMoldSdk = tg.target(async () => {
 	let detectedHost = await std.triple.host();
-	if (detectedHost.os !== "linux") {
+	if (std.triple.os(detectedHost) !== "linux") {
 		throw new Error(`mold is only available on Linux`);
 	}
 
@@ -1129,10 +1121,13 @@ export let testLLVMMoldSdk = tg.target(async () => {
 
 export let testExplicitGlibcVersionSdk = tg.target(async () => {
 	let host = await std.triple.host();
-	if (host.os !== "linux") {
+	if (std.triple.os(host) !== "linux") {
 		throw new Error(`glibc is only available on Linux`);
 	}
-	let oldGlibcHost = tg.triple(`${host.arch}-linux-gnu2.37`);
+	let oldGlibcHost = std.triple.create(host, {
+		environment: "gnu",
+		environmentVersion: "2.37",
+	});
 	let sdkArg = { host: oldGlibcHost };
 	let env = await sdk(sdkArg);
 	await sdk.assertValid(env, sdkArg);
@@ -1141,10 +1136,10 @@ export let testExplicitGlibcVersionSdk = tg.target(async () => {
 
 export let testLLVMMuslSdk = tg.target(async () => {
 	let host = await std.triple.host();
-	if (host.os !== "linux") {
+	if (std.triple.os(host) !== "linux") {
 		throw new Error(`musl is only available on Linux`);
 	}
-	let muslHost = tg.triple({ ...host, environment: "musl" });
+	let muslHost = std.triple.create(host, { environment: "musl" });
 	let sdkArg = { host: muslHost, toolchain: "llvm" as const };
 	let env = await sdk(sdkArg);
 	await sdk.assertValid(env, sdkArg);

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -804,7 +804,7 @@ export namespace sdk {
 			actualHostOs === expectedHostOs,
 			`Given env provides an SDK with host os ${actualHostOs} instead of expected ${expectedHostOs}.`,
 		);
-		let expectedHostEnvironment = std.triple.tryEnvironment(expected.host);
+		let expectedHostEnvironment = std.triple.environment(expected.host);
 		if (expectedHostEnvironment) {
 			let actualHostEnvironment = std.triple.environment(actualHost);
 			tg.assert(

--- a/packages/std/sdk/binutils.tg.ts
+++ b/packages/std/sdk/binutils.tg.ts
@@ -56,13 +56,10 @@ export let build = tg.target(async (arg?: Arg) => {
 		target: target_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
-	let target = target_ ? tg.triple(target_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
+	let target = target_ ?? host;
 
-	let buildString = std.triple.toString(build);
-	let hostString = std.triple.toString(host);
-	let targetString = std.triple.toString(target);
 	let buildPhase = arg?.staticBuild
 		? `make && make clean && make LDFLAGS=-all-static`
 		: undefined;
@@ -71,8 +68,8 @@ export let build = tg.target(async (arg?: Arg) => {
 	if (staticBuild) {
 		additionalEnv = {
 			...additionalEnv,
-			CC: await tg`${targetString}-cc -static -fPIC`,
-			CXX: await tg`${targetString}-c++ -static-libstdc++ -fPIC`,
+			CC: await tg`${target}-cc -static -fPIC`,
+			CXX: await tg`${target}-c++ -static-libstdc++ -fPIC`,
 		};
 	}
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
@@ -93,9 +90,9 @@ export let build = tg.target(async (arg?: Arg) => {
 			"--disable-nls",
 			"--disable-werror",
 			"--enable-gprofng=no",
-			`--build=${buildString}`,
-			`--host=${hostString}`,
-			`--target=${targetString}`,
+			`--build=${build}`,
+			`--host=${host}`,
+			`--target=${target}`,
 		],
 	};
 

--- a/packages/std/sdk/binutils.tg.ts
+++ b/packages/std/sdk/binutils.tg.ts
@@ -79,7 +79,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	env.push(
 		dependencies.env({
 			...rest,
-			env: std.sdk({ host: build, bootstrapMode: true }),
+			env: env_,
 			host: build,
 		}),
 	);

--- a/packages/std/sdk/binutils.tg.ts
+++ b/packages/std/sdk/binutils.tg.ts
@@ -7,7 +7,7 @@ export let metadata = {
 	version: "2.42",
 };
 
-export let source = tg.target(async (build: tg.Triple.Arg) => {
+export let source = tg.target(async (build: string) => {
 	let { name, version } = metadata;
 
 	let compressionFormat = ".xz" as const;
@@ -41,7 +41,7 @@ type Arg = std.sdk.BuildEnvArg & {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
 	source?: tg.Directory;
 	staticBuild?: boolean;
-	target?: tg.Triple.Arg;
+	target?: string;
 };
 
 /** Obtain the GNU binutils. */
@@ -56,13 +56,13 @@ export let build = tg.target(async (arg?: Arg) => {
 		target: target_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 	let target = target_ ? tg.triple(target_) : host;
 
-	let buildString = tg.Triple.toString(build);
-	let hostString = tg.Triple.toString(host);
-	let targetString = tg.Triple.toString(target);
+	let buildString = std.triple.toString(build);
+	let hostString = std.triple.toString(host);
+	let targetString = std.triple.toString(target);
 	let buildPhase = arg?.staticBuild
 		? `make && make clean && make LDFLAGS=-all-static`
 		: undefined;
@@ -108,7 +108,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: source_ ?? source(build),

--- a/packages/std/sdk/cmake.tg.ts
+++ b/packages/std/sdk/cmake.tg.ts
@@ -5,13 +5,13 @@ import ninja from "./ninja.tg.ts";
 
 export let metadata = {
 	name: "cmake",
-	version: "3.28.1",
+	version: "3.29.0",
 };
 
 export let source = tg.target(() => {
 	let { version } = metadata;
 	let checksum =
-		"sha256:15e94f83e647f7d620a140a7a5da76349fc47a1bfed66d0f5cdee8e7344079ad";
+		"sha256:a0669630aae7baa4a8228048bf30b622f9e9fd8ee8cedb941754e9e38686c778";
 	let owner = "Kitware";
 	let repo = "CMake";
 	let tag = `v${version}`;

--- a/packages/std/sdk/cmake.tg.ts
+++ b/packages/std/sdk/cmake.tg.ts
@@ -38,7 +38,7 @@ export let cmake = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let sourceDir = source_ ?? source();
@@ -75,7 +75,7 @@ export let cmake = tg.target(async (arg?: Arg) => {
 
 	let result = std.autotools.build({
 		...rest,
-		...tg.Triple.rotate({ build, host }),
+		...std.triple.rotate({ build, host }),
 		env,
 		hardeningCFlags: false,
 		phases: { prepare, configure },
@@ -103,7 +103,7 @@ export let build = tg.target(
 			useNinja = true,
 			...rest
 		} = arg ?? {};
-		let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+		let host = host_ ? tg.triple(host_) : await std.triple.host();
 		let target = target_ ? tg.triple(target_) : host;
 
 		// Set up env vars to pass through the include and library paths.
@@ -166,7 +166,7 @@ export let build = tg.target(
 );
 
 export let test = tg.target(async () => {
-	let detectedHost = await tg.Triple.host();
+	let detectedHost = await std.triple.host();
 	let host = bootstrap.toolchainTriple(detectedHost);
 	let directory = cmake({ host, sdk: { bootstrapMode: true } });
 	await std.assert.pkg({

--- a/packages/std/sdk/cmake.tg.ts
+++ b/packages/std/sdk/cmake.tg.ts
@@ -38,8 +38,8 @@ export let cmake = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let sourceDir = source_ ?? source();
 
@@ -103,8 +103,8 @@ export let build = tg.target(
 			useNinja = true,
 			...rest
 		} = arg ?? {};
-		let host = host_ ? tg.triple(host_) : await std.triple.host();
-		let target = target_ ? tg.triple(target_) : host;
+		let host = host_ ?? (await std.triple.host());
+		let target = target_ ?? host;
 
 		// Set up env vars to pass through the include and library paths.
 		let cmakeEnv = `

--- a/packages/std/sdk/dependencies.tg.ts
+++ b/packages/std/sdk/dependencies.tg.ts
@@ -45,7 +45,7 @@ export type Arg = std.sdk.BuildEnvArg;
 /** Obtain a directory containing all provided utils. */
 export let env = tg.target(async (arg?: Arg) => {
 	let { host: host_, ...rest } = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 
 	let dependencies = [];
 
@@ -123,7 +123,7 @@ export let assertProvides = async (env: std.env.Arg) => {
 
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let deps = await env({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies.tg.ts
+++ b/packages/std/sdk/dependencies.tg.ts
@@ -45,7 +45,7 @@ export type Arg = std.sdk.BuildEnvArg;
 /** Obtain a directory containing all provided utils. */
 export let env = tg.target(async (arg?: Arg) => {
 	let { host: host_, ...rest } = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
+	let host = host_ ?? (await std.triple.host());
 
 	let dependencies = [];
 

--- a/packages/std/sdk/dependencies.tg.ts
+++ b/packages/std/sdk/dependencies.tg.ts
@@ -45,9 +45,7 @@ export type Arg = std.sdk.BuildEnvArg;
 /** Obtain a directory containing all provided utils. */
 export let env = tg.target(async (arg?: Arg) => {
 	let { host: host_, ...rest } = arg ?? {};
-	let hostTriple = host_ ? tg.triple(host_) : await tg.Triple.host();
-	// Improve cache hits by only using the arch and os for child builds.
-	let host = tg.Triple.archAndOs(hostTriple);
+	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
 
 	let dependencies = [];
 

--- a/packages/std/sdk/dependencies/autoconf.tg.ts
+++ b/packages/std/sdk/dependencies/autoconf.tg.ts
@@ -39,7 +39,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let autoconf = await std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 		},
@@ -181,7 +181,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/automake.tg.ts
+++ b/packages/std/sdk/dependencies/automake.tg.ts
@@ -60,7 +60,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let automake = await std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 		},
@@ -119,7 +119,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/bc.tg.ts
+++ b/packages/std/sdk/dependencies/bc.tg.ts
@@ -41,8 +41,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = await std.triple.host(host_);
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let sourceDir = source_ ?? source();
 
@@ -52,7 +52,8 @@ export let build = tg.target(async (arg?: Arg) => {
 	};
 
 	// Define environment.
-	let ccCommand = build.os == "darwin" ? "cc -D_DARWIN_C_SOURCE" : "cc";
+	let ccCommand =
+		std.triple.os(build) == "darwin" ? "cc -D_DARWIN_C_SOURCE" : "cc";
 	let env = [env_, std.utils.env(arg), { CC: ccCommand }];
 
 	let output = std.utils.buildUtil(

--- a/packages/std/sdk/dependencies/bc.tg.ts
+++ b/packages/std/sdk/dependencies/bc.tg.ts
@@ -41,7 +41,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = await tg.Triple.host(host_);
+	let host = await std.triple.host(host_);
 	let build = build_ ? tg.triple(build_) : host;
 
 	let sourceDir = source_ ?? source();
@@ -58,7 +58,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			buildInTree: true,
 			env,
 			opt: "3",
@@ -75,7 +75,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/bison.tg.ts
+++ b/packages/std/sdk/dependencies/bison.tg.ts
@@ -44,7 +44,7 @@ export let build = tg.target((arg?: Arg) => {
 	let output = std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases: { configure },
 			source: source_ ?? source(),
@@ -60,7 +60,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/file.tg.ts
+++ b/packages/std/sdk/dependencies/file.tg.ts
@@ -39,7 +39,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = await tg.Triple.host(host_);
+	let host = await std.triple.host(host_);
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -58,7 +58,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = await std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			hardeningCFlags: false,
 			phases: { configure },
@@ -89,7 +89,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/file.tg.ts
+++ b/packages/std/sdk/dependencies/file.tg.ts
@@ -39,8 +39,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = await std.triple.host(host_);
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? await std.triple.host();
+	let build = build_ ?? host;
 
 	let configure = {
 		args: [

--- a/packages/std/sdk/dependencies/flex.tg.ts
+++ b/packages/std/sdk/dependencies/flex.tg.ts
@@ -48,7 +48,7 @@ export let build = tg.target((arg?: Arg) => {
 	let output = std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases: { configure },
 			source: source_ ?? source(),
@@ -63,7 +63,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/gperf.tg.ts
+++ b/packages/std/sdk/dependencies/gperf.tg.ts
@@ -36,7 +36,7 @@ export let build = tg.target((arg?: Arg) => {
 	let output = std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases: { configure },
 			source: source(),
@@ -51,7 +51,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/help2man.tg.ts
+++ b/packages/std/sdk/dependencies/help2man.tg.ts
@@ -46,7 +46,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let artifact = std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 		},
@@ -68,7 +68,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/libffi.tg.ts
+++ b/packages/std/sdk/dependencies/libffi.tg.ts
@@ -50,7 +50,7 @@ export let build = tg.target((arg?: Arg) => {
 	return std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases: { configure },
 			source: source_ ?? source(),
@@ -63,7 +63,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/libxcrypt.tg.ts
+++ b/packages/std/sdk/dependencies/libxcrypt.tg.ts
@@ -51,7 +51,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: source_ ?? source(),
@@ -64,7 +64,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/m4.tg.ts
+++ b/packages/std/sdk/dependencies/m4.tg.ts
@@ -37,7 +37,7 @@ export let build = tg.target((arg?: Arg) => {
 	let output = std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases: { configure },
 			source: source_ ?? source(),
@@ -52,7 +52,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/ncurses.tg.ts
+++ b/packages/std/sdk/dependencies/ncurses.tg.ts
@@ -29,8 +29,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? await std.triple.host();
+	let build = build_ ?? host;
 
 	let configure = {
 		args: [

--- a/packages/std/sdk/dependencies/ncurses.tg.ts
+++ b/packages/std/sdk/dependencies/ncurses.tg.ts
@@ -29,7 +29,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -68,7 +68,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: source_ ?? source(),
@@ -80,7 +80,7 @@ export let build = tg.target(async (arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/perl.tg.ts
+++ b/packages/std/sdk/dependencies/perl.tg.ts
@@ -89,7 +89,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let perlArtifact = await std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			prefixArg: "-Dprefix=",
@@ -151,7 +151,7 @@ export let build = tg.target(async (arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = await build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/pkg_config.tg.ts
+++ b/packages/std/sdk/dependencies/pkg_config.tg.ts
@@ -37,7 +37,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -63,7 +63,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let pkgConfigBuild = await std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases,
 			source: source_ ?? source(),
@@ -114,7 +114,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/pkg_config.tg.ts
+++ b/packages/std/sdk/dependencies/pkg_config.tg.ts
@@ -37,8 +37,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? await std.triple.host();
+	let build = build_ ?? host;
 
 	let configure = {
 		args: ["--with-internal-glib", "--disable-dependency-tracking"],
@@ -51,7 +51,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		zlib(arg),
 	];
 	let additionalLibDirs = [];
-	if (build.os === "darwin") {
+	if (std.triple.os(build) === "darwin") {
 		let libiconv = await std.utils.libiconv.build(arg);
 		dependencies.push(libiconv);
 		additionalLibDirs.push(tg.Directory.expect(await libiconv.get("lib")));

--- a/packages/std/sdk/dependencies/python.tg.ts
+++ b/packages/std/sdk/dependencies/python.tg.ts
@@ -11,7 +11,7 @@ export let metadata = {
 	version: "3.12.2",
 };
 
-export let source = tg.target(async (os: tg.Triple.Os) => {
+export let source = tg.target(async (os: std.triple.Os) => {
 	let { name, version } = metadata;
 
 	let unpackFormat = ".tar.xz" as const;
@@ -55,9 +55,9 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = await tg.Triple.host(host_);
+	let host = await std.triple.host(host_);
 	let build = build_ ? tg.triple(build_) : host;
-	let os = tg.Triple.os(build);
+	let os = std.triple.os(build);
 
 	let additionalEnv: std.env.Arg = {
 		TANGRAM_LINKER_LIBRARY_PATH_OPT_LEVEL: "resolve",
@@ -99,7 +99,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let result = std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			phases: { configure },
 			source: source_ ?? source(os),
@@ -113,7 +113,7 @@ export let build = tg.target(async (arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/python.tg.ts
+++ b/packages/std/sdk/dependencies/python.tg.ts
@@ -11,7 +11,7 @@ export let metadata = {
 	version: "3.12.2",
 };
 
-export let source = tg.target(async (os: std.triple.Os) => {
+export let source = tg.target(async (os: string) => {
 	let { name, version } = metadata;
 
 	let unpackFormat = ".tar.xz" as const;
@@ -55,8 +55,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = await std.triple.host(host_);
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? await std.triple.host();
+	let build = build_ ?? host;
 	let os = std.triple.os(build);
 
 	let additionalEnv: std.env.Arg = {

--- a/packages/std/sdk/dependencies/texinfo.tg.ts
+++ b/packages/std/sdk/dependencies/texinfo.tg.ts
@@ -39,7 +39,7 @@ export let build = tg.target((arg?: Arg) => {
 	return std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 		},
@@ -51,7 +51,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({

--- a/packages/std/sdk/dependencies/zlib.tg.ts
+++ b/packages/std/sdk/dependencies/zlib.tg.ts
@@ -43,7 +43,7 @@ export let build = tg.target((arg?: Arg) => {
 	let output = std.utils.buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 		},
@@ -57,7 +57,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/dependencies/zstd.tg.ts
+++ b/packages/std/sdk/dependencies/zstd.tg.ts
@@ -48,7 +48,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let result = std.autotools.build({
 		...rest,
-		...tg.Triple.rotate({ build, host }),
+		...std.triple.rotate({ build, host }),
 		buildInTree: true,
 		env,
 		phases: { phases, order: ["prepare", "build", "install"] },
@@ -63,7 +63,7 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/sdk/git.tg.ts
+++ b/packages/std/sdk/git.tg.ts
@@ -37,8 +37,8 @@ export let git = async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let sourceDir = source_ ?? source();
 

--- a/packages/std/sdk/git.tg.ts
+++ b/packages/std/sdk/git.tg.ts
@@ -37,7 +37,7 @@ export let git = async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let sourceDir = source_ ?? source();
@@ -61,7 +61,7 @@ export let git = async (arg?: Arg) => {
 	let result = std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			buildInTree: true,
 			env,
 			phases,

--- a/packages/std/sdk/kernel_headers.tg.ts
+++ b/packages/std/sdk/kernel_headers.tg.ts
@@ -36,15 +36,15 @@ export let kernelHeaders = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let buildTriple = build_ ? tg.triple(build_) : host;
 
-	let system = tg.Triple.archAndOs(buildTriple);
+	let system = std.triple.archAndOs(buildTriple);
 
 	let sourceDir = source_ ?? source();
 
 	tg.assert(
-		tg.Triple.os(system) === "linux",
+		std.triple.os(system) === "linux",
 		"The Linux kernel headers can only be built on Linux.",
 	);
 
@@ -98,7 +98,7 @@ export let kernelHeaders = tg.target(async (arg?: Arg) => {
 export default kernelHeaders;
 
 export let test = tg.target(async () => {
-	let detectedHost = await tg.Triple.host();
+	let detectedHost = await std.triple.host();
 	let host = bootstrap.toolchainTriple(detectedHost);
 	if (host.os !== "linux") {
 		return;
@@ -109,14 +109,18 @@ export let test = tg.target(async () => {
 
 	// test cross
 	let hostArch = host.arch;
-	let targetArch: tg.Triple.Arch = hostArch === "x86_64" ? "aarch64" : "x86_64";
+	let targetArch: std.triple.Arch =
+		hostArch === "x86_64" ? "aarch64" : "x86_64";
 	let target = tg.triple({ ...host, arch: targetArch });
 	await testKernelHeaders(host, target);
 
 	return true;
 });
 
-export let testKernelHeaders = async (host: tg.Triple, target?: tg.Triple) => {
+export let testKernelHeaders = async (
+	host: std.triple,
+	target?: std.triple,
+) => {
 	let target_ = target ?? host;
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });

--- a/packages/std/sdk/libc/glibc.tg.ts
+++ b/packages/std/sdk/libc/glibc.tg.ts
@@ -29,7 +29,6 @@ type Arg = std.sdk.BuildEnvArg & {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
 	linuxHeaders: tg.Directory;
 	source?: tg.Directory;
-	target?: string;
 	version?: GlibcVersion;
 };
 
@@ -41,19 +40,11 @@ export default tg.target(async (arg: Arg) => {
 		host: host_,
 		linuxHeaders,
 		source: source_,
-		target: target_,
 		version = defaultGlibcVersion,
 		...rest
 	} = arg;
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
-	let target = target_ ?? host;
-
-	let hostTriple = tg.triple(target ?? host);
-	let buildString = std.triple.toString(build);
-	let hostString = std.triple.toString(hostTriple);
-
-	// Resolve remaining arguments.
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let additionalFlags = [];
 
@@ -65,9 +56,7 @@ export default tg.target(async (arg: Arg) => {
 
 	if (version === "2.38" || version === "2.39") {
 		// This flag is not available in previous versions. The `-DFORTIFY_SOURCE` macro was already available to users of glibc. This flag additionally uses this macro to build libc itself. It's used to detect buffer overflows at compile time.
-		if (host.environment === "gnu") {
-			additionalFlags.push("--enable-fortify-source");
-		}
+		additionalFlags.push("--enable-fortify-source");
 	}
 
 	let configure = {
@@ -76,8 +65,8 @@ export default tg.target(async (arg: Arg) => {
 			"--disable-werror",
 			"--enable-kernel=4.14",
 			tg`--with-headers="${linuxHeaders}/include"`,
-			`--build=${buildString}`,
-			`--host=${hostString}`,
+			`--build=${build}`,
+			`--host=${host}`,
 			"libc_cv_slibdir=/lib",
 			"libc_cv_forced_unwind=yes",
 			...additionalFlags,
@@ -85,7 +74,7 @@ export default tg.target(async (arg: Arg) => {
 	};
 
 	let install = {
-		args: [`DESTDIR="$OUTPUT/${hostString}"`],
+		args: [`DESTDIR="$OUTPUT/${host}"`],
 	};
 
 	let phases = {
@@ -128,13 +117,13 @@ export default tg.target(async (arg: Arg) => {
 	// Fix libc.so.
 	result = await applySysrootFix({
 		directory: result,
-		filePath: `${hostString}/lib/libc.so`,
+		filePath: `${host}/lib/libc.so`,
 	});
 
 	// Fix libm.so.
 	result = await applySysrootFix({
 		directory: result,
-		filePath: `${hostString}/lib/libm.so`,
+		filePath: `${host}/lib/libm.so`,
 	});
 
 	return result;
@@ -172,7 +161,7 @@ export let applySysrootFix = async (arg: SysrootFixArg) => {
 };
 
 export let interpreterName = (triple: string) => {
-	let arch = std.triple.arch(tg.triple(triple));
+	let arch = std.triple.arch(triple);
 	let soVersion = arch === "x86_64" ? "2" : "1";
 	let soArch = arch === "x86_64" ? "x86-64" : arch;
 	return `ld-linux-${soArch}.so.${soVersion}`;

--- a/packages/std/sdk/libc/glibc.tg.ts
+++ b/packages/std/sdk/libc/glibc.tg.ts
@@ -29,7 +29,7 @@ type Arg = std.sdk.BuildEnvArg & {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
 	linuxHeaders: tg.Directory;
 	source?: tg.Directory;
-	target?: tg.Triple.Arg;
+	target?: string;
 	version?: GlibcVersion;
 };
 
@@ -45,13 +45,13 @@ export default tg.target(async (arg: Arg) => {
 		version = defaultGlibcVersion,
 		...rest
 	} = arg;
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 	let target = target_ ?? host;
 
 	let hostTriple = tg.triple(target ?? host);
-	let buildString = tg.Triple.toString(build);
-	let hostString = tg.Triple.toString(hostTriple);
+	let buildString = std.triple.toString(build);
+	let hostString = std.triple.toString(hostTriple);
 
 	// Resolve remaining arguments.
 
@@ -115,7 +115,7 @@ export default tg.target(async (arg: Arg) => {
 	let result = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			opt: "2",
 			phases,
@@ -171,8 +171,8 @@ export let applySysrootFix = async (arg: SysrootFixArg) => {
 	return directory;
 };
 
-export let interpreterName = (triple: tg.Triple.Arg) => {
-	let arch = tg.Triple.arch(tg.triple(triple));
+export let interpreterName = (triple: string) => {
+	let arch = std.triple.arch(tg.triple(triple));
 	let soVersion = arch === "x86_64" ? "2" : "1";
 	let soArch = arch === "x86_64" ? "x86-64" : arch;
 	return `ld-linux-${soArch}.so.${soVersion}`;

--- a/packages/std/sdk/mold.tg.ts
+++ b/packages/std/sdk/mold.tg.ts
@@ -35,7 +35,7 @@ export let mold = async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -45,7 +45,7 @@ export let mold = async (arg?: Arg) => {
 	let result = cmake.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			phases: { configure },
 			source: source_ ?? source(),
 		},

--- a/packages/std/sdk/mold.tg.ts
+++ b/packages/std/sdk/mold.tg.ts
@@ -35,8 +35,8 @@ export let mold = async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let configure = {
 		args: ["-DCMAKE_BUILD_TYPE=Release"],

--- a/packages/std/sdk/ninja.tg.ts
+++ b/packages/std/sdk/ninja.tg.ts
@@ -35,8 +35,8 @@ export let ninja = async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let configure = {
 		args: ["-DCMAKE_BUILD_TYPE=Release"],

--- a/packages/std/sdk/ninja.tg.ts
+++ b/packages/std/sdk/ninja.tg.ts
@@ -35,7 +35,7 @@ export let ninja = async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -45,7 +45,7 @@ export let ninja = async (arg?: Arg) => {
 	let result = cmake.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			phases: { configure },
 			source: source_ ?? source(),
 			useNinja: false,

--- a/packages/std/sdk/proxy.tg.ts
+++ b/packages/std/sdk/proxy.tg.ts
@@ -13,7 +13,7 @@ export type Arg = {
 	/** The build environment to use to produce components. */
 	buildToolchain: std.env.Arg;
 	/** The target triple of the build machine. */
-	build?: tg.Triple.Arg;
+	build?: string;
 	/** Should the compiler get proxied? Default: false. */
 	compiler?: boolean;
 	/** Should we expect an LLVM toolchain? */
@@ -23,7 +23,7 @@ export type Arg = {
 	/** Optional linker to use. If omitted, the linker provided by the toolchain matching the requested arguments will be used. */
 	linkerExe?: tg.File | tg.Symlink;
 	/** The triple of the computer the toolchain being proxied produces binaries for. */
-	host?: tg.Triple.Arg;
+	host?: string;
 };
 
 /** Add a proxy to an env that provides a toolchain. */
@@ -50,7 +50,7 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 
 	let dirs = [];
 
-	let host = arg.host ? tg.triple(arg.host) : await tg.Triple.host();
+	let host = arg.host ? tg.triple(arg.host) : await std.triple.host();
 	let build = arg.build ? tg.triple(arg.build) : host;
 
 	let {
@@ -73,9 +73,9 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 	let cxx: tg.File | tg.Symlink = cxx_;
 
 	if (proxyLinker) {
-		let hostString = tg.Triple.toString(host);
+		let hostString = std.triple.toString(host);
 
-		let isCross = !tg.Triple.eq(build, host);
+		let isCross = !std.triple.eq(build, host);
 		let prefix = isCross ? `${hostString}-` : ``;
 
 		// Construct the ld proxy.
@@ -217,12 +217,12 @@ export default env;
 
 type CcProxyArg = {
 	buildToolchain: std.env.Arg;
-	build?: tg.Triple.Arg;
-	host?: tg.Triple.Arg;
+	build?: string;
+	host?: string;
 };
 
 export let ccProxy = async (arg: CcProxyArg) => {
-	let host = arg.host ? tg.triple(arg.host) : await tg.Triple.host();
+	let host = arg.host ? tg.triple(arg.host) : await std.triple.host();
 	let build = arg.build ? tg.triple(arg.build) : host;
 	let buildToolchain = arg.buildToolchain;
 	let tgcc = workspace.tgcc({
@@ -231,8 +231,8 @@ export let ccProxy = async (arg: CcProxyArg) => {
 		host,
 	});
 
-	let isCross = !tg.Triple.eq(build, host);
-	let prefix = isCross ? `${tg.Triple.toString(host)}-` : ``;
+	let isCross = !std.triple.eq(build, host);
+	let prefix = isCross ? `${std.triple.toString(host)}-` : ``;
 
 	return tg.directory({
 		[`bin/${prefix}cc`]: tgcc,
@@ -244,16 +244,16 @@ export let ccProxy = async (arg: CcProxyArg) => {
 
 type LdProxyArg = {
 	buildToolchain: std.env.Arg;
-	build?: tg.Triple.Arg;
+	build?: string;
 	interpreter?: tg.File;
 	interpreterArgs?: Array<tg.Template.Arg>;
 	linker: tg.File | tg.Symlink | tg.Template;
-	host?: tg.Triple.Arg;
+	host?: string;
 };
 
 export let ldProxy = async (arg: LdProxyArg) => {
 	// Prepare the Tangram tools.
-	let host = arg.host ? tg.triple(arg.host) : await tg.Triple.host();
+	let host = arg.host ? tg.triple(arg.host) : await std.triple.host();
 	let build = arg.build ? tg.triple(arg.build) : host;
 	let buildToolchain = arg.buildToolchain;
 

--- a/packages/std/tangram.tg.ts
+++ b/packages/std/tangram.tg.ts
@@ -26,9 +26,12 @@ export let flatten = <T,>(value: tg.MaybeNestedArray<T>): Array<T> => {
 
 export let test = tg.target(() => testDefaultSdk());
 
-import { host as hostTriple } from "./triple.tg.ts";
+import * as triple from "./triple.tg.ts";
 export let testHostSystem = tg.target(async () => {
-	return hostTriple();
+	return triple.host();
+});
+export let testTriple = tg.target(async () => {
+	return await triple.test();
 });
 
 // std.wrap component tests
@@ -92,7 +95,7 @@ export let testBootstrapMusl = tg.target(async () => {
 
 import * as utils from "./utils.tg.ts";
 export let testUtilsPrerequisites = tg.target(async () => {
-	return await utils.prerequisites(bootstrap.toolchainTriple(await hostTriple()));
+	return await utils.prerequisites(bootstrap.toolchainTriple(await triple.host()));
 });
 
 export let testUtilsBash = tg.target(async () => {
@@ -217,7 +220,7 @@ export let testKernelHeaders = tg.target(async () => {
 
 import * as binutils from "./sdk/binutils.tg.ts";
 export let testBinutilsSource = tg.target(async () => {
-	return await binutils.source(await hostTriple());
+	return await binutils.source(await triple.host());
 });
 export let testBinutils = tg.target(async () => {
 	return await binutils.test();
@@ -255,7 +258,7 @@ import { toolchainTriple as bootstrapToolchainTriple } from "./bootstrap.tg.ts";
 import { sdk } from "./sdk.tg.ts";
 export let testBootstrapSdk = tg.target(async () => {
 	let env = await sdk({ bootstrapMode: true });
-	let host = await hostTriple();
+	let host = await triple.host();
 	let detectedHost = bootstrapToolchainTriple(host);
 	await sdk.assertValid(env, { host: detectedHost, bootstrapMode: true });
 	return env;
@@ -263,7 +266,7 @@ export let testBootstrapSdk = tg.target(async () => {
 
 export let testDefaultSdk = tg.target(async () => {
 	let env = await sdk();
-	let detectedHost = await hostTriple();
+	let detectedHost = await triple.host();
 	await sdk.assertValid(env, { host: detectedHost });
 	return env;
 });

--- a/packages/std/tangram.tg.ts
+++ b/packages/std/tangram.tg.ts
@@ -92,9 +92,7 @@ export let testBootstrapMusl = tg.target(async () => {
 
 import * as utils from "./utils.tg.ts";
 export let testUtilsPrerequisites = tg.target(async () => {
-	return await utils.prerequisites({
-		host: bootstrap.toolchainTriple(await hostTriple()),
-	});
+	return await utils.prerequisites(bootstrap.toolchainTriple(await hostTriple()));
 });
 
 export let testUtilsBash = tg.target(async () => {

--- a/packages/std/tangram.tg.ts
+++ b/packages/std/tangram.tg.ts
@@ -10,6 +10,7 @@ export * as file from "./file.tg.ts";
 export { patch } from "./patch.tg.ts";
 export * as phases from "./phases.tg.ts";
 export { sdk } from "./sdk.tg.ts";
+export * as triple from "./triple.tg.ts";
 export * as utils from "./utils.tg.ts";
 export { default as wrap } from "./wrap.tg.ts";
 
@@ -25,8 +26,9 @@ export let flatten = <T,>(value: tg.MaybeNestedArray<T>): Array<T> => {
 
 export let test = tg.target(() => testDefaultSdk());
 
+import { host as hostTriple } from "./triple.tg.ts";
 export let testHostSystem = tg.target(async () => {
-	return tg.Triple.host();
+	return hostTriple();
 });
 
 // std.wrap component tests
@@ -91,7 +93,7 @@ export let testBootstrapMusl = tg.target(async () => {
 import * as utils from "./utils.tg.ts";
 export let testUtilsPrerequisites = tg.target(async () => {
 	return await utils.prerequisites({
-		host: bootstrap.toolchainTriple(await tg.Triple.host()),
+		host: bootstrap.toolchainTriple(await hostTriple()),
 	});
 });
 
@@ -217,7 +219,7 @@ export let testKernelHeaders = tg.target(async () => {
 
 import * as binutils from "./sdk/binutils.tg.ts";
 export let testBinutilsSource = tg.target(async () => {
-	return await binutils.source(await tg.Triple.host());
+	return await binutils.source(await hostTriple());
 });
 export let testBinutils = tg.target(async () => {
 	return await binutils.test();
@@ -255,7 +257,7 @@ import { toolchainTriple as bootstrapToolchainTriple } from "./bootstrap.tg.ts";
 import { sdk } from "./sdk.tg.ts";
 export let testBootstrapSdk = tg.target(async () => {
 	let env = await sdk({ bootstrapMode: true });
-	let host = await tg.Triple.host();
+	let host = await hostTriple();
 	let detectedHost = bootstrapToolchainTriple(host);
 	await sdk.assertValid(env, { host: detectedHost, bootstrapMode: true });
 	return env;
@@ -263,7 +265,7 @@ export let testBootstrapSdk = tg.target(async () => {
 
 export let testDefaultSdk = tg.target(async () => {
 	let env = await sdk();
-	let detectedHost = await tg.Triple.host();
+	let detectedHost = await hostTriple();
 	await sdk.assertValid(env, { host: detectedHost });
 	return env;
 });

--- a/packages/std/triple.tg.ts
+++ b/packages/std/triple.tg.ts
@@ -11,18 +11,32 @@ export type Arg = string | Partial<Components>;
 
 /** Construct a new triple string from a list of existing triples or component objects. Later arguments override fields from previous arguments. */
 export let create = (...args: Array<Arg>): string => {
-	return tg.unimplemented();
+	let c: Partial<Components> = {};
+	for (let arg of args) {
+		if (typeof arg === "string") {
+			let next = components(arg);
+			c = { ...c, ...next };
+		} else {
+			c = { ...c, ...arg };
+		}
+	}
+	tg.assert(c.arch);
+	tg.assert(c.os);
+	return fromComponents(c as Components);
 };
 
+/** Assert a string represents a valid triple. */
 export let assert = (s: string): void => {
 	components(s);
 };
 
+/** Produce a triple string retaining only the arch and os fields from an incoming triple. Throws if unable to parse the input. */
 export let archAndOs = (s: string): string => {
 	let orig = components(s);
 	return orig.arch + "-" + orig.os;
 };
 
+/** Produce a triple string retaining only the arch and os fields from an incoming triple. Returns `undefined` if unable to parse the input. */
 export let tryArchAndOs = (s: string): string | undefined => {
 	let orig = tryComponents(s);
 	if (!orig) {
@@ -31,24 +45,22 @@ export let tryArchAndOs = (s: string): string | undefined => {
 	return orig.arch + "-" + orig.os;
 };
 
+/** Retrieve the configured host for the current running target. */
 export let host = async (): Promise<string> => {
-	return tg.unimplemented();
+	return (await tg.current.env())["TANGRAM_HOST"] as string;
 };
 
+/** Retrieve the arch field from a triple string. Throws if unable to parse the input. */
 export let arch = (s: string): string => {
 	return components(s).arch;
 };
 
+/** Retrieve the arch field from a triple string. Returns `undefined` if unable to parse the input. */
 export let tryArch = (s: string): string | undefined => {
 	return tryComponents(s)?.arch;
 };
 
-export let withArch = (s: string, arch: string): string => {
-	let orig = components(s);
-	orig.arch = arch;
-	return fromComponents(orig);
-};
-
+/** Retrieve the vendor field from a triple string. Throws if unable to parse the input. */
 export let vendor = (s: string): string => {
 	let ret = components(s).vendor;
 	if (!ret) {
@@ -57,18 +69,22 @@ export let vendor = (s: string): string => {
 	return ret;
 };
 
+/** Retrieve the vendor field from a triple string. Returns `undefined` if unable to parse the input. */
 export let tryVendor = (s: string): string | undefined => {
 	return tryComponents(s)?.vendor;
 };
 
+/** Retrieve the os field from a triple string. Throws if unable to parse the input. */
 export let os = (s: string): string => {
 	return components(s).os;
 };
 
+/** Retrieve the os field from a triple string. Returns `undefined` if unable to parse the input. */
 export let tryOs = (s: string): string | undefined => {
 	return tryComponents(s)?.os;
 };
 
+/** Retrieve the osVersion field from a triple string. Throws if unable to parse the input or the os version is not defined. */
 export let osVersion = (s: string): string => {
 	let ret = components(s).osVersion;
 	if (!ret) {
@@ -77,10 +93,12 @@ export let osVersion = (s: string): string => {
 	return ret;
 };
 
+/** Retrieve the osVersion field from a triple string. Returns `undefined` if unable to parse the input or the os version is not defined. */
 export let tryOsVersion = (s: string): string | undefined => {
 	return tryComponents(s)?.osVersion;
 };
 
+/** Retrieve the environment field from a triple string. Throws if unable to parse the input or the environment is not defined. */
 export let environment = (s: string): string => {
 	let ret = components(s).environment;
 	if (!ret) {
@@ -89,10 +107,12 @@ export let environment = (s: string): string => {
 	return ret;
 };
 
+/** Retrieve the environment field from a triple string. Returns `undefined` if unable to parse the input or the environment is not defined. */
 export let tryEnvironment = (s: string): string | undefined => {
 	return tryComponents(s)?.environment;
 };
 
+/** Retrieve the environmentVersion field from a triple string. Throws if unable to parse the input or the environment version is not defined. */
 export let environmentVersion = (s: string): string => {
 	let ret = components(s).environmentVersion;
 	if (!ret) {
@@ -101,13 +121,13 @@ export let environmentVersion = (s: string): string => {
 	return ret;
 };
 
+/** Retrieve the environmentVersion field from a triple string. Returns `undefined` if unable to parse the input or the environment version is not defined. */
 export let tryEnvironmentVersion = (s: string): string | undefined => {
 	return tryComponents(s)?.environmentVersion;
 };
 
+/** Parse the fields of a triple stirng into individual components. Throws if unable to parse the input. */
 export let components = (s: string): Components => {
-	// TODO - is it worth it to keep a global map of seen strings -> components, to avoid repeated parsing? It's not worth a target, but might be worth this.
-
 	let ret = tryComponents(s);
 	if (!ret) {
 		throw new Error(`unable to parse triple components from string ${s}`);
@@ -115,23 +135,201 @@ export let components = (s: string): Components => {
 	return ret;
 };
 
+/** Parse the fields of a triple stirng into individual components. Returns `undefined` if unable to parse the input. */
 export let tryComponents = (s: string): Components | undefined => {
-	return tg.unimplemented();
+	let parts = s.split("-");
+
+	// Reject if the triple has too few or too many parts.
+	if (parts.length < 2 || parts.length > 5) {
+		return undefined;
+	}
+
+	// The first part is always the architecture.
+	let arch = parts[0];
+	tg.assert(arch);
+
+	// If the triple has only two parts, the second part is the os. Ensure it's valid.
+	if (parts.length === 2) {
+		let next = parts[1];
+		tg.assert(next);
+		let os = parseOs(next);
+		if (os) {
+			return { ...os, arch };
+		}
+		return undefined;
+	}
+
+	// If the triple has three parts, the second part is either the vendor or the os.
+	if (parts.length === 3) {
+		let next = parts[1];
+		tg.assert(next);
+		let os = parseOs(next);
+		if (os) {
+			// The third part is the environment. Validate.
+			let envField = parts[2];
+			tg.assert(envField);
+			let env = parseEnv(envField);
+			if (env) {
+				return { ...os, ...env, arch };
+			}
+		} else {
+			// The second part is the vendor. Validate the third part for the os.
+			let vendor = next;
+			let osField = parts[2];
+			tg.assert(osField);
+			let os = parseOs(osField);
+			if (os) {
+				return { ...os, vendor, arch };
+			}
+		}
+		return undefined;
+	}
+
+	// Otherwise, we have exactly 4 parts. The second part is the vendor, the third part is the os, and the fourth part is the environment.
+	let vendor = parts[1];
+	tg.assert(vendor);
+	let osField = parts[2];
+	tg.assert(osField);
+	let os = parseOs(osField);
+	if (!os) {
+		return undefined;
+	}
+	let envField = parts[3];
+	tg.assert(envField);
+	let env = parseEnv(envField);
+	if (!env) {
+		return undefined;
+	}
+	return { ...os, ...env, vendor, arch };
 };
 
+/** Produce a triple string from a set of components. */
 export let fromComponents = (c: Components) => {
-	// TODO Should this normalize?
-	return tg.unimplemented();
+	let ret = c.arch;
+	if (c.vendor) {
+		ret += "-" + c.vendor;
+	}
+	ret += "-" + c.os;
+	if (c.osVersion) {
+		ret += c.osVersion;
+	}
+	if (c.environment) {
+		ret += "-" + c.environment;
+	}
+	if (c.environmentVersion) {
+		if (!c.environment) {
+			throw new Error("environmentVersion is defined but environment is not");
+		}
+		ret += c.environmentVersion;
+	}
+	return ret;
 };
 
+/** Normalize a triple string to the form ARCH-VENDOR-OS or ARCH-VENDOR-OS-ENVIRONMENT, filling in `unknown` for missing fields as necessary. */
 export let normalize = (s: string): string => {
-	//return fromComponents(components(s));
-	return tg.unimplemented();
+	let c = components(s);
+	if (!c.vendor) {
+		c.vendor = "unknown";
+	}
+	return fromComponents(c);
 };
 
-export let rotate = (arg: {
+/** Given optional `build` and `host` machines for a build, return the concrete `host` and `target` for producing the correct build toolchain by "rotating" the inputs: build->host, host->target. */
+export let rotate = async (arg: {
 	build?: string;
 	host?: string;
-}): { host: string; target: string } => {
-	return tg.unimplemented();
+}): Promise<{ host: string; target: string }> => {
+	let host = arg.host ?? ((await tg.current.env())["TANGRAM_HOST"] as string);
+	let build = arg.build ?? host;
+	return { host: build, target: host };
 };
+
+let envs = ["gnu", "musl"];
+let oss = ["linux", "darwin"];
+
+/** Check if a string contains a known OS and optional version. Return undefined if not. */
+let parseOs = (s: string): { os: string; osVersion?: string } | undefined => {
+	for (let knownOs of oss) {
+		if (s.startsWith(knownOs)) {
+			// If we found it, check if there's an os version.
+			let os = knownOs;
+			let osVersion = s.slice(knownOs.length);
+			return {
+				os,
+				osVersion: osVersion.length > 0 ? osVersion : undefined,
+			};
+		}
+	}
+	return undefined;
+};
+
+/** Check if a string contains a known environment and optional version. Return undefined if not. */
+let parseEnv = (
+	s: string,
+): { environment: string; environmentVersion?: string } | undefined => {
+	for (let knownEnv of envs) {
+		if (s.startsWith(knownEnv)) {
+			// If we found it, check if there's an environment version.
+			let environment = knownEnv;
+			let environmentVersion = s.slice(knownEnv.length);
+			return {
+				environment,
+				environmentVersion:
+					environmentVersion.length > 0 ? environmentVersion : undefined,
+			};
+		}
+	}
+	return undefined;
+};
+
+export let test = tg.target(() => {
+	let t0 = "aarch64-linux";
+	let c0 = components(t0);
+	tg.assert(c0.arch === "aarch64");
+	tg.assert(c0.os === "linux");
+	tg.assert(c0.vendor === undefined);
+	tg.assert(c0.osVersion === undefined);
+	tg.assert(c0.environment === undefined);
+	tg.assert(c0.environmentVersion === undefined);
+
+	let t1 = "x86_64-linux-gnu";
+	let c1 = components(t1);
+	tg.assert(c1.arch === "x86_64");
+	tg.assert(c1.os === "linux");
+	tg.assert(c1.vendor === undefined);
+	tg.assert(c1.osVersion === undefined);
+	tg.assert(c1.environment === "gnu");
+	tg.assert(c1.environmentVersion === undefined);
+
+	let t2 = "aarch64-linux-musl";
+	let c2 = components(t2);
+	tg.assert(c2.arch === "aarch64");
+	tg.assert(c2.os === "linux");
+	tg.assert(c2.vendor === undefined);
+	tg.assert(c2.osVersion === undefined);
+	tg.assert(c2.environment === "musl");
+	tg.assert(c2.environmentVersion === undefined);
+
+	let t3 = "arm64-apple-darwin23.4.0";
+	let c3 = components(t3);
+	tg.assert(c3.arch === "arm64");
+	tg.assert(c3.os === "darwin");
+	tg.assert(c3.vendor === "apple");
+	tg.assert(c3.osVersion === "23.4.0");
+	tg.assert(c3.environment === undefined);
+	tg.assert(c3.environmentVersion === undefined);
+
+	let t4 = "x86_64-unknown-linux-gnu2.37";
+	let c4 = components(t4);
+	tg.assert(c4.arch === "x86_64");
+	tg.assert(c4.os === "linux");
+	tg.assert(c4.vendor === "unknown");
+	tg.assert(c4.osVersion === undefined);
+	tg.assert(c4.environment === "gnu");
+	tg.assert(c4.environmentVersion === "2.37");
+
+	let t5 = normalize(create(t0, { arch: "x86_64", environment: "musl" }));
+	tg.assert(t5 === "x86_64-unknown-linux-musl");
+
+	return true;
+});

--- a/packages/std/triple.tg.ts
+++ b/packages/std/triple.tg.ts
@@ -1,0 +1,121 @@
+export type Components = {
+	arch: string;
+	vendor?: string;
+	os: string;
+	osVersion?: string;
+	enviroment?: string;
+	enviromentVersion?: string;
+};
+
+export let assert = (s: string): void => {
+	components(s);
+};
+
+export let archAndOs = (s: string): string => {
+	let orig = components(s);
+	return orig.arch + "-" + orig.os;
+};
+
+export let tryArchAndOs = (s: string): string | undefined => {
+	let orig = tryComponents(s);
+	if (!orig) {
+		return undefined;
+	}
+	return orig.arch + "-" + orig.os;
+};
+
+export let host = async (): Promise<string> => {
+	return tg.unimplemented();
+};
+
+export let arch = (s: string): string => {
+	return components(s).arch;
+};
+
+export let tryArch = (s: string): string | undefined => {
+	return tryComponents(s)?.arch;
+};
+
+export let withArch = (s: string, arch: string): string => {
+	let orig = components(s);
+	orig.arch = arch;
+	return fromComponents(orig);
+};
+
+export let vendor = (s: string): string => {
+	let ret = components(s).vendor;
+	if (!ret) {
+		throw new Error("vendor is not defined");
+	}
+	return ret;
+};
+
+export let tryVendor = (s: string): string | undefined => {
+	return tryComponents(s)?.vendor;
+};
+
+export let os = (s: string): string => {
+	return components(s).os;
+};
+
+export let tryOs = (s: string): string | undefined => {
+	return tryComponents(s)?.os;
+};
+
+export let osVersion = (s: string): string => {
+	let ret = components(s).osVersion;
+	if (!ret) {
+		throw new Error("osVersion is not defined");
+	}
+	return ret;
+};
+
+export let tryOsVersion = (s: string): string | undefined => {
+	return tryComponents(s)?.osVersion;
+};
+
+export let environment = (s: string): string => {
+	let ret = components(s).enviroment;
+	if (!ret) {
+		throw new Error("enviroment is not defined");
+	}
+	return ret;
+};
+
+export let tryEnvironment = (s: string): string | undefined => {
+	return tryComponents(s)?.enviroment;
+};
+
+export let environmentVersion = (s: string): string => {
+	let ret = components(s).enviromentVersion;
+	if (!ret) {
+		throw new Error("enviromentVersion is not defined");
+	}
+	return ret;
+};
+
+export let tryEnvironmentVersion = (s: string): string | undefined => {
+	return tryComponents(s)?.enviromentVersion;
+};
+
+export let components = (s: string): Components => {
+	let ret = tryComponents(s);
+	if (!ret) {
+		throw new Error(`unable to parse triple components from string ${s}`);
+	}
+	return ret;
+};
+
+export let tryComponents = (s: string): Components | undefined => {
+	return tg.unimplemented();
+};
+
+export let fromComponents = (c: Components) => {
+	// TODO Should this normalize?
+	return tg.unimplemented();
+};
+
+export let normalize = (s: string): string => {
+	//return fromComponents(components(s));
+	return tg.unimplemented();
+};

--- a/packages/std/triple.tg.ts
+++ b/packages/std/triple.tg.ts
@@ -3,8 +3,15 @@ export type Components = {
 	vendor?: string;
 	os: string;
 	osVersion?: string;
-	enviroment?: string;
-	enviromentVersion?: string;
+	environment?: string;
+	environmentVersion?: string;
+};
+
+export type Arg = string | Partial<Components>;
+
+/** Construct a new triple string from a list of existing triples or component objects. Later arguments override fields from previous arguments. */
+export let create = (...args: Array<Arg>): string => {
+	return tg.unimplemented();
 };
 
 export let assert = (s: string): void => {
@@ -75,7 +82,7 @@ export let tryOsVersion = (s: string): string | undefined => {
 };
 
 export let environment = (s: string): string => {
-	let ret = components(s).enviroment;
+	let ret = components(s).environment;
 	if (!ret) {
 		throw new Error("enviroment is not defined");
 	}
@@ -83,11 +90,11 @@ export let environment = (s: string): string => {
 };
 
 export let tryEnvironment = (s: string): string | undefined => {
-	return tryComponents(s)?.enviroment;
+	return tryComponents(s)?.environment;
 };
 
 export let environmentVersion = (s: string): string => {
-	let ret = components(s).enviromentVersion;
+	let ret = components(s).environmentVersion;
 	if (!ret) {
 		throw new Error("enviromentVersion is not defined");
 	}
@@ -95,10 +102,12 @@ export let environmentVersion = (s: string): string => {
 };
 
 export let tryEnvironmentVersion = (s: string): string | undefined => {
-	return tryComponents(s)?.enviromentVersion;
+	return tryComponents(s)?.environmentVersion;
 };
 
 export let components = (s: string): Components => {
+	// TODO - is it worth it to keep a global map of seen strings -> components, to avoid repeated parsing? It's not worth a target, but might be worth this.
+
 	let ret = tryComponents(s);
 	if (!ret) {
 		throw new Error(`unable to parse triple components from string ${s}`);
@@ -117,5 +126,12 @@ export let fromComponents = (c: Components) => {
 
 export let normalize = (s: string): string => {
 	//return fromComponents(components(s));
+	return tg.unimplemented();
+};
+
+export let rotate = (arg: {
+	build?: string;
+	host?: string;
+}): { host: string; target: string } => {
 	return tg.unimplemented();
 };

--- a/packages/std/triple.tg.ts
+++ b/packages/std/triple.tg.ts
@@ -60,16 +60,12 @@ export let tryArch = (s: string): string | undefined => {
 	return tryComponents(s)?.arch;
 };
 
-/** Retrieve the vendor field from a triple string. Throws if unable to parse the input. */
-export let vendor = (s: string): string => {
-	let ret = components(s).vendor;
-	if (!ret) {
-		throw new Error("vendor is not defined");
-	}
-	return ret;
+/** Retrieve the vendor field from a triple string. Throws if unable to parse the input, returns `undefined` if no vendor is set. */
+export let vendor = (s: string): string | undefined => {
+	return components(s).vendor;
 };
 
-/** Retrieve the vendor field from a triple string. Returns `undefined` if unable to parse the input. */
+/** Retrieve the vendor field from a triple string. Returns `undefined` if unable to parse the input or if no vendor is set. */
 export let tryVendor = (s: string): string | undefined => {
 	return tryComponents(s)?.vendor;
 };
@@ -84,13 +80,9 @@ export let tryOs = (s: string): string | undefined => {
 	return tryComponents(s)?.os;
 };
 
-/** Retrieve the osVersion field from a triple string. Throws if unable to parse the input or the os version is not defined. */
-export let osVersion = (s: string): string => {
-	let ret = components(s).osVersion;
-	if (!ret) {
-		throw new Error("osVersion is not defined");
-	}
-	return ret;
+/** Retrieve the osVersion field from a triple string. Throws if unable to parse the input, returns `undefined` if the os version is not defined. */
+export let osVersion = (s: string): string | undefined => {
+	return components(s).osVersion;
 };
 
 /** Retrieve the osVersion field from a triple string. Returns `undefined` if unable to parse the input or the os version is not defined. */
@@ -98,13 +90,9 @@ export let tryOsVersion = (s: string): string | undefined => {
 	return tryComponents(s)?.osVersion;
 };
 
-/** Retrieve the environment field from a triple string. Throws if unable to parse the input or the environment is not defined. */
-export let environment = (s: string): string => {
-	let ret = components(s).environment;
-	if (!ret) {
-		throw new Error("enviroment is not defined");
-	}
-	return ret;
+/** Retrieve the environment field from a triple string. Throws if unable to parse the input, returns `undefined` if no environment is set. */
+export let environment = (s: string): string | undefined => {
+	return components(s).environment;
 };
 
 /** Retrieve the environment field from a triple string. Returns `undefined` if unable to parse the input or the environment is not defined. */
@@ -112,13 +100,9 @@ export let tryEnvironment = (s: string): string | undefined => {
 	return tryComponents(s)?.environment;
 };
 
-/** Retrieve the environmentVersion field from a triple string. Throws if unable to parse the input or the environment version is not defined. */
-export let environmentVersion = (s: string): string => {
-	let ret = components(s).environmentVersion;
-	if (!ret) {
-		throw new Error("enviromentVersion is not defined");
-	}
-	return ret;
+/** Retrieve the environmentVersion field from a triple string. Throws if unable to parse the input, returns undefined if the environment version is not defined. */
+export let environmentVersion = (s: string): string | undefined => {
+	return components(s).environmentVersion;
 };
 
 /** Retrieve the environmentVersion field from a triple string. Returns `undefined` if unable to parse the input or the environment version is not defined. */

--- a/packages/std/utils.tg.ts
+++ b/packages/std/utils.tg.ts
@@ -41,7 +41,7 @@ export let env = tg.target(async (arg?: Arg) => {
 		host: host_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let bootstrapMode = bootstrapMode_ ?? false;
 
 	// Build bash and use it as the default shell.
@@ -81,8 +81,8 @@ export let env = tg.target(async (arg?: Arg) => {
 export default env;
 
 /** All utils builds must begin with these prerequisites in the build environment, which include patched `cp` and `install` commands that always preseve extended attributes.*/
-export let prerequisites = tg.target(async (arg?: tg.Triple.HostArg) => {
-	let host = await tg.Triple.host(arg);
+export let prerequisites = tg.target(async (arg?: string) => {
+	let host = await std.triple.host(arg);
 	let components: tg.Unresolved<std.env.Arg> = [bootstrap.utils({ host })];
 
 	// Add GNU make.
@@ -109,8 +109,8 @@ export let prerequisites = tg.target(async (arg?: tg.Triple.HostArg) => {
 });
 
 /** Build a fresh musl and use it as the runtime libc. */
-export let muslRuntimeEnv = async (arg?: tg.Triple.HostArg) => {
-	let host = await tg.Triple.host(arg);
+export let muslRuntimeEnv = async (arg?: string) => {
+	let host = await std.triple.host(arg);
 	if (host.os !== "linux") {
 		throw new Error("muslRuntimeEnv is only supported on Linux.");
 	}
@@ -201,7 +201,7 @@ export let assertProvides = async (env: std.env.Arg) => {
 };
 
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let utilsEnv = await env({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/attr.tg.ts
+++ b/packages/std/utils/attr.tg.ts
@@ -43,13 +43,12 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
-	if (host.os !== "linux") {
-		let hostString = std.triple.toString(host);
+	if (std.triple.os(host) !== "linux" || std.triple.os(build) !== "linux") {
 		throw new Error(
-			`Unsupported system: ${hostString}. The attr package is Linux-only.`,
+			`Unsupported system: ${host}. The attr package is Linux-only.`,
 		);
 	}
 
@@ -70,7 +69,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
 	if (bootstrapMode && usePrerequisites) {
-		env.push(prerequisites({ host }));
+		env.push(prerequisites(host));
 	}
 	if (staticBuild) {
 		env.push({ CC: "gcc -static" });

--- a/packages/std/utils/attr.tg.ts
+++ b/packages/std/utils/attr.tg.ts
@@ -43,11 +43,11 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	if (host.os !== "linux") {
-		let hostString = tg.Triple.toString(host);
+		let hostString = std.triple.toString(host);
 		throw new Error(
 			`Unsupported system: ${hostString}. The attr package is Linux-only.`,
 		);
@@ -79,7 +79,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = await buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			env,
 			phases,
@@ -106,7 +106,7 @@ export default build;
 
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ bootstrapMode, host });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/bash.tg.ts
+++ b/packages/std/utils/bash.tg.ts
@@ -13,7 +13,7 @@ type Arg = std.sdk.BuildEnvArg & {
 
 export let source = tg.target(async (arg?: Arg) => {
 	let { name, version } = metadata;
-	let build = arg?.build ? tg.triple(arg?.build) : await tg.Triple.host();
+	let build = arg?.build ? tg.triple(arg?.build) : await std.triple.host();
 	let env = std.env.object(
 		std.sdk({ host: build, bootstrapMode: arg?.bootstrapMode }, arg?.sdk),
 		arg?.env,
@@ -34,7 +34,7 @@ export let source = tg.target(async (arg?: Arg) => {
 		await std.phases.build({
 			env,
 			phases: { prepare, fixup },
-			target: { host: tg.Triple.archAndOs(build) },
+			target: { host: std.triple.archAndOs(build) },
 		}),
 	);
 	return patchedSource;
@@ -51,7 +51,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configureArgs = ["--without-bash-malloc", "--disable-nls"];
@@ -70,7 +70,10 @@ export let build = tg.target(async (arg?: Arg) => {
 		env.push(prerequisites({ host }));
 		env.push(bootstrap.shell({ host }));
 	}
-	if ((await std.env.tryGetKey({ env: env_, key: "CC" }))?.components[0] === "clang" ) {
+	if (
+		(await std.env.tryGetKey({ env: env_, key: "CC" }))?.components[0] ===
+		"clang"
+	) {
 		env.push({
 			CFLAGS: "-Wno-implicit-function-declaration",
 		});
@@ -79,7 +82,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			env,
 			phases: { configure },
@@ -113,7 +116,7 @@ let providesNcurses = async (env: std.env.Arg): Promise<boolean> => {
 
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/bash.tg.ts
+++ b/packages/std/utils/bash.tg.ts
@@ -13,7 +13,7 @@ type Arg = std.sdk.BuildEnvArg & {
 
 export let source = tg.target(async (arg?: Arg) => {
 	let { name, version } = metadata;
-	let build = arg?.build ? tg.triple(arg?.build) : await std.triple.host();
+	let build = arg?.build ?? (await std.triple.host());
 	let env = std.env.object(
 		std.sdk({ host: build, bootstrapMode: arg?.bootstrapMode }, arg?.sdk),
 		arg?.env,
@@ -51,8 +51,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let configureArgs = ["--without-bash-malloc", "--disable-nls"];
 
@@ -67,7 +67,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
 	if (bootstrapMode) {
-		env.push(prerequisites({ host }));
+		env.push(prerequisites(host));
 		env.push(bootstrap.shell({ host }));
 	}
 	if (

--- a/packages/std/utils/bzip2.tg.ts
+++ b/packages/std/utils/bzip2.tg.ts
@@ -69,7 +69,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
 	if (bootstrapMode) {
-		env.push(prerequisites({ host }));
+		env.push(prerequisites(host));
 	}
 
 	let output = buildUtil(

--- a/packages/std/utils/bzip2.tg.ts
+++ b/packages/std/utils/bzip2.tg.ts
@@ -75,7 +75,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			buildInTree: true,
 			env,
@@ -91,7 +91,7 @@ export let build = tg.target(async (arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/coreutils.tg.ts
+++ b/packages/std/utils/coreutils.tg.ts
@@ -10,7 +10,7 @@ export let metadata = {
 	version: "9.4",
 };
 
-export let source = tg.target(async (os: std.triple.Os) => {
+export let source = tg.target(async (os: string) => {
 	let { name, version } = metadata;
 	let compressionFormat = ".xz" as const;
 	let checksum =
@@ -63,14 +63,14 @@ export let build = tg.target(async (arg?: Arg) => {
 		usePrerequisites = true,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 	let os = std.triple.os(host);
 
 	let dependencies: tg.Unresolved<std.env.Arg> = [];
 
 	if (bootstrapMode && usePrerequisites) {
-		dependencies.push(prerequisites({ host }));
+		dependencies.push(prerequisites(host));
 	}
 
 	let attrArtifact;
@@ -146,7 +146,7 @@ export let gnuEnv = tg.target(async () => {
 	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ bootstrapMode, host });
-	let make = await bootstrap.make.build({ host });
+	let make = await bootstrap.make.build(host);
 	let directory = await build({
 		host,
 		bootstrapMode,

--- a/packages/std/utils/coreutils.tg.ts
+++ b/packages/std/utils/coreutils.tg.ts
@@ -10,7 +10,7 @@ export let metadata = {
 	version: "9.4",
 };
 
-export let source = tg.target(async (os: tg.Triple.Os) => {
+export let source = tg.target(async (os: std.triple.Os) => {
 	let { name, version } = metadata;
 	let compressionFormat = ".xz" as const;
 	let checksum =
@@ -63,9 +63,9 @@ export let build = tg.target(async (arg?: Arg) => {
 		usePrerequisites = true,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
-	let os = tg.Triple.os(host);
+	let os = std.triple.os(host);
 
 	let dependencies: tg.Unresolved<std.env.Arg> = [];
 
@@ -117,7 +117,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = await buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			env,
 			phases: { configure },
@@ -143,7 +143,7 @@ export default build;
 
 /** Obtain just the `env` binary. */
 export let gnuEnv = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ bootstrapMode, host });
 	let make = await bootstrap.make.build({ host });
@@ -160,9 +160,9 @@ export let gnuEnv = tg.target(async () => {
 
 /** This test asserts that this installation of coreutils preserves xattrs when using both `cp` and `install` on Linux. */
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
-	let system = tg.Triple.archAndOs(host);
-	let os = tg.Triple.os(system);
+	let host = bootstrap.toolchainTriple(await std.triple.host());
+	let system = std.triple.archAndOs(host);
+	let os = std.triple.os(system);
 	let bootstrapMode = true;
 	let sdk = std.sdk({ bootstrapMode, host });
 

--- a/packages/std/utils/diffutils.tg.ts
+++ b/packages/std/utils/diffutils.tg.ts
@@ -30,13 +30,12 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
 		args: ["--disable-dependency-tracking", "--disable-rpath"],
 	};
-
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
 	if (bootstrapMode) {
@@ -46,7 +45,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			env,
 			phases: { configure },
@@ -62,7 +61,7 @@ export default build;
 
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = await build({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/diffutils.tg.ts
+++ b/packages/std/utils/diffutils.tg.ts
@@ -30,8 +30,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let configure = {
 		args: ["--disable-dependency-tracking", "--disable-rpath"],
@@ -39,7 +39,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
 	if (bootstrapMode) {
-		env.push(prerequisites({ host }));
+		env.push(prerequisites(host));
 	}
 
 	let output = buildUtil(

--- a/packages/std/utils/file_cmds.tg.ts
+++ b/packages/std/utils/file_cmds.tg.ts
@@ -38,8 +38,8 @@ type Arg = std.sdk.BuildEnvArg;
 
 /** Produce an `install` executable that preserves xattrs on macOS, alongside the `xattr` command, to include with the coreutils. */
 export let macOsXattrCmds = tg.target(async (arg?: Arg) => {
-	let build = arg?.build ? tg.triple(arg.build) : await std.triple.host(arg);
-	let os = build.os;
+	let build = arg?.build ?? await std.triple.host();
+	let os = std.triple.os(build);
 
 	// Assert that the system is macOS.
 	if (os !== "darwin") {
@@ -84,7 +84,7 @@ type UtilArg = std.sdk.BuildEnvArg & {
 };
 
 export let compileUtil = async (arg: UtilArg) => {
-	let build = arg.build ? tg.triple(arg.build) : await std.triple.host(arg);
+	let build = arg.build ?? await std.triple.host();
 	let host = build;
 
 	// Grab args.

--- a/packages/std/utils/file_cmds.tg.ts
+++ b/packages/std/utils/file_cmds.tg.ts
@@ -38,7 +38,7 @@ type Arg = std.sdk.BuildEnvArg;
 
 /** Produce an `install` executable that preserves xattrs on macOS, alongside the `xattr` command, to include with the coreutils. */
 export let macOsXattrCmds = tg.target(async (arg?: Arg) => {
-	let build = arg?.build ? tg.triple(arg.build) : await tg.Triple.host(arg);
+	let build = arg?.build ? tg.triple(arg.build) : await std.triple.host(arg);
 	let os = build.os;
 
 	// Assert that the system is macOS.
@@ -84,7 +84,7 @@ type UtilArg = std.sdk.BuildEnvArg & {
 };
 
 export let compileUtil = async (arg: UtilArg) => {
-	let build = arg.build ? tg.triple(arg.build) : await tg.Triple.host(arg);
+	let build = arg.build ? tg.triple(arg.build) : await std.triple.host(arg);
 	let host = build;
 
 	// Grab args.
@@ -106,7 +106,7 @@ export let compileUtil = async (arg: UtilArg) => {
 
 	let util = tg.File.expect(
 		await tg.build(await tg.template(script), {
-			host: tg.Triple.archAndOs(build),
+			host: std.triple.archAndOs(build),
 			env: std.env.object([
 				arg.env ?? {},
 				{

--- a/packages/std/utils/findutils.tg.ts
+++ b/packages/std/utils/findutils.tg.ts
@@ -7,7 +7,7 @@ export let metadata = {
 	version: "4.9.0",
 };
 
-export let source = tg.target(async (os: std.triple.Os) => {
+export let source = tg.target(async (os: string) => {
 	let { name, version } = metadata;
 	let compressionFormat = ".xz" as const;
 	let checksum =
@@ -44,8 +44,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 	let os = std.triple.os(build);
 
 	let wrapBashScriptPaths: Array<string> | undefined =
@@ -57,7 +57,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
 	if (bootstrapMode) {
-		env.push(prerequisites({ host }));
+		env.push(prerequisites(host));
 	}
 
 	let output = buildUtil(

--- a/packages/std/utils/findutils.tg.ts
+++ b/packages/std/utils/findutils.tg.ts
@@ -7,7 +7,7 @@ export let metadata = {
 	version: "4.9.0",
 };
 
-export let source = tg.target(async (os: tg.Triple.Os) => {
+export let source = tg.target(async (os: std.triple.Os) => {
 	let { name, version } = metadata;
 	let compressionFormat = ".xz" as const;
 	let checksum =
@@ -44,9 +44,9 @@ export let build = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
-	let os = tg.Triple.os(build);
+	let os = std.triple.os(build);
 
 	let wrapBashScriptPaths: Array<string> | undefined =
 		os === "linux" ? ["bin/updatedb"] : undefined;
@@ -63,7 +63,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			env,
 			phases: { configure },
@@ -79,7 +79,7 @@ export let build = tg.target(async (arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/gawk.tg.ts
+++ b/packages/std/utils/gawk.tg.ts
@@ -30,7 +30,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -45,7 +45,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			env,
 			phases: { configure },
@@ -62,7 +62,7 @@ export default build;
 
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/gawk.tg.ts
+++ b/packages/std/utils/gawk.tg.ts
@@ -30,8 +30,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let configure = {
 		args: ["--disable-dependency-tracking", "--disable-rpath"],
@@ -39,7 +39,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
 	if (bootstrapMode) {
-		env.push(prerequisites({ host }));
+		env.push(prerequisites(host));
 	}
 
 	let output = buildUtil(

--- a/packages/std/utils/grep.tg.ts
+++ b/packages/std/utils/grep.tg.ts
@@ -30,7 +30,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -50,7 +50,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			env,
 			phases: { configure },
@@ -67,7 +67,7 @@ export default build;
 
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/grep.tg.ts
+++ b/packages/std/utils/grep.tg.ts
@@ -30,8 +30,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let configure = {
 		args: [
@@ -44,7 +44,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
 	if (bootstrapMode) {
-		env.push(prerequisites({ host }));
+		env.push(prerequisites(host));
 	}
 
 	let output = buildUtil(

--- a/packages/std/utils/gzip.tg.ts
+++ b/packages/std/utils/gzip.tg.ts
@@ -30,7 +30,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -45,7 +45,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			env,
 			phases: { configure },
@@ -75,7 +75,7 @@ export default build;
 
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/gzip.tg.ts
+++ b/packages/std/utils/gzip.tg.ts
@@ -30,8 +30,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let configure = {
 		args: ["--disable-dependency-tracking"],
@@ -39,7 +39,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
 	if (bootstrapMode) {
-		env.push(prerequisites({ host }));
+		env.push(prerequisites(host));
 	}
 
 	let output = buildUtil(

--- a/packages/std/utils/libiconv.tg.ts
+++ b/packages/std/utils/libiconv.tg.ts
@@ -31,7 +31,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -46,7 +46,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			env,
 			phases: { configure },
@@ -62,7 +62,7 @@ export default build;
 
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ bootstrapMode, host });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/libiconv.tg.ts
+++ b/packages/std/utils/libiconv.tg.ts
@@ -31,8 +31,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let configure = {
 		args: ["--disable-dependency-tracking"],
@@ -40,7 +40,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
 	if (bootstrapMode && usePrerequisites) {
-		env.push(prerequisites({ host }));
+		env.push(prerequisites(host));
 	}
 
 	let output = buildUtil(

--- a/packages/std/utils/make.tg.ts
+++ b/packages/std/utils/make.tg.ts
@@ -39,7 +39,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
 	if (bootstrapMode) {
-		env.push(prerequisites({ host }));
+		env.push(prerequisites(host));
 	}
 
 	return buildUtil(

--- a/packages/std/utils/make.tg.ts
+++ b/packages/std/utils/make.tg.ts
@@ -45,7 +45,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	return buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			env,
 			phases,
@@ -58,7 +58,7 @@ export let build = tg.target(async (arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let makeArtifact = await build({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/patch.tg.ts
+++ b/packages/std/utils/patch.tg.ts
@@ -37,7 +37,7 @@ export let build = tg.target((arg?: Arg) => {
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
 	if (bootstrapMode) {
-		env.push(prerequisites({ host }));
+		env.push(prerequisites(host));
 	}
 
 	let output = buildUtil(

--- a/packages/std/utils/patch.tg.ts
+++ b/packages/std/utils/patch.tg.ts
@@ -43,7 +43,7 @@ export let build = tg.target((arg?: Arg) => {
 	let output = buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			env,
 			phases: { configure },
@@ -58,7 +58,7 @@ export let build = tg.target((arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/sed.tg.ts
+++ b/packages/std/utils/sed.tg.ts
@@ -30,7 +30,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -45,7 +45,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			env,
 			phases: { configure },
@@ -61,7 +61,7 @@ export default build;
 
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/sed.tg.ts
+++ b/packages/std/utils/sed.tg.ts
@@ -30,8 +30,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let configure = {
 		args: ["--disable-dependency-tracking"],
@@ -39,7 +39,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
 	if (bootstrapMode) {
-		env.push(prerequisites({ host }));
+		env.push(prerequisites(host));
 	}
 
 	let output = buildUtil(

--- a/packages/std/utils/tar.tg.ts
+++ b/packages/std/utils/tar.tg.ts
@@ -31,7 +31,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await tg.Triple.host();
+	let host = host_ ? tg.triple(host_) : await std.triple.host();
 	let build = build_ ? tg.triple(build_) : host;
 
 	let dependencies: tg.Unresolved<std.env.Arg> = [];
@@ -59,7 +59,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			env,
 			phases: { configure },
@@ -75,7 +75,7 @@ export default build;
 
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let directory = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/tar.tg.ts
+++ b/packages/std/utils/tar.tg.ts
@@ -31,15 +31,15 @@ export let build = tg.target(async (arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let host = host_ ? tg.triple(host_) : await std.triple.host();
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let dependencies: tg.Unresolved<std.env.Arg> = [];
 	if (bootstrapMode) {
-		dependencies.push(prerequisites({ host }));
+		dependencies.push(prerequisites(host));
 	}
 	let additionalEnv = {};
-	if (build.os === "darwin") {
+	if (std.triple.os(build) === "darwin") {
 		dependencies.push(libiconv({ ...rest, build, host }));
 		// Bug: https://savannah.gnu.org/bugs/?64441.
 		// Fix http://git.savannah.gnu.org/cgit/tar.git/commit/?id=8632df39

--- a/packages/std/utils/xz.tg.ts
+++ b/packages/std/utils/xz.tg.ts
@@ -41,7 +41,7 @@ export let build = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = await tg.Triple.host(host_);
+	let host = await std.triple.host(host_);
 	let build = build_ ? tg.triple(build_) : host;
 
 	let configure = {
@@ -61,7 +61,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let output = await buildUtil(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			bootstrapMode,
 			env,
 			phases: { configure },
@@ -81,7 +81,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	for (let bin of bins) {
 		let unwrappedBin = tg.File.expect(await output.get(`bin/${bin}`));
 		let wrappedBin = std.wrap({
-		 	buildToolchain: bootstrapMode ? env_ : undefined,
+			buildToolchain: bootstrapMode ? env_ : undefined,
 			executable: unwrappedBin,
 			libraryPaths: [libDir],
 		});
@@ -93,7 +93,7 @@ export let build = tg.target(async (arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await tg.Triple.host());
+	let host = bootstrap.toolchainTriple(await std.triple.host());
 	let bootstrapMode = true;
 	let sdk = std.sdk({ host, bootstrapMode });
 	let xzArtifact = build({ host, bootstrapMode, env: sdk });

--- a/packages/std/utils/xz.tg.ts
+++ b/packages/std/utils/xz.tg.ts
@@ -41,8 +41,8 @@ export let build = tg.target(async (arg?: Arg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = await std.triple.host(host_);
-	let build = build_ ? tg.triple(build_) : host;
+	let host = host_ ?? await std.triple.host();
+	let build = build_ ?? host;
 
 	let configure = {
 		args: [
@@ -55,7 +55,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let env: tg.Unresolved<std.env.Arg> = [env_];
 	if (bootstrapMode) {
-		env.push(prerequisites({ host }));
+		env.push(prerequisites(host));
 	}
 
 	let output = await buildUtil(

--- a/packages/std/wrap/workspace.tg.ts
+++ b/packages/std/wrap/workspace.tg.ts
@@ -204,17 +204,11 @@ export let build = async (arg: BuildArg) => {
 	let buildToolchain = arg.buildToolchain;
 	let setSysroot = false;
 	if (os === "linux") {
-		if (tg.Triple.environment(target_) === "musl") {
-			// If the incoming toolchain is musl-based, it hasn't yet been wrapped. We need to set --sysroot.
-			setSysroot = true;
+		if (!isCross) {
+			buildToolchain = await bootstrap.sdk.env(host_);
 		} else {
-			// If the incoming toolchain is not musl-based, we need to pull in a musl-based toolchain.
-			if (!isCross) {
-				buildToolchain = await bootstrap.sdk.env(host_);
-			} else {
-				buildToolchain = await gcc.toolchain({ host, target });
-				setSysroot = true;
-			}
+			buildToolchain = await gcc.toolchain({ host, target });
+			setSysroot = true;
 		}
 	}
 

--- a/packages/texinfo/tangram.tg.ts
+++ b/packages/texinfo/tangram.tg.ts
@@ -24,9 +24,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -54,7 +54,7 @@ export let texinfo = tg.target(async (arg?: Arg) => {
 	let output = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 		},

--- a/packages/vsce/tangram.tg.ts
+++ b/packages/vsce/tangram.tg.ts
@@ -24,7 +24,7 @@ export let source = tg.target(() => {
 
 export type Arg = {
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	nodejs?: tg.MaybeNestedArray<node.Arg>;
 	source?: tg.Directory;
 };

--- a/packages/wget/tangram.tg.ts
+++ b/packages/wget/tangram.tg.ts
@@ -19,9 +19,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -54,7 +54,7 @@ export let wget = tg.target(async (arg?: Arg) => {
 	let output = await std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			env,
 			source: source_ ?? source(),
 		},

--- a/packages/zlib/tangram.tg.ts
+++ b/packages/zlib/tangram.tg.ts
@@ -25,9 +25,9 @@ export let source = tg.target(async () => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -38,7 +38,7 @@ export let zlib = tg.target((arg?: Arg) => {
 	return std.autotools.build(
 		{
 			...rest,
-			...tg.Triple.rotate({ build, host }),
+			...std.triple.rotate({ build, host }),
 			source: source_ ?? source(),
 		},
 		autotools,

--- a/packages/zstd/tangram.tg.ts
+++ b/packages/zstd/tangram.tg.ts
@@ -29,9 +29,9 @@ export let source = tg.target(() => {
 
 type Arg = {
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
-	build?: tg.Triple.Arg;
+	build?: string;
 	env?: std.env.Arg;
-	host?: tg.Triple.Arg;
+	host?: string;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
@@ -46,7 +46,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	return std.autotools.build({
 		...rest,
-		...tg.Triple.rotate({ build, host }),
+		...std.triple.rotate({ build, host }),
 		buildInTree: true,
 		phases: { phases, order: ["prepare", "build", "install"] },
 		prefixArg: "none",


### PR DESCRIPTION
This PR updates the packages to reflect the removal of `tg.Triple`; instead, it prefers to work with strings facilitated by utility functions under the `std.triple` namespace. Closes #19.