### PR TITLE
refactor(std): remove bootstrapMode from interfaces

### DIFF
--- a/packages/icu/tangram.tg.ts
+++ b/packages/icu/tangram.tg.ts
@@ -14,16 +14,19 @@ export let source = tg.target(async () => {
 	let owner = "unicode-org";
 	let repo = name;
 	let unpackFormat = ".tar.gz" as const;
-	let checksum = "sha256:68db082212a96d6f53e35d60f47d38b962e9f9d207a74cfac78029ae8ff5e08c";
+	let checksum =
+		"sha256:68db082212a96d6f53e35d60f47d38b962e9f9d207a74cfac78029ae8ff5e08c";
 	let releaseVersion = version.replace(/\./, "-");
 	let pkgVersion = version.replace(/\./, "_");
 	let pkgName = `icu4c-${pkgVersion}-src`;
 	let url = `https://github.com/${owner}/${repo}/releases/download/release-${releaseVersion}/${pkgName}.tgz`;
-	let outer = tg.Directory.expect(await std.download({
-		unpackFormat,
-		url,
-		checksum,
-	}));
+	let outer = tg.Directory.expect(
+		await std.download({
+			unpackFormat,
+			url,
+			checksum,
+		}),
+	);
 	return std.directory.unwrap(outer);
 });
 
@@ -53,7 +56,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let configure = {
 		command: tg`${sourceDir}/source/configure`,
-		args: ["--enable-static"]
+		args: ["--enable-static"],
 	};
 	let phases = { configure };
 
@@ -70,7 +73,7 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	// Every file in bin/ needs to get wrapped to include lib/.
 	let libDir = tg.Directory.expect(await output.get("lib"));
