### PR TITLE
fix(std): macOS SDK

### DIFF
--- a/packages/rust/Cargo.lock
+++ b/packages/rust/Cargo.lock
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"
@@ -1189,9 +1189,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -1324,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -1393,7 +1393,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=14ae3e9e048bd538e1089e35e5cb137b611714f6#14ae3e9e048bd538e1089e35e5cb137b611714f6"
+source = "git+https://github.com/tangramdotdev/tangram?rev=d3f8968fe6a03902ed80c6be845619a215ed6ef8#d3f8968fe6a03902ed80c6be845619a215ed6ef8"
 dependencies = [
  "blake3",
  "bytes",
@@ -1453,7 +1453,7 @@ dependencies = [
 [[package]]
 name = "tangram_sse"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=14ae3e9e048bd538e1089e35e5cb137b611714f6#14ae3e9e048bd538e1089e35e5cb137b611714f6"
+source = "git+https://github.com/tangramdotdev/tangram?rev=d3f8968fe6a03902ed80c6be845619a215ed6ef8#d3f8968fe6a03902ed80c6be845619a215ed6ef8"
 dependencies = [
  "futures",
  "tokio",

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -9,7 +9,7 @@ futures = "0.3"
 itertools = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "14ae3e9e048bd538e1089e35e5cb137b611714f6" }
+tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "d3f8968fe6a03902ed80c6be845619a215ed6ef8" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -1082,9 +1082,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.33"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3cc72858054fcff6d7dea32df2aeaee6a7c24227366d7ea429aada2f26b16ad"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -1312,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=84b35fb30a6fb7349d0dc4aa47802a63fd4c949d#84b35fb30a6fb7349d0dc4aa47802a63fd4c949d"
+source = "git+https://github.com/tangramdotdev/tangram?rev=d3f8968fe6a03902ed80c6be845619a215ed6ef8#d3f8968fe6a03902ed80c6be845619a215ed6ef8"
 dependencies = [
  "blake3",
  "bytes",
@@ -1375,7 +1375,7 @@ dependencies = [
 [[package]]
 name = "tangram_sse"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=84b35fb30a6fb7349d0dc4aa47802a63fd4c949d#84b35fb30a6fb7349d0dc4aa47802a63fd4c949d"
+source = "git+https://github.com/tangramdotdev/tangram?rev=d3f8968fe6a03902ed80c6be845619a215ed6ef8#d3f8968fe6a03902ed80c6be845619a215ed6ef8"
 dependencies = [
  "futures",
  "tokio",

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -28,7 +28,7 @@ itertools = "0.12"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "84b35fb30a6fb7349d0dc4aa47802a63fd4c949d" }
+tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "d3f8968fe6a03902ed80c6be845619a215ed6ef8" }
 tokio = { version = "1", default-features = false, features = [
   "rt",
   "macros",

--- a/packages/std/packages/wrapper/src/main.rs
+++ b/packages/std/packages/wrapper/src/main.rs
@@ -359,6 +359,8 @@ fn set_dyld_environment(
 		} else {
 			manifest_library_path
 		};
+		#[cfg(feature = "tracing")]
+		tracing::trace!(?library_path);
 		std::env::set_var("DYLD_LIBRARY_PATH", library_path);
 	}
 
@@ -603,7 +605,6 @@ fn symlink_from_artifact_value_data(value: &tg::value::Data) -> tg::symlink::Dat
 }
 
 fn template_from_symlink(symlink: &tg::symlink::Data) -> tg::template::Data {
-	// TODO use path here.
 	let mut components = Vec::with_capacity(3);
 	if let Some(artifact) = &symlink.artifact {
 		components.push(tg::template::component::Data::Artifact(artifact.clone()));

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -74,6 +74,7 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 	});
 	// Obtain host and targets.
 	let host = host_ ?? (await std.triple.host());
+	let hostOs = std.triple.os(host);
 	let targets = targets_ ?? [];
 
 	// Set the default proxy arguments.
@@ -96,7 +97,7 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 	// Determine host toolchain.
 	let toolchain: std.env.Arg;
 	if (toolchain_ === "gcc") {
-		if (std.triple.os(host) === "darwin") {
+		if (hostOs === "darwin") {
 			throw new Error(`The GCC toolchain is not available on macOS.`);
 		}
 		toolchain = await gcc.toolchain({ host });
@@ -731,7 +732,7 @@ export namespace sdk {
 		}
 
 		// Assert it provides at the utils. If utils was set to false, check for the smaller set, otherwise ensure we built all the utils.
-		if (arg?.utils) {
+		if (arg?.utils ?? true) {
 			await std.utils.assertProvides(env);
 		} else {
 			await std.env.assertProvides({

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -730,25 +730,27 @@ export namespace sdk {
 			);
 		}
 
-		// Assert it provides at the basic utilities all builds will assume to be available.
-		await std.env.assertProvides({
-			env,
-			names: [
-				"awk",
-				"cp",
-				"diff",
-				"find",
-				"grep",
-				"gzip",
-				"patch",
-				"ls",
-				"mkdir",
-				"mv",
-				"sed",
-				"sh",
-				"tar",
-			],
-		});
+		// Assert it provides at the utils. If utils was set to false, check for the smaller set, otherwise ensure we built all the utils.
+		if (arg?.utils) {
+			await std.utils.assertProvides(env);
+		} else {
+			await std.env.assertProvides({
+				env,
+				names: [
+					"awk",
+					"cp",
+					"find",
+					"grep",
+					"patch",
+					"ls",
+					"mkdir",
+					"mv",
+					"sed",
+					"sh",
+					"tar",
+				],
+			});
+		}
 
 		// Assert it can compile and wrap for all requested targets.
 		let allTargets =

--- a/packages/std/sdk/llvm.tg.ts
+++ b/packages/std/sdk/llvm.tg.ts
@@ -42,8 +42,9 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 	let host = await canonicalTriple(host_ ?? (await std.triple.host()));
 	let build = build_ ?? host;
 
-	if (std.triple.os(host) !== "linux") {
-		throw new Error("LLVM toolchain must be built for Linux");
+	if (std.triple.os(host) === "darwin") {
+		// On macOS, just return the bootstrap toolchain, which provides Apple Clang.
+		return bootstrap.sdk.env(host);
 	}
 
 	let sourceDir = source_ ?? source();

--- a/packages/std/sdk/llvm.tg.ts
+++ b/packages/std/sdk/llvm.tg.ts
@@ -137,6 +137,7 @@ export let wrapArgs = async (arg: WrapArgsArg) => {
 	if (std.triple.os(host) === "darwin") {
 		// Note - the Apple Clang version provided by the OS is 15, not ${version}.
 		clangArgs.push(tg`-resource-dir=${toolchainDir}/lib/clang/15.0.0`);
+		clangxxArgs = [...clangArgs];
 		env = {
 			SDKROOT: tg.Mutation.setIfUnset(bootstrap.macOsSdk()),
 		};

--- a/packages/std/tangram.tg.ts
+++ b/packages/std/tangram.tg.ts
@@ -70,6 +70,22 @@ export let testBootstrap = tg.target(async () => {
 export let testBootstrapShell = tg.target(async () => {
 	return await bootstrap.shell();
 });
+export let testBootstrapUtils = tg.target(async () => {
+	return await bootstrap.utils();
+});
+export let testBootstrapToolchain = tg.target(async () => {
+	return await bootstrap.toolchain();
+});
+export let testBootstrapMacosSdk = tg.target(async () => {
+	return await bootstrap.macOsSdk();
+});
+export let testAllBootstrapComponents = tg.target(async () => {
+	let shell = await bootstrap.shell();
+	let utils = await bootstrap.utils();
+	let toolchain = await bootstrap.toolchain();
+	let macOsSdk = await bootstrap.macOsSdk();
+	return [shell, utils, toolchain, macOsSdk];
+});
 export let testPlainBootstrapSdk = tg.target(async () => {
 	let bootstrapSdk = await bootstrap.sdk.env();
 	return bootstrapSdk;

--- a/packages/std/utils.tg.ts
+++ b/packages/std/utils.tg.ts
@@ -65,7 +65,7 @@ export let env = tg.target(async (arg?: Arg) => {
 			patch({ ...rest, env, host }),
 			sed({ ...rest, env, host }),
 			tar({ ...rest, env, host }),
-			xz({ ...rest, env, host }),
+			//xz({ ...rest, env, host }),
 		]),
 	);
 	return utils;

--- a/packages/std/utils.tg.ts
+++ b/packages/std/utils.tg.ts
@@ -65,7 +65,7 @@ export let env = tg.target(async (arg?: Arg) => {
 			patch({ ...rest, env, host }),
 			sed({ ...rest, env, host }),
 			tar({ ...rest, env, host }),
-			//xz({ ...rest, env, host }),
+			xz({ ...rest, env, host }),
 		]),
 	);
 	return utils;

--- a/packages/std/utils/bash.tg.ts
+++ b/packages/std/utils/bash.tg.ts
@@ -61,6 +61,7 @@ export let build = tg.target(async (arg?: Arg) => {
 	let configure = {
 		args: configureArgs,
 	};
+	let buildPhase = `make -j$(nproc) NO_GETTEXT=1`;
 
 	let env: tg.Unresolved<Array<std.env.Arg>> = [env_];
 	env.push(prerequisites(host));
@@ -76,7 +77,7 @@ export let build = tg.target(async (arg?: Arg) => {
 			...rest,
 			...std.triple.rotate({ build, host }),
 			env,
-			phases: { configure },
+			phases: { configure, build: buildPhase },
 			source: source_ ?? source(arg),
 		},
 		autotools,

--- a/packages/std/utils/file_cmds.tg.ts
+++ b/packages/std/utils/file_cmds.tg.ts
@@ -3,13 +3,13 @@ import * as std from "../tangram.tg.ts";
 
 export let metadata = {
 	name: "file_cmds",
-	version: "493.100.6",
+	version: "430.100.5",
 };
 
 export let source = tg.target(async () => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:ac636da85aaa15ba03affc2bed43821d53d745e077845d85cb2964409eb61a99";
+		"sha256:035272979817edb250e3527b95a028e59b5bff546a13346c4a4e0e83c4d7ac20";
 	let owner = "apple-oss-distributions";
 	let repo = "file_cmds";
 	let tag = std.download.packageName({ name, version });

--- a/packages/std/utils/tar.tg.ts
+++ b/packages/std/utils/tar.tg.ts
@@ -39,8 +39,8 @@ export let build = tg.target(async (arg?: Arg) => {
 
 	let dependencies: tg.Unresolved<std.env.Arg> = [prerequisites(host)];
 	let additionalEnv = {};
-	if (std.triple.os(build) === "darwin") {
-		dependencies.push(libiconv({ ...rest, build, host }));
+	if (std.triple.os(host) === "darwin") {
+		dependencies.push(libiconv({ ...rest, build, env: env_, host }));
 		// Bug: https://savannah.gnu.org/bugs/?64441.
 		// Fix http://git.savannah.gnu.org/cgit/tar.git/commit/?id=8632df39
 		// Remove in next release.

--- a/packages/std/utils/xz.tg.ts
+++ b/packages/std/utils/xz.tg.ts
@@ -66,18 +66,25 @@ export let build = tg.target(async (arg?: Arg) => {
 		},
 		autotools,
 	);
+	console.log("pre-wrap xz", await output.id());
 
 	let bins = ["lzmadec", "lzmainfo", "xz", "xzdec"];
 	let libDir = tg.Directory.expect(await output.get("lib"));
+	console.log("libDir", await libDir.id());
 	for (let bin of bins) {
+		console.log("wrapping", bin);
 		let unwrappedBin = tg.File.expect(await output.get(`bin/${bin}`));
+		console.log("unwrappedBin", await unwrappedBin.id());
 		let wrappedBin = std.wrap({
-			buildToolchain: bootstrap.sdk(),
+			buildToolchain: bootstrap.sdk.env(host),
 			executable: unwrappedBin,
 			libraryPaths: [libDir],
 		});
+		console.log("wrappedBin", await (await wrappedBin).id());
 		output = await tg.directory(output, { [`bin/${bin}`]: wrappedBin });
 	}
+	console.log("post-wrap xz", await output.id());
+
 	return output;
 });
 

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -1261,7 +1261,7 @@ let manifestInterpreterFromArg = async (
 		let host = await std.triple.host();
 		let buildToolchain = buildToolchainArg
 			? buildToolchainArg
-			: gcc.toolchain({ host });
+			: bootstrap.sdk.env(host);
 		let injectionLibrary = await injection.default({
 			buildToolchain,
 			host,
@@ -1327,8 +1327,7 @@ let manifestInterpreterFromExecutableArg = async (
 			return manifestInterpreterFromElf(metadata);
 		}
 		case "mach-o": {
-			let arch = metadata.arches[0];
-			tg.assert(arch);
+			let arch = std.triple.arch(await std.triple.host());
 			let host = std.triple.create({ os: "darwin", arch });
 			let buildToolchain = buildToolchainArg
 				? buildToolchainArg
@@ -2003,11 +2002,10 @@ async function* fileReferences(file: tg.File): AsyncGenerator<tg.Artifact> {
 async function* symlinkReferences(
 	symlink: tg.Symlink,
 ): AsyncGenerator<tg.Artifact> {
-	if (await symlink.artifact()) {
-		let artifact = await symlink.resolve();
-		if (artifact) {
-			yield* artifactReferences(artifact);
-		}
+	yield symlink;
+	let artifact = await symlink.artifact();
+	if (artifact) {
+		yield artifact;
 	}
 }
 

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -159,19 +159,14 @@ export async function wrap(...args: tg.Args<wrap.Arg>): Promise<tg.File> {
 				object.identity = arg.identity ?? "executable";
 			}
 			if (arg.libraryPaths !== undefined) {
-				if (arg.libraryPaths !== undefined) {
-					object.libraryPaths = tg.Mutation.is(arg.libraryPaths)
-						? arg.libraryPaths
-						: await tg.Mutation.arrayAppend(
-								arg.libraryPaths.map(manifestTemplateFromArg),
-						  );
-				}
+				object.libraryPaths = tg.Mutation.is(arg.libraryPaths)
+					? arg.libraryPaths
+					: await tg.Mutation.arrayAppend(
+							arg.libraryPaths.map(manifestTemplateFromArg),
+					  );
 			}
 			if (arg.interpreter !== undefined) {
 				object.interpreter = arg.interpreter;
-			}
-			if (arg.executable !== undefined) {
-				object.executable = arg.executable;
 			}
 			if (arg.args !== undefined) {
 				object.manifestArgs = tg.Mutation.is(arg.args)


### PR DESCRIPTION
This PR fixes outstanding issues in the SDK definition to restore producing the default environment on macOS.  It also fixes a bug where `std.wrap()` was not correctly re-wrapping already-wrapped executables.