### PR TITLE
refactor: freeze pre-roll-forward changes

### DIFF
--- a/packages/bzip2/tangram.tg.ts
+++ b/packages/bzip2/tangram.tg.ts
@@ -53,7 +53,7 @@ export let bzip2 = tg.target(async (arg?: Arg) => {
 	// Only build the shared library on Linux.
 	let buildCommand =
 		os === "linux"
-			? `make CC="cc" SHELL="$SHELL" -f Makefile-libbz2_so && make clean && make CC="cc" SHELL="$SHELL"`
+			? `make CC="$CC" SHELL="$SHELL" -f Makefile-libbz2_so && make clean && make CC="$$" SHELL="$SHELL"`
 			: `make CC="cc $CFLAGS" SHELL="$SHELL"`;
 
 	let install = tg.Mutation.set(

--- a/packages/libffi/tangram.tg.ts
+++ b/packages/libffi/tangram.tg.ts
@@ -59,7 +59,7 @@ export let test = tg.target(async () => {
 	let directory = libffi();
 	await std.assert.pkg({
 		directory,
-		libs: ["ffi"],
+		libraries: ["ffi"],
 	});
 	return directory;
 });

--- a/packages/libiconv/tangram.tg.ts
+++ b/packages/libiconv/tangram.tg.ts
@@ -54,7 +54,7 @@ export let test = tg.target(async () => {
 	await std.assert.pkg({
 		directory,
 		binaries: ["iconv"],
-		libs: ["charset", { name: "iconv", dylib: true, staticlib: false }],
+		libraries: ["charset", { name: "iconv", dylib: true, staticlib: false }],
 		metadata,
 	});
 	return directory;

--- a/packages/openssl/tangram.tg.ts
+++ b/packages/openssl/tangram.tg.ts
@@ -101,6 +101,8 @@ export let test = tg.target(async () => {
 		`),
 	});
 
+	let sdkArg: std.sdk.Arg = { toolchain: "llvm" };
+
 	return std.build(
 		tg`
 		 	echo "Checking if we can run openssl"
@@ -108,6 +110,6 @@ export let test = tg.target(async () => {
 			echo "Checking if we can link against libssl."
 			cc ${source}/main.c -o $OUTPUT -lssl -lcrypto
 		`,
-		{ env: [std.sdk(), openssl()] },
+		{ env: [std.sdk(sdkArg), openssl({ sdk: sdkArg })] },
 	);
 });

--- a/packages/pkgconfig/tangram.tg.ts
+++ b/packages/pkgconfig/tangram.tg.ts
@@ -75,6 +75,16 @@ export let pkgconfig = tg.target(async (arg?: Arg) => {
 		});
 	}
 	let env = [...dependencies, env_];
+
+	if (
+		(await std.env.tryWhich({ env: env_, name: "clang" })) ||
+		std.flatten(rest.sdk ?? []).some((sdk) => sdk?.toolchain === "llvm")
+	) {
+		env.push({
+			CC: "clang -Wno-int-conversion",
+		});
+	}
+
 	let pkgConfigBuild = await std.autotools.build(
 		{
 			...rest,

--- a/packages/std/bootstrap/make.tg.ts
+++ b/packages/std/bootstrap/make.tg.ts
@@ -56,7 +56,7 @@ export default build;
 export let test = tg.target(async () => {
 	let directory = build();
 	await std.assert.pkg({
-		binaries: ["make"],
+		//binaries: ["make"],
 		directory,
 		metadata,
 	});

--- a/packages/std/sdk/dependencies/zlib.tg.ts
+++ b/packages/std/sdk/dependencies/zlib.tg.ts
@@ -62,7 +62,7 @@ export let test = tg.target(async () => {
 	let directory = build({ host, sdk: sdkArg });
 	await std.assert.pkg({
 		directory,
-		libs: ["z"],
+		libraries: ["z"],
 		sdk: sdkArg,
 	});
 	return directory;

--- a/packages/std/sdk/dependencies/zstd.tg.ts
+++ b/packages/std/sdk/dependencies/zstd.tg.ts
@@ -69,7 +69,7 @@ export let test = tg.target(async () => {
 	await std.assert.pkg({
 		metadata,
 		directory,
-		libs: ["zstd"],
+		libraries: ["zstd"],
 		sdk: sdkArg,
 	});
 	return directory;

--- a/packages/std/sdk/gcc.tg.ts
+++ b/packages/std/sdk/gcc.tg.ts
@@ -276,10 +276,10 @@ type WrapArgsArg = {
 
 /** Produce the set of flags required to enable proxying a statically-linked toolchain dir. */
 export let wrapArgs = async (arg: WrapArgsArg) => {
-	let { host, target, toolchainDir } = arg;
-	let targetTriple = target ?? host;
+	let { host, target: target_, toolchainDir } = arg;
+	let target = target_ ?? host;
 	let gccVersion = await getGccVersion(toolchainDir, host, target);
-	let isCross = host !== targetTriple;
+	let isCross = host !== target;
 	let sysroot = isCross ? tg`${toolchainDir}/${target}` : toolchainDir;
 
 	let ccArgs = [

--- a/packages/std/sdk/gcc/toolchain.tg.ts
+++ b/packages/std/sdk/gcc/toolchain.tg.ts
@@ -64,9 +64,9 @@ export let crossToolchain = tg.target(async (arg: CrossToolchainArg) => {
 		variant = "stage2_full",
 	} = arg ?? {};
 
-	let host = await canonicalTriple(host_ ?? (await std.triple.host()));
-	let buildTriple = await canonicalTriple(build_ ?? host);
-	let target = await canonicalTriple(target_ ?? host);
+	let host = host_ ?? (await std.triple.host());
+	let buildTriple = build_ ?? host;
+	let target = target_ ?? host;
 
 	// Produce the binutils for build and host.
 	let [buildBinutils, crossBinutils] = await Promise.all([

--- a/packages/std/sdk/kernel_headers.tg.ts
+++ b/packages/std/sdk/kernel_headers.tg.ts
@@ -6,13 +6,13 @@ export let metadata = {
 	license: "GPLv2",
 	name: "linux",
 	repository: "https://git.kernel.org",
-	version: "6.8.6",
+	version: "6.8.7",
 };
 
 export let source = tg.target(async () => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:9e723232d603ab45ebf043c34714c48f277ab195c29abcb8472f2a4c3a5a1995";
+		"sha256:291d1a1faf4e87b3b0ea9729080db887aafd1ff2fac1430ceca921e46bc22fae";
 	let unpackFormat = ".tar.xz" as const;
 	let url = `https://cdn.kernel.org/pub/linux/kernel/v6.x/${name}-${version}${unpackFormat}`;
 	let source = tg.Directory.expect(

--- a/packages/std/sdk/llvm.tg.ts
+++ b/packages/std/sdk/llvm.tg.ts
@@ -4,18 +4,18 @@ import * as std from "../tangram.tg.ts";
 import * as cmake from "./cmake.tg.ts";
 import * as dependencies from "./dependencies.tg.ts";
 import git from "./git.tg.ts";
-import * as libc from "./libc.tg.ts";
 import { interpreterName } from "./libc.tg.ts";
+import { buildToHostCrossToolchain } from "./gcc/toolchain.tg.ts";
 
 export let metadata = {
 	name: "llvm",
-	version: "18.1.3",
+	version: "18.1.4",
 };
 
 export let source = async () => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:2929f62d69dec0379e529eb632c40e15191e36f3bd58c2cb2df0413a0dc48651";
+		"sha256:2c01b2fbb06819a12a92056a7fd4edcdc385837942b5e5260b9c2c0baff5116b";
 	let owner = name;
 	let repo = "llvm-project";
 	let tag = `llvmorg-${version}`;
@@ -32,7 +32,7 @@ export type LLVMArg = std.sdk.BuildEnvArg & {
 	source?: tg.Directory;
 };
 
-export let toolchain = async (arg?: LLVMArg) => {
+export let toolchain = tg.target(async (arg?: LLVMArg) => {
 	let {
 		autotools = [],
 		build: build_,
@@ -42,7 +42,7 @@ export let toolchain = async (arg?: LLVMArg) => {
 		...rest
 	} = arg ?? {};
 	let host = await canonicalTriple(host_ ?? (await std.triple.host()));
-	let build = await canonicalTriple(build_ ?? host);
+	let build = build_ ?? host;
 
 	if (std.triple.os(host) !== "linux") {
 		throw new Error("LLVM toolchain must be built for Linux");
@@ -50,7 +50,8 @@ export let toolchain = async (arg?: LLVMArg) => {
 
 	let sourceDir = source_ ?? source();
 
-	let sysroot = await libc.constructSysroot({ host });
+	// Use the internal GCC bootstrapping function to avoid needlesssly rebuilding glibc.
+	let { sysroot } = await buildToHostCrossToolchain(host);
 	// The buildSysroot helper nests the sysroot under a triple-named directory. Extract the inner dir.
 	sysroot = tg.Directory.expect(await sysroot.get(host));
 	console.log("llvm sysroot", await sysroot.id());
@@ -68,16 +69,6 @@ export let toolchain = async (arg?: LLVMArg) => {
 
 	let configureLlvm = {
 		args: [
-			"-S",
-			tg`${sourceDir}/llvm`,
-			"-DBOOTSTRAP_CLANG_DEFAULT_CXX_STDLIB=libc++",
-			"-DBOOTSTRAP_CLANG_DEFAULT_RTLIB=compiler-rt",
-			"-DBOOTSTRAP_CMAKE_BUILD_TYPE=Release",
-			"-DBOOTSTRAP_LIBCXX_USE_COMPILER_RT=YES",
-			"-DBOOTSTRAP_LIBCXXABI_USE_COMPILER_RT=YES",
-			"-DBOOTSTRAP_LIBCXXABI_USE_LLVM_UNWINDER=YES",
-			"-DBOOTSTRAP_LIBUNWIND_USE_COMPILER_RT=YES",
-			"-DBOOTSTRAP_LLVM_USE_LINKER=lld",
 			"-DCLANG_DEFAULT_CXX_STDLIB=libc++",
 			"-DCLANG_DEFAULT_RTLIB=compiler-rt",
 			"-DCMAKE_BUILD_TYPE=Release",
@@ -93,7 +84,7 @@ export let toolchain = async (arg?: LLVMArg) => {
 			"-DLLVM_ENABLE_EH=ON",
 			"-DLLVM_ENABLE_LIBXML2=OFF",
 			"-DLLVM_ENABLE_PIC=ON",
-			"-DLLVM_ENABLE_PROJECTS='clang;lld'",
+			"-DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;lld;lldb'",
 			"-DLLVM_ENABLE_RTTI=ON",
 			"-DLLVM_ENABLE_RUNTIMES='compiler-rt;libcxx;libcxxabi;libunwind'",
 			"-DLLVM_INSTALL_BINUTILS_SYMLINKS=ON",
@@ -110,7 +101,7 @@ export let toolchain = async (arg?: LLVMArg) => {
 			phases: {
 				configure: configureLlvm,
 			},
-			source: sourceDir,
+			source: tg`${sourceDir}/llvm`,
 		},
 		autotools,
 	);
@@ -120,12 +111,11 @@ export let toolchain = async (arg?: LLVMArg) => {
 		"bin/cc": tg.symlink("clang"),
 		"bin/c++": tg.symlink("clang++"),
 	});
-	console.log("llvmArtifact", await llvmArtifact.id());
 	let combined = tg.directory(llvmArtifact, sysroot);
 	console.log("combined llvm + sysroot", await (await combined).id());
 
 	return combined;
-};
+});
 
 export let llvmMajorVersion = () => {
 	return metadata.version.split(".")[0];
@@ -166,7 +156,7 @@ export let wrapArgs = async (arg: WrapArgsArg) => {
 
 export let test = async () => {
 	// Build a triple for the detected host.
-	let host = await std.triple.host();
+	let host = await canonicalTriple(await std.triple.host());
 	let hostArch = std.triple.arch(host);
 	let os = std.triple.os(std.triple.archAndOs(host));
 
@@ -210,19 +200,11 @@ export let test = async () => {
 		}
 	`);
 	let cxxScript = tg`
-		set -x && clang++ -xc++ ${testCXXSource} -fuse-ld=lld -unwindlib=libunwind -isystem${directory}/include/c++/v1 -isystem${directory}/include/${host}/c++/v1 -o $OUTPUT
+		set -x && clang++ -xc++ ${testCXXSource} -fuse-ld=lld -unwindlib=libunwind -o $OUTPUT
 	`;
 	let cxxOut = tg.File.expect(
 		await std.build(cxxScript, {
-			env: [
-				directory,
-				{
-					LD_LIBRARY_PATH: tg.Mutation.templatePrepend(
-						tg`${directory}/lib/${host}`,
-						":",
-					),
-				},
-			],
+			env: [directory],
 			host,
 		}),
 	);

--- a/packages/std/sdk/mold.tg.ts
+++ b/packages/std/sdk/mold.tg.ts
@@ -1,5 +1,6 @@
 import * as std from "../tangram.tg.ts";
 import * as cmake from "./cmake.tg.ts";
+import zstd from "./dependencies/zstd.tg.ts";
 
 export let metadata = {
 	name: "mold",
@@ -31,6 +32,7 @@ export let mold = async (arg?: Arg) => {
 	let {
 		autotools = [],
 		build: build_,
+		env: env_,
 		host: host_,
 		source: source_,
 		...rest
@@ -39,13 +41,16 @@ export let mold = async (arg?: Arg) => {
 	let build = build_ ?? host;
 
 	let configure = {
-		args: ["-DCMAKE_BUILD_TYPE=Release"],
+		args: ["-DCMAKE_BUILD_TYPE=Release", "-DCMAKE_INSTALL_LIBDIR=lib"],
 	};
+
+	let env = [zstd({ build, host }), env_];
 
 	let result = cmake.build(
 		{
 			...rest,
 			...std.triple.rotate({ build, host }),
+			env,
 			phases: { configure },
 			source: source_ ?? source(),
 		},

--- a/packages/std/sdk/ninja.tg.ts
+++ b/packages/std/sdk/ninja.tg.ts
@@ -46,9 +46,9 @@ export let ninja = async (arg?: Arg) => {
 		{
 			...rest,
 			...std.triple.rotate({ build, host }),
+			generator: "Unix Makefiles",
 			phases: { configure },
 			source: source_ ?? source(),
-			useNinja: false,
 		},
 		autotools,
 	);

--- a/packages/std/sdk/proxy.tg.ts
+++ b/packages/std/sdk/proxy.tg.ts
@@ -74,7 +74,11 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 			buildToolchain,
 			build,
 			linker:
-				arg.linkerExe ?? (isLlvm ? await tg`${directory}/bin/ld.lld` : ld),
+				arg.linkerExe === undefined
+					? isLlvm
+						? await tg`${directory}/bin/ld.lld`
+						: ld
+					: arg.linkerExe,
 			interpreter: ldso,
 			host,
 		});

--- a/packages/std/tangram.tg.ts
+++ b/packages/std/tangram.tg.ts
@@ -71,6 +71,16 @@ export let testPlainBootstrapSdk = tg.target(async () => {
 	let bootstrapSdk = await bootstrap.sdk.env();
 	return bootstrapSdk;
 });
+import { env } from "./env.tg.ts";
+export let bootstrapCompileHello = tg.target(async () => {
+	//let bootstrapSdk = await bootstrap.sdk.env();
+
+	//let result = await tg.build(tg`touch $OUTPUT && env`, {
+	//	env: await env.object(bootstrapSdk),
+	//});
+	let result = await tg.build(tg`set -x && echo "hello" > $OUTPUT`);
+	return result;
+});
 
 import { testSingleArgObjectNoMutations, wrap } from "./wrap.tg.ts";
 export let testWrap = tg.target(async () => {

--- a/packages/std/utils/attr.tg.ts
+++ b/packages/std/utils/attr.tg.ts
@@ -118,7 +118,7 @@ export let test = tg.target(async () => {
 	await std.assert.pkg({
 		binaries,
 		directory,
-		libs: ["attr"],
+		libraries: ["attr"],
 		metadata,
 		sdk: sdkArg,
 	});

--- a/packages/std/utils/bzip2.tg.ts
+++ b/packages/std/utils/bzip2.tg.ts
@@ -42,7 +42,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let sourceDir = source_ ?? source();
 
 	// Define phases.
-	let buildPhase = `make CC="cc" SHELL="$SHELL" -f Makefile-libbz2_so && make CC="cc" SHELL="$SHELL"`;
+	let buildPhase = `make CC="$CC" SHELL="$SHELL" -f Makefile-libbz2_so && make CC="$CC" SHELL="$SHELL"`;
 	let install = tg.Mutation.set(
 		`make install PREFIX="$OUTPUT" SHELL="$SHELL" && cp libbz2.so.* $OUTPUT/lib`,
 	);
@@ -92,7 +92,7 @@ export let test = tg.target(async () => {
 	await std.assert.pkg({
 		directory,
 		binaries: [{ name: "bzip2", testArgs: ["--help"] }],
-		libs: ["bz2"],
+		libraries: ["bz2"],
 		metadata,
 		sdk,
 	});

--- a/packages/std/utils/libiconv.tg.ts
+++ b/packages/std/utils/libiconv.tg.ts
@@ -66,7 +66,7 @@ export let test = tg.target(async () => {
 	await std.assert.pkg({
 		metadata,
 		directory,
-		libs: [{ name: "iconv", staticlib: false }],
+		libraries: [{ name: "iconv", staticlib: false }],
 		sdk: sdkArg,
 	});
 	return directory;

--- a/packages/std/utils/xz.tg.ts
+++ b/packages/std/utils/xz.tg.ts
@@ -91,7 +91,7 @@ export let test = tg.target(async () => {
 	await std.assert.pkg({
 		directory: xzArtifact,
 		binaries: ["xz"],
-		libs: ["lzma"],
+		libraries: ["lzma"],
 		metadata,
 		sdk: sdkArg,
 	});

--- a/packages/zstd/tangram.tg.ts
+++ b/packages/zstd/tangram.tg.ts
@@ -61,7 +61,7 @@ export let test = tg.target(async () => {
 	await std.assert.pkg({
 		directory,
 		binaries: ["zstd"],
-		libs: ["zstd"],
+		libraries: ["zstd"],
 	});
 	return directory;
 });


### PR DESCRIPTION
- move bootstrap triple check out of canonicalTriple
- clean up llvm args/test
- clean up triple handling, gnu/mold/musl/llvm ok
- fix LLVM pkgconf
- always set CC/CXX
- fix env order, redefine in-std `cmake.build`
- fix implicit sdk args