-	let binDir =tg.Directory.expect(await output.get("bin"));
+	let binDir = tg.Directory.expect(await output.get("bin"));
 	for await (let [name, artifact] of binDir) {
 		let unwrappedBin = tg.File.expect(artifact);
 		let wrappedBin = std.wrap(unwrappedBin, {
@@ -91,7 +94,19 @@ export let test = tg.target(async () => {
 
 	await std.assert.pkg({
 		directory,
-		binaries: ["derb", "genbrk", "gencfu", "gencval", "gendict", "icu-config", "icuexportdata", "icuinfo", "makeconv", "pkgdata", "uconv"],
+		binaries: [
+			"derb",
+			"genbrk",
+			"gencfu",
+			"gencval",
+			"gendict",
+			"icu-config",
+			"icuexportdata",
+			"icuinfo",
+			"makeconv",
+			"pkgdata",
+			"uconv",
+		],
 		libs: ["icudata", "icui18n", "icuio", "icutest", "icutu", "icuuc"],
 		metadata,
 	});

--- a/packages/nodejs/tangram.tg.ts
+++ b/packages/nodejs/tangram.tg.ts
@@ -96,8 +96,10 @@ export let nodejs = tg.target(async (args?: ToolchainArg) => {
 
 export let test = tg.target(async () => {
 	let node = nodejs();
+	console.log("node", await (await node).id());
 	return std.build(
 		tg`
+		set -x
 		mkdir -p $OUTPUT
 		echo "node: " ${node}
 		node --version

--- a/packages/python/tangram.tg.ts
+++ b/packages/python/tangram.tg.ts
@@ -19,7 +19,7 @@ export let metadata = {
 	name: "Python",
 	license: "Python Software Foundation License",
 	repository: "https://github.com/python/cpython",
-	version: "3.12.2",
+	version: "3.12.3",
 };
 
 /** Return the MAJ.MIN version of python, used by some installation scripts. */
@@ -32,7 +32,7 @@ export let versionString = () => {
 export let source = tg.target(async (): Promise<tg.Directory> => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:be28112dac813d2053545c14bf13a16401a21877f1a69eb6ea5d84c4a0f3d870";
+		"sha256:56bfef1fdfc1221ce6720e43a661e3eb41785dd914ce99698d8c7896af4bdaa1";
 	let unpackFormat = ".tar.xz" as const;
 	let url = `https://www.python.org/ftp/python/${version}/${name}-${version}${unpackFormat}`;
 
@@ -48,7 +48,7 @@ export let source = tg.target(async (): Promise<tg.Directory> => {
 });
 
 type ToolchainArg = {
- 	/** Optional autotools configuration. */
+	/** Optional autotools configuration. */
 	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
 
 	/** Optional environment variables to set. */
@@ -75,7 +75,14 @@ type ToolchainArg = {
 
 /** Build and create a python environment. */
 export let python = tg.target(async (arg?: ToolchainArg) => {
-	let { autotools = [], build, env: env_, host, source: source_, ...rest } = arg ?? {};
+	let {
+		autotools = [],
+		build,
+		env: env_,
+		host,
+		source: source_,
+		...rest
+	} = arg ?? {};
 
 	let dependencies = [
 		bison(arg),
@@ -93,7 +100,7 @@ export let python = tg.target(async (arg?: ToolchainArg) => {
 		{
 			TANGRAM_LINKER_LIBRARY_PATH_OPT_LEVEL: "resolve",
 		},
-		env_
+		env_,
 	];
 
 	let configure = {
@@ -102,7 +109,7 @@ export let python = tg.target(async (arg?: ToolchainArg) => {
 			"--enable-optimizations",
 			"--with-pkg-config=yes",
 			"--without-c-locale-coercion",
-			"--without-readline"
+			"--without-readline",
 		],
 	};
 

--- a/packages/rust/tangram.tg.ts
+++ b/packages/rust/tangram.tg.ts
@@ -10,7 +10,7 @@ export let metadata = {
 	version: "0.0.0",
 };
 
-let VERSION = "1.77.1" as const;
+let VERSION = "1.77.2" as const;
 let PROFILE = "minimal" as const;
 
 type ToolchainArg = {

--- a/packages/sqlite/tangram.tg.ts
+++ b/packages/sqlite/tangram.tg.ts
@@ -1,3 +1,5 @@
+import ncurses from "tg:ncurses" with { path: "../ncurses" };
+import pkgconfig from "tg:pkgconfig" with { path: "../pkgconfig" };
 import readline from "tg:readline" with { path: "../readline" };
 import * as std from "tg:std" with { path: "../std" };
 import zlib from "tg:zlib" with { path: "../zlib" };
@@ -55,7 +57,12 @@ export let sqlite = tg.target((arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let dependencies = [readline(arg), zlib(arg)];
+	let dependencies = [
+		ncurses(arg),
+		pkgconfig(arg),
+		readline(arg),
+		zlib(arg),
+	];
 	let env = [...dependencies, env_];
 
 	return std.autotools.build(

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd97381a8cc6493395a5afc4c691c1084b3768db713b73aa215217aa245d153"
+checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
 dependencies = [
  "jobserver",
  "libc",
@@ -1434,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1599,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=db7cce370cb16c0da4e0c14d427642de3ca250c6#db7cce370cb16c0da4e0c14d427642de3ca250c6"
+source = "git+https://github.com/tangramdotdev/tangram?rev=1ef8d0a94f4e1b1cf0130320751aa2fe387ce3ec#1ef8d0a94f4e1b1cf0130320751aa2fe387ce3ec"
 dependencies = [
  "async-compression",
  "blake3",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "tangram_sse"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=db7cce370cb16c0da4e0c14d427642de3ca250c6#db7cce370cb16c0da4e0c14d427642de3ca250c6"
+source = "git+https://github.com/tangramdotdev/tangram?rev=1ef8d0a94f4e1b1cf0130320751aa2fe387ce3ec#1ef8d0a94f4e1b1cf0130320751aa2fe387ce3ec"
 dependencies = [
  "futures",
  "tokio",

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -28,7 +28,7 @@ itertools = "0.12"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "db7cce370cb16c0da4e0c14d427642de3ca250c6" }
+tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "1ef8d0a94f4e1b1cf0130320751aa2fe387ce3ec" }
 tokio = { version = "1", default-features = false, features = [
   "rt",
   "macros",

--- a/packages/std/bootstrap/make.tg.ts
+++ b/packages/std/bootstrap/make.tg.ts
@@ -1,4 +1,5 @@
 import * as std from "../tangram.tg.ts";
+import { sdk } from "./sdk.tg.ts";
 
 export let metadata = {
 	homepage: "https://www.gnu.org/software/make/",
@@ -16,7 +17,7 @@ export let source = tg.target(() => {
 });
 
 export let build = tg.target(async (arg?: string) => {
-	let host = arg ?? await std.triple.host();
+	let host = arg ?? (await std.triple.host());
 
 	let configure = {
 		args: ["--disable-dependency-tracking"],
@@ -43,7 +44,7 @@ export let build = tg.target(async (arg?: string) => {
 		opt: "s",
 		phases,
 		prefixArg: "none",
-		sdk: { bootstrapMode: true },
+		sdk: sdk.arg(host),
 		source: source(),
 	});
 

--- a/packages/std/bootstrap/musl.tg.ts
+++ b/packages/std/bootstrap/musl.tg.ts
@@ -59,7 +59,7 @@ export let build = tg.target(async (arg?: std.sdk.BuildEnvArg) => {
 		host,
 		phases,
 		prefixPath: "/",
-		sdk: { bootstrapMode: true },
+		sdk: bootstrap.sdk.arg(host),
 		source: source(),
 	});
 

--- a/packages/std/bootstrap/sdk.tg.ts
+++ b/packages/std/bootstrap/sdk.tg.ts
@@ -1,95 +1,107 @@
 import * as bootstrap from "../bootstrap.tg.ts";
 import * as std from "../tangram.tg.ts";
 
-/** Get a build environment containing only the components from the pre-built bootstrap artifacts with no proxying. Instead of using this env directly, consider using `std.sdk({ bootstrapMode: true })`, which can optionally include the linker and/or cc proxies. */
-export let env = async (hostArg?: string): Promise<std.env.Arg> => {
-	let host = hostArg ?? (await std.triple.host());
-	let toolchain = await prepareBootstrapToolchain(host);
-	let bootstrapHost = bootstrap.toolchainTriple(host);
-	let utils = await prepareBootstrapUtils(bootstrapHost);
-	let shellExe = tg.File.expect(await utils.get("bin/dash"));
-	let env: tg.MutationMap<Record<string, tg.Template.Arg>> = {
-		CONFIG_SHELL: shellExe,
-		SHELL: shellExe,
-	};
-	if (std.triple.os(host) === "darwin") {
-		let sdkroot = await tg.Mutation.setIfUnset(bootstrap.macOsSdk());
-		env = {
-			...env,
-			SDKROOT: sdkroot,
+/** Produce a std.sdk() consisting only of components from the bootstrap bundles, with the `ld` proxy enabled. Will not compile any utilites or toolchains. */
+export async function sdk(host?: string) {
+	return std.sdk(sdk.arg(host));
+}
+
+export namespace sdk {
+	/** Produce the arg object to create a bootstrap-only SDK. */
+	export let arg = async (hostArg?: string): Promise<std.sdk.Arg> => {
+		let host = await bootstrap.toolchainTriple(hostArg);
+		let toolchain = await env(host);
+		// The toolchain env already includes the busybox utils.
+		let utils = false;
+		return {
+			host,
+			toolchain,
+			utils,
 		};
-	}
-	return std.env.object(
-		toolchain,
-		utils,
-		{ [`TANGRAM_SYSROOT_${host.replace(/-/g, "_").toUpperCase()}`]: toolchain },
-		env,
-	);
-};
+	};
 
-export default env;
-
-/** Get the bootstrap components as a single directory, for use before SDK. */
-export let prepareBootstrapToolchain = async (hostArg?: string) => {
-	// Detect the host triple if not provided.
-	let host = hostArg ?? (await std.triple.host());
-	let os = std.triple.os(host);
-
-	// Obtain the bootstrap toolchain and triple for the detected host to construct the env.
-	let bootstrapToolchain = await bootstrap.toolchain({ host });
-	let bootstrapTriple = bootstrap.toolchainTriple(host);
-
-	if (os === "darwin") {
-		// Replace the Xcode-tied gcc and g++ entries with symlinks to clang and return.
-		bootstrapToolchain = await tg.directory(bootstrapToolchain, {
-			["bin/gcc"]: tg.symlink("clang"),
-			["bin/g++"]: tg.symlink("clang++"),
-		});
-	} else if (os === "linux") {
-		// Nothing to do.
-	} else {
-		throw new Error(`Unsupported host OS: ${os}.`);
-	}
-
-	return bootstrapToolchain;
-};
-
-/** Combine the busybox/toybox artifact with the dash shell from the bootstrap. */
-export let prepareBootstrapUtils = async (hostArg?: string) => {
-	let host = hostArg ?? (await std.triple.host());
-	let shell = await bootstrap.shell({ host });
-	let shellFile = tg.File.expect(await shell.get("bin/dash"));
-	let utils = bootstrap.utils({ host });
-	let combined = tg.directory(utils, {
-		"bin/dash": shellFile,
-		"bin/sh": tg.symlink("dash"),
-	});
-	return combined;
-};
-
-export let prefixBins = async (
-	dir: tg.Directory,
-	bins: Array<String>,
-	prefix: string,
-): Promise<tg.Directory> => {
-	let ret = dir;
-	for (let bin of bins) {
-		if (!ret.tryGet(`bin/${bin}`)) {
-			throw new Error(`Could not locate bin/${bin}.`);
+	/** Get a build environment containing only the components from the pre-built bootstrap artifacts with no proxying. Instead of using this env directly, consider using `std.sdk({ bootstrapMode: true })`, which can optionally include the linker and/or cc proxies. */
+	export let env = async (hostArg?: string): Promise<std.env.Arg> => {
+		let host = hostArg ?? (await std.triple.host());
+		let toolchain = await prepareBootstrapToolchain(host);
+		let bootstrapHost = await bootstrap.toolchainTriple(host);
+		let utils = await prepareBootstrapUtils(bootstrapHost);
+		let shellExe = tg.File.expect(await utils.get("bin/dash"));
+		let env: tg.MutationMap<Record<string, tg.Template.Arg>> = {
+			CONFIG_SHELL: shellExe,
+			SHELL: shellExe,
+		};
+		if (std.triple.os(host) === "darwin") {
+			let sdkroot = await tg.Mutation.setIfUnset(bootstrap.macOsSdk());
+			env = {
+				...env,
+				SDKROOT: sdkroot,
+			};
 		}
-		ret = await tg.directory(ret, {
-			bin: {
-				[`${prefix}${bin}`]: tg.symlink(`${bin}`),
-			},
-		});
-	}
-	return ret;
-};
+		return std.env.object(toolchain, utils, env);
+	};
 
-export let test = tg.target(async () => {
-	let sdk = await env();
-	let detectedHost = await std.triple.host();
-	let expectedHost = bootstrap.toolchainTriple(detectedHost);
-	await std.sdk.assertValid(sdk, { host: expectedHost, bootstrapMode: true });
-	return sdk;
-});
+	/** Get the bootstrap components as a single directory, for use before SDK. */
+	export let prepareBootstrapToolchain = async (hostArg?: string) => {
+		// Detect the host triple if not provided.
+		let host = hostArg ?? (await std.triple.host());
+		let os = std.triple.os(host);
+
+		// Obtain the bootstrap toolchain and triple for the detected host to construct the env.
+		let bootstrapToolchain = await bootstrap.toolchain(host);
+
+		if (os === "darwin") {
+			// Replace the Xcode-tied gcc and g++ entries with symlinks to clang and return.
+			bootstrapToolchain = await tg.directory(bootstrapToolchain, {
+				["bin/gcc"]: tg.symlink("clang"),
+				["bin/g++"]: tg.symlink("clang++"),
+			});
+		} else if (os === "linux") {
+			// Nothing to do.
+		} else {
+			throw new Error(`Unsupported host OS: ${os}.`);
+		}
+
+		return bootstrapToolchain;
+	};
+
+	/** Combine the busybox/toybox artifact with the dash shell from the bootstrap. */
+	export let prepareBootstrapUtils = async (hostArg?: string) => {
+		let host = hostArg ?? (await std.triple.host());
+		let shell = await bootstrap.shell(host);
+		let shellFile = tg.File.expect(await shell.get("bin/dash"));
+		let utils = bootstrap.utils(host);
+		let combined = tg.directory(utils, {
+			"bin/dash": shellFile,
+			"bin/sh": tg.symlink("dash"),
+		});
+		return combined;
+	};
+
+	export let prefixBins = async (
+		dir: tg.Directory,
+		bins: Array<String>,
+		prefix: string,
+	): Promise<tg.Directory> => {
+		let ret = dir;
+		for (let bin of bins) {
+			if (!ret.tryGet(`bin/${bin}`)) {
+				throw new Error(`Could not locate bin/${bin}.`);
+			}
+			ret = await tg.directory(ret, {
+				bin: {
+					[`${prefix}${bin}`]: tg.symlink(`${bin}`),
+				},
+			});
+		}
+		return ret;
+	};
+
+	export let test = tg.target(async () => {
+		let sdkEnv = await sdk();
+		console.log(sdkEnv);
+		let arg = await sdk.arg();
+		await std.sdk.assertValid(sdkEnv, arg);
+		return sdkEnv;
+	});
+}

--- a/packages/std/image.tg.ts
+++ b/packages/std/image.tg.ts
@@ -92,12 +92,8 @@ export let testBasicRootfs = tg.target(async () => {
 export let testOciBasicEnv = tg.target(async () => {
 	let detectedHost = await std.triple.host();
 	let host = bootstrap.toolchainTriple(detectedHost);
-	let utils = await std.utils.env({ host, sdk: { bootstrapMode: true } });
-	let basicEnv = await std.env(
-		utils,
-		{ NAME: "Tangram" },
-		{ bootstrapMode: true },
-	);
+	let utils = await std.utils.env({ host, sdk: bootstrap.sdk.arg() });
+	let basicEnv = await std.env(utils, { NAME: "Tangram" }, { utils: true });
 	return basicEnv;
 });
 

--- a/packages/std/sdk/cmake.tg.ts
+++ b/packages/std/sdk/cmake.tg.ts
@@ -113,12 +113,11 @@ export let build = tg.target(
 		let prefixArg = prefixArg_ ?? `-DCMAKE_INSTALL_PREFIX=`;
 
 		// Obtain a statically linked `cmake` binary and add it to the env.
-		let bootstrapHost = bootstrap.toolchainTriple(host);
+		let bootstrapHost = await bootstrap.toolchainTriple(host);
 		let dependencies = [
 			cmake({
 				host: bootstrapHost,
-				bootstrapMode: true,
-				env: std.sdk({ host: bootstrapHost, bootstrapMode: true }),
+				sdk: bootstrap.sdk.arg(bootstrapHost),
 			}),
 		];
 		if (useNinja) {
@@ -160,8 +159,9 @@ export let build = tg.target(
 
 export let test = tg.target(async () => {
 	let detectedHost = await std.triple.host();
-	let host = bootstrap.toolchainTriple(detectedHost);
-	let directory = cmake({ host, sdk: { bootstrapMode: true } });
+	let host = await bootstrap.toolchainTriple(detectedHost);
+	let sdkArg = await bootstrap.sdk.arg(host);
+	let directory = cmake({ host, sdk: sdkArg });
 	await std.assert.pkg({
 		directory,
 		binaries: ["cmake"],

--- a/packages/std/sdk/dependencies/bison.tg.ts
+++ b/packages/std/sdk/dependencies/bison.tg.ts
@@ -38,8 +38,11 @@ export let build = tg.target((arg?: Arg) => {
 		],
 	};
 
-	let dependencies = [m4({ ...rest, build, env: env_, host })];
-	let env = [env_, std.utils.env({ ...rest, build, env: env_, host }), ...dependencies];
+	let dependencies = [
+		std.utils.env({ ...rest, build, host }),
+		m4({ ...rest, build, host }),
+	];
+	let env = [env_, ...dependencies];
 
 	let output = std.utils.buildUtil(
 		{
@@ -60,15 +63,14 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await std.triple.host());
-	let bootstrapMode = true;
-	let sdk = std.sdk({ host, bootstrapMode });
-	let directory = build({ host, bootstrapMode, env: sdk });
+	let host = await bootstrap.toolchainTriple(await std.triple.host());
+	let sdkArg = await bootstrap.sdk.arg(host);
+	let directory = build({ host, sdk: sdkArg });
 	await std.assert.pkg({
-		bootstrapMode,
 		directory,
 		binaries: ["bison"],
 		metadata,
+		sdk: sdkArg,
 	});
 	return directory;
 });

--- a/packages/std/sdk/dependencies/m4.tg.ts
+++ b/packages/std/sdk/dependencies/m4.tg.ts
@@ -32,7 +32,7 @@ export let build = tg.target((arg?: Arg) => {
 		args: ["--disable-dependency-tracking"],
 	};
 
-	let env = [env_, std.utils.env({ ...rest, build, env: env_, host })];
+	let env = [env_, std.utils.env({ ...rest, build, host })];
 
 	let output = std.utils.buildUtil(
 		{
@@ -52,15 +52,14 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await std.triple.host());
-	let bootstrapMode = true;
-	let sdk = std.sdk({ host, bootstrapMode });
-	let directory = build({ host, bootstrapMode, env: sdk });
+	let host = await bootstrap.toolchainTriple(await std.triple.host());
+	let sdkArg = await bootstrap.sdk.arg(host);
+	let directory = build({ host, sdk: sdkArg });
 	await std.assert.pkg({
-		bootstrapMode,
 		directory,
 		binaries: ["m4"],
 		metadata,
+		sdk: sdkArg,
 	});
 	return directory;
 });

--- a/packages/std/sdk/dependencies/zlib.tg.ts
+++ b/packages/std/sdk/dependencies/zlib.tg.ts
@@ -38,7 +38,7 @@ export let build = tg.target((arg?: Arg) => {
 		...rest
 	} = arg ?? {};
 
-	let env = [env_, std.utils.env(arg)];
+	let env = [env_, std.utils.env({ ...rest, build, host })];
 
 	let output = std.utils.buildUtil(
 		{
@@ -57,14 +57,13 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await std.triple.host());
-	let bootstrapMode = true;
-	let sdk = std.sdk({ host, bootstrapMode });
-	let directory = build({ host, bootstrapMode, env: sdk });
+	let host = await bootstrap.toolchainTriple(await std.triple.host());
+	let sdkArg = await bootstrap.sdk.arg(host);
+	let directory = build({ host, sdk: sdkArg });
 	await std.assert.pkg({
-		bootstrapMode,
 		directory,
 		libs: ["z"],
+		sdk: sdkArg,
 	});
 	return directory;
 });

--- a/packages/std/sdk/dependencies/zstd.tg.ts
+++ b/packages/std/sdk/dependencies/zstd.tg.ts
@@ -44,7 +44,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let install = tg`make install PREFIX=$OUTPUT`;
 	let phases = { install };
 
-	let env = [env_, std.utils.env({ ...rest, build, env: env_, host })];
+	let env = [env_, std.utils.env({ ...rest, build, host })];
 
 	let result = std.autotools.build({
 		...rest,
@@ -63,14 +63,14 @@ export default build;
 
 import * as bootstrap from "../../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await std.triple.host());
-	let bootstrapMode = true;
-	let sdk = std.sdk({ host, bootstrapMode });
-	let directory = build({ host, bootstrapMode, env: sdk });
+	let host = await bootstrap.toolchainTriple(await std.triple.host());
+	let sdkArg = await bootstrap.sdk.arg(host);
+	let directory = build({ host, sdk: sdkArg });
 	await std.assert.pkg({
-		bootstrapMode,
+		metadata,
 		directory,
 		libs: ["zstd"],
+		sdk: sdkArg,
 	});
 	return directory;
 });

--- a/packages/std/sdk/libc/glibc.tg.ts
+++ b/packages/std/sdk/libc/glibc.tg.ts
@@ -1,3 +1,4 @@
+import * as bootstrap from "../../bootstrap.tg.ts";
 import * as std from "../../tangram.tg.ts";
 import * as dependencies from "../dependencies.tg.ts";
 
@@ -83,18 +84,16 @@ export default tg.target(async (arg: Arg) => {
 	};
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
-	let buildSdk = std.sdk({ host: build, bootstrapMode: true });
+	let buildSdkArg = await bootstrap.sdk.arg(build);
 	env = env.concat([
-		std.utils.env({ host: build, bootstrapMode: true, env: buildSdk }),
+		std.utils.env({ host: build, sdk: buildSdkArg }),
 		dependencies.bison.build({
 			host: build,
-			bootstrapMode: true,
-			env: buildSdk,
+			sdk: buildSdkArg,
 		}),
 		dependencies.python.build({
 			host: build,
-			bootstrapMode: true,
-			env: buildSdk,
+			sdk: buildSdkArg,
 		}),
 	]);
 

--- a/packages/std/sdk/libc/musl.tg.ts
+++ b/packages/std/sdk/libc/musl.tg.ts
@@ -79,15 +79,12 @@ export default tg.target(async (arg?: Arg) => {
 	};
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
-	if (rest.bootstrapMode) {
 		env.push(
 			std.utils.env({
-				bootstrapMode: true,
-				env: std.sdk({ host: build, bootstrapMode: true }),
+				sdk: bootstrap.sdk.arg(build),
 				host: build,
 			}),
 		);
-	}
 	env = env.concat([{ CPATH: tg.Mutation.unset() }]);
 
 	let result = await std.autotools.build(

--- a/packages/std/sdk/llvm.tg.ts
+++ b/packages/std/sdk/llvm.tg.ts
@@ -41,8 +41,8 @@ export let toolchain = async (arg?: LLVMArg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = canonicalTriple(host_ ?? (await std.triple.host()));
-	let build = canonicalTriple(build_ ?? host);
+	let host = await canonicalTriple(host_ ?? (await std.triple.host()));
+	let build = await canonicalTriple(build_ ?? host);
 
 	if (std.triple.os(host) !== "linux") {
 		throw new Error("LLVM toolchain must be built for Linux");
@@ -60,8 +60,7 @@ export let toolchain = async (arg?: LLVMArg) => {
 		git({ host: build }),
 		dependencies.python.build({
 			host: build,
-			bootstrapMode: true,
-			env: std.sdk({ bootstrapMode: true, host: build }),
+			sdk: bootstrap.sdk.arg(build),
 		}),
 	];
 

--- a/packages/std/tangram.tg.ts
+++ b/packages/std/tangram.tg.ts
@@ -217,14 +217,9 @@ export let testCrossToolchainRpi = tg.target(() => {
 
 // SDK tests.
 
-import { toolchainTriple as bootstrapToolchainTriple } from "./bootstrap.tg.ts";
 import { sdk } from "./sdk.tg.ts";
 export let testBootstrapSdk = tg.target(async () => {
-	let env = await sdk({ bootstrapMode: true });
-	let host = await triple.host();
-	let detectedHost = bootstrapToolchainTriple(host);
-	await sdk.assertValid(env, { host: detectedHost, bootstrapMode: true });
-	return env;
+	return await bootstrap.sdk.test();
 });
 
 export let testDefaultSdk = tg.target(async () => {

--- a/packages/std/utils/diffutils.tg.ts
+++ b/packages/std/utils/diffutils.tg.ts
@@ -22,7 +22,6 @@ type Arg = std.sdk.BuildEnvArg & {
 export let build = tg.target(async (arg?: Arg) => {
 	let {
 		autotools = [],
-		bootstrapMode,
 		build: build_,
 		env: env_,
 		host: host_,
@@ -37,16 +36,12 @@ export let build = tg.target(async (arg?: Arg) => {
 		args: ["--disable-dependency-tracking", "--disable-rpath"],
 	};
 
-	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
-	if (bootstrapMode) {
-		env.push(prerequisites(host));
-	}
+	let env = [env_, prerequisites(host)];
 
 	let output = buildUtil(
 		{
 			...rest,
 			...std.triple.rotate({ build, host }),
-			bootstrapMode,
 			env,
 			phases: { configure },
 			source: source_ ?? source(),
@@ -61,15 +56,14 @@ export default build;
 
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await std.triple.host());
-	let bootstrapMode = true;
-	let sdk = std.sdk({ host, bootstrapMode });
-	let directory = await build({ host, bootstrapMode, env: sdk });
+	let host = await bootstrap.toolchainTriple(await std.triple.host());
+	let sdkArg = await bootstrap.sdk.arg(host);
+	let directory = await build({ host, sdk: sdkArg });
 	await std.assert.pkg({
-		bootstrapMode,
 		directory,
 		binaries: ["cmp", "diff"],
 		metadata,
+		sdk: sdkArg,
 	});
 	return directory;
 });

--- a/packages/std/utils/file_cmds.tg.ts
+++ b/packages/std/utils/file_cmds.tg.ts
@@ -91,8 +91,8 @@ export let compileUtil = async (arg: UtilArg) => {
 	let { destDir, fileName, utilName, utilSource } = arg;
 
 	// Grab prerequisites.
-	let dashArtifact = await bootstrap.shell({ host });
-	let toolchainArtifact = await bootstrap.toolchain({ host });
+	let dashArtifact = await bootstrap.shell(host);
+	let toolchainArtifact = await bootstrap.toolchain(host);
 	let macOsSdk = await bootstrap.macOsSdk();
 
 	// Compile the util.

--- a/packages/std/utils/findutils.tg.ts
+++ b/packages/std/utils/findutils.tg.ts
@@ -37,7 +37,6 @@ type Arg = std.sdk.BuildEnvArg & {
 export let build = tg.target(async (arg?: Arg) => {
 	let {
 		autotools = [],
-		bootstrapMode,
 		build: build_,
 		env: env_,
 		host: host_,
@@ -55,16 +54,12 @@ export let build = tg.target(async (arg?: Arg) => {
 		args: ["--disable-dependency-tracking", "--disable-rpath"],
 	};
 
-	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
-	if (bootstrapMode) {
-		env.push(prerequisites(host));
-	}
+	let env = [env_, prerequisites(host)];
 
 	let output = buildUtil(
 		{
 			...rest,
 			...std.triple.rotate({ build, host }),
-			bootstrapMode,
 			env,
 			phases: { configure },
 			source: source_ ?? source(os),
@@ -79,15 +74,14 @@ export let build = tg.target(async (arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await std.triple.host());
-	let bootstrapMode = true;
-	let sdk = std.sdk({ host, bootstrapMode });
-	let directory = build({ host, bootstrapMode, env: sdk });
+	let host = await bootstrap.toolchainTriple(await std.triple.host());
+	let sdkArg = await bootstrap.sdk.arg(host);
+	let directory = build({ host, sdk: sdkArg });
 	await std.assert.pkg({
-		bootstrapMode,
 		directory,
 		binaries: ["find", "xargs"],
 		metadata,
+		sdk: sdkArg,
 	});
 	return directory;
 });

--- a/packages/std/utils/make.tg.ts
+++ b/packages/std/utils/make.tg.ts
@@ -22,7 +22,6 @@ type Arg = std.sdk.BuildEnvArg & {
 export let build = tg.target(async (arg?: Arg) => {
 	let {
 		autotools = [],
-		bootstrapMode,
 		build,
 		env: env_,
 		host,
@@ -37,16 +36,12 @@ export let build = tg.target(async (arg?: Arg) => {
 		configure,
 	};
 
-	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
-	if (bootstrapMode) {
-		env.push(prerequisites(host));
-	}
+	let env = [env_, prerequisites(host)];
 
 	return buildUtil(
 		{
 			...rest,
 			...std.triple.rotate({ build, host }),
-			bootstrapMode,
 			env,
 			phases,
 			source: source_ ?? source(),
@@ -58,15 +53,14 @@ export let build = tg.target(async (arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await std.triple.host());
-	let bootstrapMode = true;
-	let sdk = std.sdk({ host, bootstrapMode });
-	let makeArtifact = await build({ host, bootstrapMode, env: sdk });
+	let host = await bootstrap.toolchainTriple(await std.triple.host());
+	let sdkArg = await bootstrap.sdk.arg(host);
+	let makeArtifact = await build({ host, sdk: sdkArg });
 	await std.assert.pkg({
-		bootstrapMode,
 		directory: makeArtifact,
 		binaries: ["make"],
 		metadata,
+		sdk: sdkArg,
 	});
 	return makeArtifact;
 });

--- a/packages/std/utils/patch.tg.ts
+++ b/packages/std/utils/patch.tg.ts
@@ -23,7 +23,6 @@ type Arg = std.sdk.BuildEnvArg & {
 export let build = tg.target((arg?: Arg) => {
 	let {
 		autotools = [],
-		bootstrapMode,
 		build,
 		env: env_,
 		host,
@@ -35,16 +34,12 @@ export let build = tg.target((arg?: Arg) => {
 		args: ["--disable-dependency-tracking"],
 	};
 
-	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
-	if (bootstrapMode) {
-		env.push(prerequisites(host));
-	}
+	let env = [env_, prerequisites(host)];
 
 	let output = buildUtil(
 		{
 			...rest,
 			...std.triple.rotate({ build, host }),
-			bootstrapMode,
 			env,
 			phases: { configure },
 			source: source_ ?? source(),
@@ -58,15 +53,14 @@ export let build = tg.target((arg?: Arg) => {
 export default build;
 
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await std.triple.host());
-	let bootstrapMode = true;
-	let sdk = std.sdk({ host, bootstrapMode });
-	let directory = build({ host, bootstrapMode, env: sdk });
+	let host = await bootstrap.toolchainTriple(await std.triple.host());
+	let sdkArg = await bootstrap.sdk.arg(host);
+	let directory = build({ host, sdk: sdkArg });
 	await std.assert.pkg({
-		bootstrapMode,
 		directory,
 		binaries: ["patch"],
 		metadata,
+		sdk: sdkArg,
 	});
 	return directory;
 });

--- a/packages/std/utils/sed.tg.ts
+++ b/packages/std/utils/sed.tg.ts
@@ -22,7 +22,6 @@ type Arg = std.sdk.BuildEnvArg & {
 export let build = tg.target(async (arg?: Arg) => {
 	let {
 		autotools = [],
-		bootstrapMode,
 		build: build_,
 		env: env_,
 		host: host_,
@@ -37,16 +36,12 @@ export let build = tg.target(async (arg?: Arg) => {
 		args: ["--disable-dependency-tracking"],
 	};
 
-	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
-	if (bootstrapMode) {
-		env.push(prerequisites(host));
-	}
+	let env = [env_, prerequisites(host)];
 
 	let output = buildUtil(
 		{
 			...rest,
 			...std.triple.rotate({ build, host }),
-			bootstrapMode,
 			env,
 			phases: { configure },
 			source: source_ ?? source(),
@@ -61,15 +56,14 @@ export default build;
 
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
-	let host = bootstrap.toolchainTriple(await std.triple.host());
-	let bootstrapMode = true;
-	let sdk = std.sdk({ host, bootstrapMode });
-	let directory = build({ host, bootstrapMode, env: sdk });
+	let host = await bootstrap.toolchainTriple(await std.triple.host());
+	let sdkArg = await bootstrap.sdk.arg(host);
+	let directory = build({ host, sdk: sdkArg });
 	await std.assert.pkg({
-		bootstrapMode,
 		directory,
 		binaries: ["sed"],
 		metadata,
+		sdk: sdkArg,
 	});
 	return directory;
 });

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -1434,7 +1434,7 @@ export let defaultShellInterpreter = async (
 	// Provide bash for the detected host system.
 	let buildArg = undefined;
 	if (buildToolchainArg) {
-		buildArg = { bootstrapMode: true, env: buildToolchainArg };
+		buildArg = { env: buildToolchainArg };
 	}
 	let shellArtifact = await std.utils.bash.build(buildArg);
 	let shellExecutable = tg.File.expect(await shellArtifact.get("bin/bash"));
@@ -2150,7 +2150,7 @@ export let testSingleArgObjectNoMutations = tg.target(async () => {
 	let executable = await argAndEnvDump();
 	let executableID = await executable.id();
 
-	let buildToolchain = await std.sdk({ bootstrapMode: true });
+	let buildToolchain = await bootstrap.sdk();
 
 	let wrapper = await wrap({
 		args: ["--arg1", "--arg2"],

--- a/packages/std/wrap/workspace.tg.ts
+++ b/packages/std/wrap/workspace.tg.ts
@@ -50,7 +50,7 @@ export let tgld = async (arg: Arg) =>
 export let wrapper = async (arg: Arg) =>
 	tg.File.expect(await (await workspace(arg)).get("bin/wrapper"));
 
-let version = "1.77.1";
+let version = "1.77.2";
 
 type ToolchainArg = {
 	target?: string;
@@ -211,10 +211,7 @@ export let build = async (arg: BuildArg) => {
 		}
 	}
 
-	let bootstrapMode =
-		os === "darwin" || (os === "linux" && hostArch === targetArch);
 	let { directory, ldso, libDir } = await std.sdk.toolchainComponents({
-		bootstrapMode,
 		env: buildToolchain,
 		host: isCross ? host : host_,
 		target: isCross ? target : target_,


### PR DESCRIPTION
This PR removes the `bootstrapMode` arguments from all `std` interfaces, and allows setting `sdk: false` in `std.autotools` builds to prevent implicitly selecting an SDK if a manually-created environment is more appropriate.  It additionally restructures the SDK construction logic to reduce branching on specific configuration types, and eliminates several redundant rebuilds of SDK dependencies where possible.  Closes #18.