### PR TITLE
feat(std/wrap): add inPlace option

### DIFF
--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -168,6 +168,7 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 	if (utils) {
 		let hostUtils = await std.utils.env({
 			build: host,
+			debug: toolchain_ === "llvm",
 			host,
 			env: envs,
 			sdk: false,

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -168,7 +168,6 @@ export async function sdk(...args: tg.Args<sdk.Arg>): Promise<std.env.Arg> {
 	if (utils) {
 		let hostUtils = await std.utils.env({
 			build: host,
-			debug: toolchain_ === "llvm",
 			host,
 			env: envs,
 			sdk: false,

--- a/packages/std/sdk/llvm.tg.ts
+++ b/packages/std/sdk/llvm.tg.ts
@@ -83,12 +83,14 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 			"-DLLVM_ENABLE_EH=ON",
 			"-DLLVM_ENABLE_LIBXML2=OFF",
 			"-DLLVM_ENABLE_PIC=ON",
+			//"-DLLVM_ENABLE_PROJECTS='clang;lld'",
 			"-DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;lld;lldb'",
 			"-DLLVM_ENABLE_RTTI=ON",
 			"-DLLVM_ENABLE_RUNTIMES='compiler-rt;libcxx;libcxxabi;libunwind'",
 			"-DLLVM_INSTALL_BINUTILS_SYMLINKS=ON",
 			"-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON",
 			"-DLLVM_PARALLEL_LINK_JOBS=1",
+			//"-DLLVM_TARGETS_TO_BUILD=X86",
 		],
 	};
 
@@ -174,7 +176,7 @@ export let test = async () => {
 		}
 	`);
 	let cScript = tg`
-		set -x && clang -xc ${testCSource} -fuse-ld=lld -o $OUTPUT
+		set -x && clang -v -xc ${testCSource} -fuse-ld=lld -o $OUTPUT
 	`;
 	let cOut = tg.File.expect(
 		await std.build(cScript, {
@@ -200,7 +202,7 @@ export let test = async () => {
 		}
 	`);
 	let cxxScript = tg`
-		set -x && clang++ -xc++ ${testCXXSource} -fuse-ld=lld -unwindlib=libunwind -o $OUTPUT
+		set -x && clang++ -v -xc++ ${testCXXSource} -fuse-ld=lld -unwindlib=libunwind -o $OUTPUT
 	`;
 	let cxxOut = tg.File.expect(
 		await std.build(cxxScript, {

--- a/packages/std/sdk/llvm.tg.ts
+++ b/packages/std/sdk/llvm.tg.ts
@@ -83,14 +83,12 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 			"-DLLVM_ENABLE_EH=ON",
 			"-DLLVM_ENABLE_LIBXML2=OFF",
 			"-DLLVM_ENABLE_PIC=ON",
-			//"-DLLVM_ENABLE_PROJECTS='clang;lld'",
 			"-DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;lld;lldb'",
 			"-DLLVM_ENABLE_RTTI=ON",
 			"-DLLVM_ENABLE_RUNTIMES='compiler-rt;libcxx;libcxxabi;libunwind'",
 			"-DLLVM_INSTALL_BINUTILS_SYMLINKS=ON",
 			"-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON",
 			"-DLLVM_PARALLEL_LINK_JOBS=1",
-			//"-DLLVM_TARGETS_TO_BUILD=X86",
 		],
 	};
 

--- a/packages/std/sdk/proxy.tg.ts
+++ b/packages/std/sdk/proxy.tg.ts
@@ -208,10 +208,6 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 		);
 	}
 
-	console.log(
-		"proxy env dirs",
-		await Promise.all(dirs.map(async (d) => await (await d).id())),
-	);
 	return std.env.object(...dirs);
 });
 

--- a/packages/std/sdk/proxy.tg.ts
+++ b/packages/std/sdk/proxy.tg.ts
@@ -86,7 +86,7 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 
 		if (isLlvm) {
 			cc = await tg.symlink(tg`${directory}/bin/clang`);
-			cxx = await tg.symlink(tg`${directory}/bin/clang++`);
+			cxx = cc;
 		}
 		let ldProxyDir = tg.directory({
 			ld: ldProxyArtifact,
@@ -164,6 +164,7 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 				break;
 			}
 			case "llvm": {
+				console.log("proxy dir", await directory.id());
 				let { clangArgs, clangxxArgs, env } = await llvmToolchain.wrapArgs({
 					host: build,
 					target: host,
@@ -204,6 +205,10 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 		);
 	}
 
+	console.log(
+		"proxy env dirs",
+		await Promise.all(dirs.map(async (d) => await (await d).id())),
+	);
 	return std.env.object(...dirs);
 });
 

--- a/packages/std/sdk/proxy.tg.ts
+++ b/packages/std/sdk/proxy.tg.ts
@@ -85,7 +85,7 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 		});
 
 		if (isLlvm) {
-			cc = await tg.symlink(tg`${directory}/bin/clang`);
+			cc = tg.File.expect(await directory.get(`bin/clang`));
 			cxx = cc;
 		}
 		let ldProxyDir = tg.directory({
@@ -164,23 +164,26 @@ export let env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 				break;
 			}
 			case "llvm": {
-				console.log("proxy dir", await directory.id());
 				let { clangArgs, clangxxArgs, env } = await llvmToolchain.wrapArgs({
 					host: build,
 					target: host,
 					toolchainDir: directory,
 				});
+				// On Linux, don't wrap in place.
+				let inPlace = os === "darwin";
 				wrappedCC = std.wrap({
 					args: [tg`-B${ldProxyDir}`, ...clangArgs],
 					buildToolchain,
 					env,
 					executable: cc,
+					inPlace,
 				});
 				wrappedCXX = std.wrap({
 					args: [tg`-B${ldProxyDir}`, ...clangxxArgs],
 					buildToolchain,
 					env,
 					executable: cxx,
+					inPlace,
 				});
 				binDir = tg.directory({
 					bin: {

--- a/packages/std/utils/bash.tg.ts
+++ b/packages/std/utils/bash.tg.ts
@@ -68,7 +68,10 @@ export let build = tg.target(async (arg?: Arg) => {
 	env.push(bootstrap.shell(host));
 	if (await std.env.tryWhich({ env: env_, name: "clang" })) {
 		env.push({
-			CC: "clang -Wno-implicit-function-declaration",
+			CFLAGS: tg.Mutation.templatePrepend(
+				"-v -Wno-implicit-function-declaration",
+				" ",
+			),
 		});
 	}
 

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -298,7 +298,7 @@ export namespace wrap {
 		/** The identity of the executable. The default is "executable". */
 		identity?: Identity;
 
-		/** If the executable being wrapped is already a Tangram wrapper, should we simply amend the existing wrapper in place, or create a new wrapper pointing to the existing one? Default: true. */
+		/** Specify how to handle executables that are already Tangram wrappers. When `inPlace` is true, retain the original executable in the resulting manifest. When `inPlace` is set to false, produce a manifest pointing to the original wrapper. Default: true. */
 		inPlace?: boolean;
 
 		/** The interpreter to run the executable with. If not provided, a default is detected. */


### PR DESCRIPTION
This PR implements the `inPlace` option on `std.wrap` to specify how to handle executables that are already Tangram wrappers.  The default behavior is `inPlace: true`, producing a manifest with the executable from the original wrapper. Specify `inPlace: false` to create a manifest pointing to the original wrapper as the executable.

This change unbreaks the LLVM proxy env on Linux.