### PR TITLE
feat: thread checksum argument through builders

### DIFF
--- a/packages/cmake/tangram.tg.ts
+++ b/packages/cmake/tangram.tg.ts
@@ -94,6 +94,9 @@ export let cmake = tg.target(async (arg?: Arg) => {
 export default cmake;
 
 export type BuildArg = {
+	/** If the build requires network access, provide a checksum or the string "unsafe" to accept any result. */
+	checksum?: tg.Checksum;
+
 	/** Debug mode will enable additional log output, allow failiures in subprocesses, and include a folder of logs at $OUTPUT/.tangram_logs. Default: false */
 	debug?: boolean;
 
@@ -190,6 +193,9 @@ export let target = async (...args: tg.Args<BuildArg>) => {
 		} else if (typeof arg === "object") {
 			let object: tg.MutationMap<Apply> = {};
 			let phasesArgs: Array<std.phases.Arg> = [];
+			if (arg.checksum !== undefined) {
+				phasesArgs.push({ checksum: arg.checksum });
+			}
 			if (arg.debug !== undefined) {
 				object.debug = arg.debug;
 			}

--- a/packages/eslint/tangram.tg.ts
+++ b/packages/eslint/tangram.tg.ts
@@ -2,14 +2,17 @@ import * as node from "tg:nodejs" with { path: "../nodejs" };
 import * as std from "tg:std" with { path: "../std" };
 
 export let metadata = {
+	home: "https://eslint.org",
+	license: "MIT",
 	name: "eslint",
-	version: "8.55.0",
+	repository: "https://github.com/eslint/eslint",
+	version: "9.1.1",
 };
 
 export let source = tg.target(async () => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:249fc81da9761b0f8710d0239ad09dcceea0c777d4933111496900a0ed2b3128";
+		"sha256:4f39cb81c3540cbb5e0ccbbb7afff672fec31ac835b1f0be9bbf353083c61b38";
 	let owner = name;
 	let repo = name;
 	let tag = `v${version}`;

--- a/packages/fzf/tangram.tg.ts
+++ b/packages/fzf/tangram.tg.ts
@@ -3,13 +3,13 @@ import * as std from "tg:std" with { path: "../std" };
 
 export let metadata = {
 	name: "fzf",
-	version: "0.46.1",
+	version: "0.50.0",
 };
 
 export let source = tg.target((): Promise<tg.Directory> => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:b0d640be3ae79980fdf461096f7d9d36d38ec752e25f8c4d2ca3ca6c041c2491";
+		"sha256:3dd8f57eb58c039d343c23fbe1b4f03e441eb796d564c959f8241106805370d0";
 	return std.download.fromGithub({
 		checksum,
 		owner: "junegunn",
@@ -35,6 +35,7 @@ export let fzf = tg.target(async (arg?: Arg) => {
 		{
 			...rest,
 			...std.triple.rotate({ build, host }),
+			checksum: "unsafe",
 			source: source_ ?? source(),
 		},
 		goArg,
@@ -45,7 +46,7 @@ export let test = tg.target(async () => {
 	await std.assert.pkg({
 		buildFunction: fzf,
 		binaries: [
-			{ name: "fzf", testPredicate: (stdout) => stdout.includes("0.46") },
+			{ name: "fzf", testPredicate: (stdout) => stdout.includes("0.50") },
 		],
 		metadata,
 	});

--- a/packages/go/tangram.tg.ts
+++ b/packages/go/tangram.tg.ts
@@ -1,30 +1,33 @@
 import * as std from "tg:std" with { path: "../std" };
 
 export let metadata = {
+	homepage: "https://go.dev/",
+	license: "BSD-3-Clause",
 	name: "go",
-	version: "1.22.1",
+	repository: "https://github.com/golang/go",
+	version: "1.22.2",
 };
 
 // See https://go.dev/dl.
 let RELEASES = {
 	["aarch64-linux"]: {
 		checksum:
-			"sha256:e56685a245b6a0c592fc4a55f0b7803af5b3f827aaa29feab1f40e491acf35b8",
+			"sha256:36e720b2d564980c162a48c7e97da2e407dfcc4239e1e58d98082dfa2486a0c1",
 		url: `https://go.dev/dl/go${metadata.version}.linux-arm64.tar.gz`,
 	},
 	["x86_64-linux"]: {
 		checksum:
-			"sha256:aab8e15785c997ae20f9c88422ee35d962c4562212bb0f879d052a35c8307c7f",
+			"sha256:5901c52b7a78002aeff14a21f93e0f064f74ce1360fce51c6ee68cd471216a17",
 		url: `https://go.dev/dl/go${metadata.version}.linux-amd64.tar.gz`,
 	},
 	["aarch64-darwin"]: {
 		checksum:
-			"sha256:5f10b95e2678618f85ba9d87fbed506b3b87efc9d5a8cafda939055cb97949ba",
+			"sha256:e09de4ad7b0bd112437912781429f717b092053600b804b10e7c22107d18accf",
 		url: `https://go.dev/dl/go${metadata.version}.darwin-arm64.tar.gz`,
 	},
 	["x86_64-darwin"]: {
 		checksum:
-			"sha245:943e4f9f038239f9911c44366f52ab9202f6ee13610322a668fe42406fb3deef",
+			"sha256:35c399ffa0195193eba73cd3ce4e2382b78154cbe8296ebbb53f27cfdbb11c57",
 		url: `https://go.dev/dl/go${metadata.version}.darwin-amd64.tar.gz`,
 	},
 };
@@ -71,6 +74,9 @@ export let toolchain = tg.target(
 export default toolchain;
 
 export type Arg = {
+	/** If the build requires network access, provide a checksum or the string "unsafe" to accept any result. */
+	checksum?: tg.Checksum;
+
 	/**
 	 * Explicitly enable or disable updating vendored dependencies, or override the command used in the vendor phase.
 	 *
@@ -122,6 +128,7 @@ export type Arg = {
 
 export let build = async (...args: tg.Args<Arg>): Promise<tg.Directory> => {
 	type Apply = {
+		checksum: tg.Checksum;
 		cgo: boolean;
 		env: Array<std.env.Arg>;
 		generate: boolean | { command: tg.Template.Arg };
@@ -134,6 +141,7 @@ export let build = async (...args: tg.Args<Arg>): Promise<tg.Directory> => {
 	};
 
 	let {
+		checksum,
 		cgo,
 		env: env_,
 		generate,
@@ -148,6 +156,9 @@ export let build = async (...args: tg.Args<Arg>): Promise<tg.Directory> => {
 			return {};
 		} else {
 			let object: tg.MutationMap<Apply> = {};
+			if (arg.checksum !== undefined) {
+				object.checksum = arg.checksum;
+			}
 			if (arg.source !== undefined) {
 				object.source = arg.source;
 			}
@@ -261,7 +272,7 @@ export let build = async (...args: tg.Args<Arg>): Promise<tg.Directory> => {
 		{
 			host,
 			env,
-			checksum: "unsafe",
+			checksum,
 		},
 	);
 

--- a/packages/hyperfine/tangram.tg.ts
+++ b/packages/hyperfine/tangram.tg.ts
@@ -1,0 +1,66 @@
+import * as rust from "tg:rust" with { path: "../rust" };
+import * as std from "tg:std" with { path: "../std" };
+
+export let metadata = {
+	homepage: "https://github.com/sharkdp/hyperfine",
+	license: "Apache-2.0, MIT",
+	name: "hyperfine",
+	repository: "https://github.com/sharkdp/hyperfine",
+	version: "1.18.0",
+};
+
+export let source = tg.target(async () => {
+	let { name, version } = metadata;
+	let checksum =
+		"sha256:fea7b92922117ed04b9c84bb9998026264346768804f66baa40743c5528bed6b";
+	let owner = "sharkdp";
+	let repo = name;
+	let tag = `v${version}`;
+	return std.download.fromGithub({
+		checksum,
+		owner,
+		repo,
+		source: "tag",
+		tag,
+	});
+});
+
+type Arg = {
+	build?: string;
+	env?: std.env.Arg;
+	rust?: tg.MaybeNestedArray<rust.Arg>;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+	host?: string;
+};
+
+export let hyperfine = tg.target(async (arg?: Arg) => {
+	let {
+		build,
+		host,
+		rust: rustArgs = [],
+		source: source_,
+		...rest
+	} = arg ?? {};
+
+	return rust.build(
+		{
+			...rest,
+			...std.triple.rotate({ build, host }),
+			source: source_ ?? source(),
+		},
+		rustArgs,
+	);
+});
+
+export default hyperfine;
+
+export let test = tg.target(async () => {
+	let artifact = hyperfine();
+	await std.assert.pkg({
+		buildFunction: hyperfine,
+		binaries: ["hyperfine"],
+		metadata,
+	});
+	return artifact;
+});

--- a/packages/lz4/tangram.tg.ts
+++ b/packages/lz4/tangram.tg.ts
@@ -1,0 +1,67 @@
+import * as std from "tg:std" with { path: "../std" };
+
+export let metadata = {
+	homepage: "https://lz4.org/",
+	license:
+		"https://github.com/lz4/lz4/blob/5ff839680134437dbf4678f3d0c7b371d84f4964/LICENSE",
+	name: "lz4",
+	repository: "https://github.com/lz4/lz4",
+	version: "1.9.4",
+};
+
+export let source = tg.target(() => {
+	let { name, version } = metadata;
+	let checksum =
+		"sha256:0b0e3aa07c8c063ddf40b082bdf7e37a1562bda40a0ff5272957f3e987e0e54b";
+	let owner = name;
+	let repo = name;
+	let tag = `v${version}`;
+	return std.download.fromGithub({
+		checksum,
+		owner,
+		repo,
+		source: "release",
+		tag,
+		version,
+	});
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: string;
+	env?: std.env.Arg;
+	host?: string;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let lz4 = tg.target(async (arg?: Arg) => {
+	let { autotools = [], build, host, source: source_, ...rest } = arg ?? {};
+
+	let sourceDir = source_ ?? source();
+
+	let install = {
+		args: ["prefix=$OUTPUT"],
+	};
+	let phases = { configure: tg.Mutation.unset(), install };
+
+	return std.autotools.build({
+		...rest,
+		...std.triple.rotate({ build, host }),
+		buildInTree: true,
+		phases,
+		source: sourceDir,
+	});
+});
+
+export default lz4;
+
+export let test = tg.target(async () => {
+	let artifact = lz4();
+	await std.assert.pkg({
+		buildFunction: lz4,
+		binaries: ["lz4"],
+		libraries: ["lz4"],
+	});
+	return artifact;
+});

--- a/packages/ncurses/tangram.tg.ts
+++ b/packages/ncurses/tangram.tg.ts
@@ -96,6 +96,12 @@ export let ncurses = tg.target(async (arg?: Arg) => {
 		}),
 	);
 
+	// Add links from curses to ncurses.
+	result = await tg.directory(result, {
+		[`lib/libcurses.${dylibExt}`]: tg.symlink(`libncurses.${dylibExt}`),
+		[`lib/pkgconfig/curses.pc`]: tg.symlink(`ncurses.pc`),
+	});
+
 	return result;
 });
 

--- a/packages/nodejs/tangram.tg.ts
+++ b/packages/nodejs/tangram.tg.ts
@@ -113,10 +113,11 @@ export default nodejs;
 
 export type Arg = {
 	build?: string;
+	checksum?: tg.Checksum;
 	env?: std.env.Arg;
 	host?: string;
 	packageLock?: tg.File;
-	phases?: tg.MaybeNestedArray<std.phases.Arg>;
+	phases?: std.phases.Arg;
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source: tg.Directory;
 };
@@ -144,6 +145,10 @@ export let build = async (...args: tg.Args<Arg>) => {
 			return {};
 		} else {
 			let object: tg.MutationMap<Apply> = {};
+			let phasesArgs: Array<std.phases.Arg> = [];
+			if (arg.checksum !== undefined) {
+				phasesArgs.push({ checksum: arg.checksum });
+			}
 			if (arg.env !== undefined) {
 				object.env = tg.Mutation.is(arg.env)
 					? arg.env
@@ -155,9 +160,11 @@ export let build = async (...args: tg.Args<Arg>) => {
 					: await tg.Mutation.arrayAppend<std.sdk.Arg>(arg.sdk);
 			}
 			if (arg.phases !== undefined) {
-				object.phases = tg.Mutation.is(arg.phases)
-					? arg.phases
-					: await tg.Mutation.arrayAppend(arg.phases);
+				if (tg.Mutation.is(arg.phases)) {
+					object.phases = arg.phases;
+				} else {
+					phasesArgs.push(arg.phases);
+				}
 			}
 			if (arg.source !== undefined) {
 				object.source = arg.source;

--- a/packages/perl/tangram.tg.ts
+++ b/packages/perl/tangram.tg.ts
@@ -5,6 +5,7 @@ import * as std from "tg:std" with { path: "../std" };
 import zlib from "tg:zlib" with { path: "../zlib" };
 
 export let metadata = {
+	homepage: "https://www.perl.org/",
 	name: "perl",
 	version: "5.38.2",
 };

--- a/packages/postgresql/tangram.tg.ts
+++ b/packages/postgresql/tangram.tg.ts
@@ -1,4 +1,5 @@
 import icu from "tg:icu" with { path: "../icu" };
+import lz4 from "tg:lz4" with { path: "../lz4" };
 import ncurses from "tg:ncurses" with { path: "../ncurses" };
 import openssl from "tg:openssl" with { path: "../openssl" };
 import perl from "tg:perl" with { path: "../perl" };
@@ -53,6 +54,7 @@ export let postgresql = tg.target(async (arg?: Arg) => {
 
 	let env = [
 		icu({ ...rest, build, env: env_, host }),
+		lz4({ ...rest, build, env: env_, host }),
 		ncurses({ ...rest, build, env: env_, host }),
 		openssl({ ...rest, build, env: env_, host }),
 		perl({ ...rest, build, env: env_, host }),
@@ -69,7 +71,7 @@ export let postgresql = tg.target(async (arg?: Arg) => {
 	let sourceDir = source_ ?? source();
 
 	let configure = {
-		args: ["--with-zstd"],
+		args: ["--with-lz4", "--with-zstd"],
 	};
 	let phases = { configure };
 

--- a/packages/postgresql/tangram.tg.ts
+++ b/packages/postgresql/tangram.tg.ts
@@ -62,16 +62,13 @@ export let postgresql = tg.target(async (arg?: Arg) => {
 		readline({ ...rest, build, env: env_, host }),
 		zlib({ ...rest, build, env: env_, host }),
 		zstd({ ...rest, build, env: env_, host }),
-		{
-			LDFLAGS: tg.Mutation.templatePrepend(`-ltinfo`, ` `),
-		},
 		env_,
 	];
 
 	let sourceDir = source_ ?? source();
 
 	let configure = {
-		args: ["--with-lz4", "--with-zstd"],
+		args: ["--disable-rpath", "--with-lz4", "--with-zstd"],
 	};
 	let phases = { configure };
 
@@ -103,10 +100,12 @@ export let postgresql = tg.target(async (arg?: Arg) => {
 export default postgresql;
 
 export let test = tg.target(async () => {
+	let artifact = postgresql();
 	await std.assert.pkg({
 		buildFunction: postgresql,
 		binaries: ["psql"],
+		libraries: ["pq"],
 		metadata,
 	});
-	return true;
+	return artifact;
 });

--- a/packages/python/requirements.tg.ts
+++ b/packages/python/requirements.tg.ts
@@ -21,7 +21,7 @@ export let install = tg.target(
 				`,
 			{
 				env: pythonArtifact,
-				targetArg: { checksum: "unsafe" },
+				checksum: "unsafe",
 			},
 		);
 		tg.Directory.assert(downloads);

--- a/packages/python/requirements.tg.ts
+++ b/packages/python/requirements.tg.ts
@@ -21,7 +21,7 @@ export let install = tg.target(
 				`,
 			{
 				env: pythonArtifact,
-				checksum: "unsafe",
+				targetArg: { checksum: "unsafe" },
 			},
 		);
 		tg.Directory.assert(downloads);

--- a/packages/python/tangram.tg.ts
+++ b/packages/python/tangram.tg.ts
@@ -8,6 +8,7 @@ import m4 from "tg:m4" with { path: "../m4" };
 import ncurses from "tg:ncurses" with { path: "../ncurses" };
 import openssl from "tg:openssl" with { path: "../openssl" };
 import pkgconfig from "tg:pkgconfig" with { path: "../pkgconfig" };
+import readline from "tg:readline" with { path: "../readline" };
 import sqlite from "tg:sqlite" with { path: "../sqlite" };
 import zlib from "tg:zlib" with { path: "../zlib" };
 
@@ -100,6 +101,7 @@ export let python = tg.target(async (arg?: ToolchainArg) => {
 		ncurses({ ...rest, build, env: env_, host }),
 		openssl({ ...rest, build, env: env_, host }),
 		pkgconfig({ ...rest, build, env: env_, host }),
+		readline({ ...rest, build, env: env_, host }),
 		sqlite({ ...rest, build, env: env_, host }),
 		zlib({ ...rest, build, env: env_, host }),
 	];
@@ -120,7 +122,6 @@ export let python = tg.target(async (arg?: ToolchainArg) => {
 			"--enable-optimizations",
 			"--with-pkg-config=yes",
 			"--without-c-locale-coercion",
-			"--without-readline",
 		],
 	};
 

--- a/packages/python/tangram.tg.ts
+++ b/packages/python/tangram.tg.ts
@@ -221,7 +221,10 @@ let isPythonScript = (metadata: std.file.ExecutableMetadata): boolean => {
 };
 
 export type Arg = {
+	/** The machine this package will build on. */
 	build?: string;
+
+	/** The machine this package produces binaries for. */
 	host?: string;
 
 	/** An optional pyproject.toml. */

--- a/packages/readline/tangram.tg.ts
+++ b/packages/readline/tangram.tg.ts
@@ -51,7 +51,7 @@ export let readline = tg.target(async (arg?: Arg) => {
 	};
 	let phases = { configure };
 
-	let output = await std.autotools.build(
+	return std.autotools.build(
 		{
 			...rest,
 			...std.triple.rotate({ build, host }),
@@ -61,28 +61,6 @@ export let readline = tg.target(async (arg?: Arg) => {
 		},
 		autotools,
 	);
-
-	// Patch pc files to add tinfo as `Requires` instead of Requires.private`.
-	let libNames = ["history", "readline"];
-	await Promise.all(
-		libNames.map(async (name) => {
-			let pc = tg.File.expect(await output.get(`lib/pkgconfig/${name}.pc`));
-			let content = await pc.text();
-			let lines = content.split("\n");
-			lines = lines.map((line) => {
-				if (line.startsWith("Requires.private: tinfo")) {
-					return `Requires: tinfo`;
-				} else {
-					return line;
-				}
-			});
-			output = await tg.directory(output, {
-				[`lib/pkgconfig/${name}.pc`]: tg.file(lines.join("\n")),
-			});
-		}),
-	);
-
-	return output;
 });
 
 export default readline;

--- a/packages/rust/tangram.tg.ts
+++ b/packages/rust/tangram.tg.ts
@@ -141,20 +141,43 @@ export let rust = tg.target(async (arg?: ToolchainArg) => {
 export default rust;
 
 export type Arg = {
+	/** If the build requires network access, provide a checksum or the string "unsafe" to accept any result. */
+	checksum?: tg.Checksum;
+
+	/** Environment variables to set during the build. */
 	env?: std.env.Arg;
+
+	/** Features to enable during the build. */
 	features?: Array<string>;
+
+	/** Machine that will run the compilation. */
 	host?: string;
+
+	/** Whether to compile in parallel. */
 	parallel?: boolean;
+
+	/** Whether to use the tangram_rustc proxy. */
 	proxy?: boolean;
+
+	/** SDK configuration to use during the build. */
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+
+	/** Source directory containing the Cargo.toml. */
 	source?: tg.Artifact;
+
+	/** Target triple for the build. */
 	target?: string;
+
+	/** Whether to use cargo vendor instead of the Tangram-native vendoring. */
 	useCargoVendor?: boolean;
+
+	/** Whether to enable verbose logging. */
 	verbose?: boolean;
 };
 
 export let build = async (...args: tg.Args<Arg>) => {
 	type Apply = {
+		checksum: tg.Checksum;
 		env: Array<std.env.Arg>;
 		features: Array<string>;
 		host: string;
@@ -167,6 +190,7 @@ export let build = async (...args: tg.Args<Arg>) => {
 		verbose: boolean;
 	};
 	let {
+		checksum,
 		env,
 		features = [],
 		host: host_,
@@ -182,6 +206,9 @@ export let build = async (...args: tg.Args<Arg>) => {
 			return {};
 		} else {
 			let object: tg.MutationMap<Apply> = {};
+			if (arg.checksum !== undefined) {
+				object.checksum = arg.checksum;
+			}
 			if (arg.env !== undefined) {
 				object.env = tg.Mutation.is(arg.env)
 					? arg.env
@@ -301,6 +328,7 @@ export let build = async (...args: tg.Args<Arg>) => {
 	}
 
 	let artifact = await std.build(buildScript, {
+		checksum,
 		env: std.env(
 			sdk,
 			//libgccSdk,

--- a/packages/std/autotools.tg.ts
+++ b/packages/std/autotools.tg.ts
@@ -4,7 +4,7 @@ export type Arg = {
 	/** By default, autotools builds compile "out-of-tree", creating build artifacts in a mutable working directory but referring to an immutable source. Enabling `buildInTree` will instead first copy the source directory into the working build directory. Default: false. */
 	buildInTree?: boolean;
 
-	/** If the build rewuires network access, provide a checksum or the string "unsafe" to accept any result. */
+	/** If the build requires network access, provide a checksum or the string "unsafe" to accept any result. */
 	checksum?: tg.Checksum;
 
 	/** Debug mode will enable additional log output, allow failiures in subprocesses, and include a folder of logs at $OUTPUT/.tangram_logs. Default: false */

--- a/packages/std/build.tg.ts
+++ b/packages/std/build.tg.ts
@@ -5,19 +5,26 @@ export async function build(
 	...args: tg.Args<build.Arg>
 ): Promise<tg.Artifact | undefined> {
 	type Apply = {
-		system: string;
-		checksum: tg.Checksum;
+		targetArg: Array<tg.Target.Arg>;
 	};
-	let { system, checksum } = await tg.Args.apply<build.Arg, Apply>(
+	let { targetArg: targetArgs_ } = await tg.Args.apply<build.Arg, Apply>(
 		args,
 		async (arg) => {
-			if (isArgObject(arg)) {
-				return {
-					system: arg.system,
-					checksum: arg.checksum,
-				};
-			} else {
+			if (
+				typeof arg === "string" ||
+				tg.Template.is(arg) ||
+				tg.File.is(arg) ||
+				tg.Symlink.is(arg)
+			) {
 				return {};
+			} else {
+				let object: tg.MaybeMutationMap<Apply> = {};
+				if (arg.targetArg) {
+					object.targetArg = tg.Mutation.is(arg.targetArg)
+						? arg.targetArg
+						: await tg.Mutation.arrayAppend<tg.Target.Arg>(arg.targetArg);
+				}
+				return object;
 			}
 		},
 	);
@@ -25,24 +32,36 @@ export async function build(
 	// Create the executable.
 	let executable = await std.wrap(...args);
 
-	// If the system was not set in the args, then get it from the executable or the host.
-	let host = await std.triple.host();
-	if (!system) {
+	// Check if the user specified an explicit host.
+	let targetArgs = targetArgs_ ?? [];
+	let specifiedHost =
+		targetArgs.filter(
+			(arg) =>
+				arg !== undefined &&
+				typeof arg === "object" &&
+				"host" in arg &&
+				arg.host !== undefined,
+		).length > 0;
+
+	// If not, determine an approriate host from the executable.
+	if (!specifiedHost) {
+		let detectedHost = await std.triple.host();
 		let executableTriples = await std.file.executableTriples(executable);
-		let hostSystem = executableTriples?.includes(host)
-			? host
+		let hostSystem = executableTriples?.includes(detectedHost)
+			? detectedHost
 			: executableTriples?.at(0);
-		system = std.triple.archAndOs(hostSystem ?? host);
+		let host = std.triple.archAndOs(hostSystem ?? detectedHost);
+		targetArgs.push({ host });
 	}
-	system = system ?? host;
 
 	// Run.
 	return tg.Artifact.expect(
-		await tg.build({
-			host: system,
-			executable,
-			checksum,
-		}),
+		await tg.build(
+			{
+				executable,
+			},
+			...targetArgs,
+		),
 	);
 }
 
@@ -50,16 +69,7 @@ export namespace build {
 	export type Arg = string | tg.Template | tg.File | tg.Symlink | ArgObject;
 
 	export type ArgObject = std.wrap.ArgObject & {
-		system?: string;
-		unsafe?: boolean;
-		checksum?: tg.Checksum;
-		network?: boolean;
+		/** Options to configure the target being built. */
+		targetArg?: tg.Target.Arg;
 	};
 }
-
-let isArgObject = (arg: unknown): arg is build.ArgObject => {
-	return (
-		typeof arg === "object" &&
-		!(tg.File.is(arg) || tg.Symlink.is(arg) || tg.Template.is(arg))
-	);
-};

--- a/packages/std/utils.tg.ts
+++ b/packages/std/utils.tg.ts
@@ -44,7 +44,6 @@ export let env = tg.target(async (arg?: Arg) => {
 		env: env_,
 		host,
 	});
-	console.log("bashArtifact", await bashArtifact.id());
 
 	let bashExecutable = tg.File.expect(await bashArtifact.get("bin/bash"));
 	let bashEnv = {


### PR DESCRIPTION
This PR corrects the arguments accepted by `std.build`, dropping obsolete fields, and adds a `checksum` argument to the following interfaces which passes through to the underlying builder:

- `std.autotools.build`
- `cmake.build`
- `go.build`
- `node.build`
- `rust.build`

This closes #58.

Additionally, this PR includes fixes to `ncurses` and `readline`, finally allowing downstream packages to properly build against these dependencies using their `pkg-config` files. Closes #31.

Also includes new package definitions for `lz4` and `hyperfine`.