### PR TITLE
fix(demo): working LLVM demo

### DIFF
--- a/packages/binutils/tangram.tg.ts
+++ b/packages/binutils/tangram.tg.ts
@@ -1,0 +1,150 @@
+import * as std from "tg:std" with { path: "../std" };
+import texinfo from "tg:texinfo" with { path: "../texinfo" };
+
+export let metadata = {
+	homepage: "https://www.gnu.org/software/binutils/",
+	license: "GPL-3.0-or-later",
+	name: "binutils",
+	repository: "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git",
+	version: "2.42",
+};
+
+export let source = tg.target(async () => {
+	let { name, version } = metadata;
+
+	let checksum =
+		"sha256:f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800";
+
+	let unpatchedSource = std.download.fromGnu({
+		name,
+		version,
+		compressionFormat: "xz",
+		checksum,
+	});
+
+	// Work around an issue regarding libtool and sysroots. See: https://www.linuxfromscratch.org/lfs/view/stable/chapter06/binutils-pass2.html
+	let script = tg`
+		mkdir -p $OUTPUT
+		cp -R ${unpatchedSource}/* $OUTPUT
+		chmod -R u+w $OUTPUT
+		cd $OUTPUT
+		sed '6009s/$add_dir//' -i ltmain.sh
+	`;
+	let result = tg.Directory.expect(await std.build(script));
+	return result;
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: string;
+	env?: std.env.Arg;
+	host?: string;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+	staticBuild?: boolean;
+	target?: string;
+};
+
+export let binutils = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build: build_,
+		env: env_,
+		host: host_,
+		sdk,
+		source: source_,
+		staticBuild,
+		target: target_,
+		...rest
+	} = arg ?? {};
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
+	let target = target_ ?? host;
+
+	let buildPhase = staticBuild
+		? `make configure-host && make LDFLAGS=-all-static`
+		: `make`;
+
+	let additionalEnv: std.env.Arg = {};
+	let additionalArgs: Array<string> = [];
+	if (staticBuild) {
+		additionalEnv = {
+			...additionalEnv,
+			CC: await tg`${target}-cc --static -fPIC`,
+			CXX: await tg`${target}-c++ -static-libstdc++ -fPIC`,
+		};
+		additionalArgs = [
+			"--enable-shared=no",
+			"--enable-static=yes",
+			"--enable-static-link",
+			"--disable-shared-plugins",
+			"--disable-dynamicplugin",
+		];
+		if (std.triple.environment(target) === "musl") {
+			/*
+				Support musl >= 1.2.4 pending an upstream fix to binutils.
+				https://musl.libc.org/releases.html
+				"On the API level, the legacy "LFS64" ("large file support") interfaces, which were provided by macros remapping them to their standard names (#define stat64 stat and similar) have been deprecated and are no longer provided under the _GNU_SOURCE feature profile, only under explicit _LARGEFILE64_SOURCE. The latter will also be removed in a future version. Builds broken by this change can be fixed short-term by adding -D_LARGEFILE64_SOURCE to CFLAGS, but should be fixed to use the standard interfaces."
+			*/
+			additionalEnv = {
+				...additionalEnv,
+				CFLAGS: await tg.Mutation.templatePrepend("-D_LARGEFILE64_SOURCE", " "),
+			};
+		}
+	}
+
+	let deps = [texinfo({ host: build })];
+	let env = [...deps, additionalEnv, env_];
+
+	// Collect configuration.
+	let configure = {
+		args: [
+			`--with-sysroot=$OUTPUT`,
+			"--disable-dependency-tracking",
+			"--disable-nls",
+			`--build=${build}`,
+			`--host=${host}`,
+			`--target=${target}`,
+			...additionalArgs,
+		],
+	};
+
+	let phases = {
+		configure,
+		build: buildPhase,
+	};
+
+	return std.autotools.build(
+		{
+			...rest,
+			...std.triple.rotate({ build, host }),
+			env,
+			phases,
+			sdk,
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+});
+
+export default binutils;
+
+export let test = tg.target(async () => {
+	let binaries = [
+		"ar",
+		"as",
+		"ld",
+		"nm",
+		"objcopy",
+		"objdump",
+		"ranlib",
+		"strip",
+	];
+
+	await std.assert.pkg({
+		buildFunction: binutils,
+		binaries,
+		metadata,
+	});
+	return true;
+});

--- a/packages/glibc/tangram.tg.ts
+++ b/packages/glibc/tangram.tg.ts
@@ -66,7 +66,7 @@ export let glibc = tg.target(async (arg: Arg) => {
 	};
 
 	let install = {
-		args: [`DESTDIR="$OUTPUT/${host}"`],
+		args: [`DESTDIR="$OUTPUT"`],
 	};
 
 	let phases = {
@@ -106,13 +106,13 @@ export let glibc = tg.target(async (arg: Arg) => {
 	// Fix libc.so.
 	result = await applySysrootFix({
 		directory: result,
-		filePath: `${host}/lib/libc.so`,
+		filePath: `lib/libc.so`,
 	});
 
 	// Fix libm.so.
 	result = await applySysrootFix({
 		directory: result,
-		filePath: `${host}/lib/libm.so`,
+		filePath: `lib/libm.so`,
 	});
 
 	return result;

--- a/packages/glibc/tangram.tg.ts
+++ b/packages/glibc/tangram.tg.ts
@@ -1,0 +1,159 @@
+import * as std from "tg:std" with { path: "../std" };
+import bison from "tg:bison" with { path: "../bison" };
+import * as linux from "tg:linux" with { path: "../linux" };
+import perl from "tg:perl" with { path: "../perl" };
+import python from "tg:python" with { path: "../python" };
+import texinfo from "tg:texinfo" with { path: "../texinfo" };
+
+export let metadata = {
+	homepage: "https://sourceware.org/glibc/",
+	license: "LGPL-2.1-or-later",
+	name: "glibc",
+	repository: "https://sourceware.org/git/?p=glibc.git",
+	version: "2.39",
+};
+
+export let source = tg.target(() => {
+	let { name, version } = metadata;
+	let checksum =
+		"sha256:f77bd47cf8170c57365ae7bf86696c118adb3b120d3259c64c502d3dc1e2d926";
+	return std.download.fromGnu({
+		name,
+		version,
+		compressionFormat: "xz",
+		checksum,
+	});
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: string;
+	env?: std.env.Arg;
+	host?: string;
+	linuxHeaders?: tg.Directory;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let glibc = tg.target(async (arg: Arg) => {
+	let {
+		autotools = [],
+		build: build_,
+		env: env_,
+		host: host_,
+		linuxHeaders: linuxHeaders_,
+		source: source_,
+		...rest
+	} = arg;
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
+	if (std.triple.os(host) !== "linux") {
+		throw new Error("glibc is only supported on Linux");
+	}
+	let linuxHeaders = linuxHeaders_ ?? (await linux.kernelHeaders({ host }));
+
+	let configure = {
+		args: [
+			"--disable-nls",
+			"--enable-fortify-source",
+			"--enable-kernel=4.14",
+			tg`--with-headers=${linuxHeaders}`,
+			`--build=${build}`,
+			`--host=${host}`,
+			"libc_cv_slibdir=/lib",
+			"libc_cv_forced_unwind=yes",
+		],
+	};
+
+	let install = {
+		args: [`DESTDIR="$OUTPUT/${host}"`],
+	};
+
+	let phases = {
+		configure,
+		install,
+	};
+
+	let deps = [
+		bison({ host: build }),
+		perl({ host: build }),
+		python({ host: build }),
+		texinfo({ host: build }),
+	];
+	let env = [
+		...deps,
+		{
+			CPATH: tg.Mutation.unset(),
+			LIBRARY_PATH: tg.Mutation.unset(),
+			TANGRAM_LINKER_PASSTHROUGH: "1",
+		},
+		env_,
+	];
+
+	let result = await std.autotools.build(
+		{
+			...rest,
+			...std.triple.rotate({ build, host }),
+			env,
+			opt: "2",
+			phases,
+			prefixPath: "/",
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+
+	// Fix libc.so.
+	result = await applySysrootFix({
+		directory: result,
+		filePath: `${host}/lib/libc.so`,
+	});
+
+	// Fix libm.so.
+	result = await applySysrootFix({
+		directory: result,
+		filePath: `${host}/lib/libm.so`,
+	});
+
+	return result;
+});
+
+export default glibc;
+
+type SysrootFixArg = {
+	directory: tg.Directory;
+	filePath: string;
+};
+
+/** Some linker scripts need a small patch to work properly with `ld`'s sysroot replacement, prepending a `=` character to paths that need to resolve relative to the sysroot rather than absolute. This target modifies the script with the given name in the given directory. */
+export let applySysrootFix = async (arg: SysrootFixArg) => {
+	let { directory, filePath } = arg;
+	let linkerScript = tg.File.expect(await arg.directory.get(arg.filePath));
+	let isElfObject =
+		std.file.detectExecutableKind(await linkerScript.bytes()) === "elf";
+	// If the given path points to an ELF object, don't do anything. Apply the fix if it's a text file.
+	if (!isElfObject) {
+		let scriptContents = await linkerScript.text();
+		let scriptContentsFixed = scriptContents
+			.split("\n")
+			.map((line) => {
+				if (line.startsWith("GROUP")) {
+					return line.replace(/(\/[^ ]+)/g, "=$1");
+				} else {
+					return line;
+				}
+			})
+			.join("\n");
+		directory = await tg.directory(directory, {
+			[filePath]: tg.file(scriptContentsFixed),
+		});
+	}
+	return directory;
+};
+
+export let interpreterName = (triple: string) => {
+	let arch = std.triple.arch(triple);
+	let soVersion = arch === "x86_64" ? "2" : "1";
+	let soArch = arch === "x86_64" ? "x86-64" : arch;
+	return `ld-linux-${soArch}.so.${soVersion}`;
+};

--- a/packages/libffi/tangram.tg.ts
+++ b/packages/libffi/tangram.tg.ts
@@ -1,7 +1,10 @@
 import * as std from "tg:std" with { path: "../std" };
 
 export let metadata = {
+	homepage: "https://sourceware.org/libffi/",
+	license: "https://github.com/libffi/libffi/blob/master/LICENSE",
 	name: "libffi",
+	repository: "https://github.com/libffi/libffi",
 	version: "3.4.6",
 };
 
@@ -9,7 +12,6 @@ export let source = tg.target(async (): Promise<tg.Directory> => {
 	let { name, version } = metadata;
 	let checksum =
 		"sha256:b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e";
-	let unpackFormat = ".tar.gz" as const;
 	let owner = name;
 	let repo = name;
 	let tag = `v${version}`;

--- a/packages/libxml2/tangram.tg.ts
+++ b/packages/libxml2/tangram.tg.ts
@@ -1,0 +1,97 @@
+import * as std from "tg:std" with { path: "../std" };
+import icu from "tg:icu" with { path: "../icu" };
+import ncurses from "tg:ncurses" with { path: "../ncurses" };
+import pkgconfig from "tg:pkgconfig" with { path: "../pkgconfig" };
+import perl from "tg:perl" with { path: "../perl" };
+import python from "tg:python" with { path: "../python" };
+import readline from "tg:readline" with { path: "../readline" };
+import xz from "tg:xz" with { path: "../xz" };
+import zlib from "tg:zlib" with { path: "../zlib" };
+
+export let metadata = {
+	homepage: "https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home",
+	license: "https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright",
+	name: "libxml2",
+	repository: "https://gitlab.gnome.org/GNOME/libxml2/-/tree/master",
+	version: "2.12.6",
+};
+
+export let source = tg.target(async (): Promise<tg.Directory> => {
+	let { name, version } = metadata;
+	let checksum =
+		"sha256:889c593a881a3db5fdd96cc9318c87df34eb648edfc458272ad46fd607353fbb";
+	let packageArchive = std.download.packageArchive({
+		name,
+		version,
+		extension: ".tar.xz",
+	});
+	let majorMinor = version.split(".").slice(0, 2).join(".");
+	let url = `https://download.gnome.org/sources/${name}/${majorMinor}/${packageArchive}`;
+	let outer = tg.Directory.expect(await std.download({ url, checksum }));
+	return std.directory.unwrap(outer);
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: string;
+	env?: std.env.Arg;
+	host?: string;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let libxml2 = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build,
+		env: env_,
+		host,
+		source: source_,
+		...rest
+	} = arg ?? {};
+
+	let prepare = "export LD_LIBRARY_PATH=$LIBRARY_PATH";
+	let configure = {
+		args: [
+			"--disable-dependency-tracking",
+			"--enable-static",
+			"--enable-shared",
+			"--with-history",
+			"--with-icu",
+		],
+	};
+
+	let deps = [
+		icu({ ...rest, build, env: env_, host }),
+		ncurses({ ...rest, build, env: env_, host }),
+		perl({ ...rest, build, env: env_, host }),
+		pkgconfig({ ...rest, build, env: env_, host }),
+		python({ ...rest, build, env: env_, host }),
+		readline({ ...rest, build, env: env_, host }),
+		xz({ ...rest, build, env: env_, host }),
+		zlib({ ...rest, build, env: env_, host }),
+	];
+	let env = [...deps, env_];
+
+	return std.autotools.build(
+		{
+			...rest,
+			...std.triple.rotate({ build, host }),
+			env,
+			phases: { prepare, configure },
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+});
+
+export default libxml2;
+
+export let test = tg.target(async () => {
+	await std.assert.pkg({
+		buildFunction: libxml2,
+		binaries: ["xml2-config", "xmlcatalog", "xmllint"],
+		libraries: ["xml2"],
+	});
+	return true;
+});

--- a/packages/linux/tangram.tg.ts
+++ b/packages/linux/tangram.tg.ts
@@ -1,0 +1,119 @@
+import * as std from "tg:std" with { path: "../std" };
+
+export let metadata = {
+	homepage: "https://www.kernel.org",
+	license: "GPLv2",
+	name: "linux",
+	repository: "https://git.kernel.org",
+	version: "6.8.8",
+};
+
+export let source = tg.target(async () => {
+	let { name, version } = metadata;
+	let checksum =
+		"sha256:1c4cdcb9d560fad1fb95db2cb8afbedc922f9ead848371fe40363b13f9f631ba";
+	let extension = ".tar.xz";
+	let packageArchive = std.download.packageArchive({
+		name,
+		version,
+		extension,
+	});
+	let url = `https://cdn.kernel.org/pub/linux/kernel/v6.x/${packageArchive}`;
+	let source = tg.Directory.expect(await std.download({ url, checksum }));
+	return std.directory.unwrap(source);
+});
+
+type Arg = std.sdk.BuildEnvArg & {
+	phases?: tg.MaybeNestedArray<std.phases.Arg>;
+	source?: tg.Directory;
+};
+
+export let kernelHeaders = tg.target(async (arg?: Arg) => {
+	let {
+		build: build_,
+		env: env_,
+		host: host_,
+		phases: phasesArg = [],
+		sdk: sdk_,
+		source: source_,
+	} = arg ?? {};
+	let host = host_ ?? (await std.triple.host());
+	let buildTriple = build_ ?? host;
+
+	let system = std.triple.archAndOs(buildTriple);
+
+	let sdk =
+		typeof sdk_ === "boolean"
+			? await std.sdk({ host: buildTriple, target: host })
+			: std.sdk(sdk_);
+
+	let sourceDir = source_ ?? source();
+
+	tg.assert(
+		std.triple.os(system) === "linux",
+		"The Linux kernel headers can only be built on Linux.",
+	);
+
+	// NOTE - the kernel build wants the string x86_64 on x86_64 but arm64 on aarch64.
+	let tripleArch = std.triple.arch(host);
+	let karch = tripleArch;
+	if (karch === "aarch64") {
+		karch = "arm64";
+	} else if (karch.includes("arm")) {
+		karch = "arm";
+	}
+
+	let env = [sdk, env_];
+
+	let prepare = tg`cp -r ${sourceDir}/* . && chmod -R +w . && make mrproper`;
+	let build = {
+		body: `make -j"\$(nproc)" ARCH=${karch} headers`,
+		post: "find usr/include -type f ! -name '*.h' -delete",
+	};
+	let install = {
+		pre: "mkdir -p $OUTPUT",
+		body: `cp -r usr/include/. $OUTPUT && mkdir -p $OUTPUT/config && echo ${metadata.version}-default > $OUTPUT/config/kernel.release`,
+	};
+	let order = ["prepare", "build", "install"];
+
+	let result = tg.Directory.expect(
+		await std.phases.build(
+			{
+				env,
+				phases: { prepare, build, install },
+				order,
+				target: { host: system },
+			},
+			phasesArg,
+		),
+	);
+
+	return result;
+});
+
+export default kernelHeaders;
+
+export let test = tg.target(async () => {
+	let host = await std.triple.host();
+	if (std.triple.os(host) !== "linux") {
+		return;
+	}
+
+	// test host
+	return await testKernelHeaders(host);
+});
+
+export let testKernelHeaders = async (host: string, target?: string) => {
+	let target_ = target ?? host;
+	let headers = await kernelHeaders({
+		build: host,
+		host: target_,
+	});
+	let configFile = tg.File.expect(await headers.get("config/kernel.release"));
+	let configFileContents = (await configFile.text()).trim();
+	tg.assert(configFileContents === `${metadata.version}-default`);
+	let kernelH = tg.File.expect(await headers.get("linux/kernel.h"));
+	let kernelHContents = await kernelH.text();
+	tg.assert(kernelHContents.includes("#ifndef _LINUX_KERNEL_H"));
+	return headers;
+};

--- a/packages/linux/tangram.tg.ts
+++ b/packages/linux/tangram.tg.ts
@@ -23,8 +23,13 @@ export let source = tg.target(async () => {
 	return std.directory.unwrap(source);
 });
 
-type Arg = std.sdk.BuildEnvArg & {
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: string;
+	env?: std.env.Arg;
+	host?: string;
 	phases?: tg.MaybeNestedArray<std.phases.Arg>;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
 

--- a/packages/musl/musl_permission.patch
+++ b/packages/musl/musl_permission.patch
@@ -1,0 +1,11 @@
+diff -Naur musl-1.2.4/Makefile musl-1.2.4_patched/Makefile
+--- musl-1.2.4/Makefile	2023-05-01 23:39:41.000000000 -0400
++++ musl-1.2.4_patched/Makefile	2024-01-18 10:51:49.053309022 -0500
+@@ -100,6 +100,7 @@
+ 
+ obj/include/bits/syscall.h: $(srcdir)/arch/$(ARCH)/bits/syscall.h.in
+ 	cp $< $@
++	chmod +w $@
+ 	sed -n -e s/__NR_/SYS_/p < $< >> $@
+ 
+ obj/src/internal/version.h: $(wildcard $(srcdir)/VERSION $(srcdir)/.git)

--- a/packages/musl/tangram.tg.ts
+++ b/packages/musl/tangram.tg.ts
@@ -77,7 +77,7 @@ export let musl = tg.target(async (arg?: Arg) => {
 	};
 
 	let install = {
-		args: [`DESTDIR="$OUTPUT/${host}"`],
+		args: [`DESTDIR="$OUTPUT"`],
 	};
 
 	let phases = {

--- a/packages/musl/tangram.tg.ts
+++ b/packages/musl/tangram.tg.ts
@@ -1,0 +1,115 @@
+import * as std from "tg:std" with { path: "../std" };
+
+export let metadata = {
+	homepage: "https://musl.libc.org/",
+	license: "MIT",
+	name: "musl",
+	repository: "https://git.musl-libc.org/cgit/musl",
+	version: "1.2.5",
+};
+
+export let source = tg.target(async () => {
+	let { name, version } = metadata;
+	let extension = ".tar.gz";
+	let packageArchive = std.download.packageArchive({
+		extension,
+		name,
+		version,
+	});
+	let checksum =
+		"sha256:a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4";
+	let url = `https://musl.libc.org/releases/${packageArchive}`;
+	let source = tg.Directory.expect(await std.download({ url, checksum }));
+	source = await std.directory.unwrap(source);
+
+	let patch = tg.File.expect(await tg.include("musl_permission.patch"));
+	source = await std.patch(source, patch);
+
+	return source;
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: string;
+	env?: std.env.Arg;
+	host?: string;
+	/* Optionally point to a specific implementation of libcc. */
+	libcc?: tg.File;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let musl = tg.target(async (arg?: Arg) => {
+	let {
+		autotools = [],
+		build: build_,
+		env: env_,
+		host: host_,
+		libcc = false,
+		source: source_,
+		...rest
+	} = arg ?? {};
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
+	if (std.triple.os(host) !== "linux") {
+		throw new Error("musl is only supported on Linux");
+	}
+
+	let isCrossCompiling = build !== host;
+
+	let commonFlags = [
+		`--enable-debug`,
+		`--enable-optimize=*`,
+		`--build=${build}`,
+		`--host=${host}`,
+	];
+
+	let additionalFlags: Array<string | tg.Template> = isCrossCompiling
+		? [`CROSS_COMPILE="${host}-"`, `CC="${host}-gcc"`, "--disable-gcc-wrapper"]
+		: [];
+
+	if (libcc) {
+		additionalFlags.push(await tg`LIBCC="${arg?.libcc}"`);
+	}
+
+	let configure = {
+		args: [...commonFlags, ...additionalFlags],
+	};
+
+	let install = {
+		args: [`DESTDIR="$OUTPUT/${host}"`],
+	};
+
+	let phases = {
+		configure,
+		install,
+	};
+
+	let env = [{ CPATH: tg.Mutation.unset() }, env_];
+
+	let result = await std.autotools.build(
+		{
+			...rest,
+			...std.triple.rotate({ build, host }),
+			env,
+			phases,
+			prefixPath: "/",
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+
+	// Add an ld.so file, which in musl is just a symlink to libc.so.
+	result = await tg.directory(result, {
+		[`lib/${interpreterName(host)}`]: tg.symlink("libc.so"),
+	});
+
+	return result;
+});
+
+export default musl;
+
+export let interpreterName = (triple: string) => {
+	let arch = std.triple.arch(triple);
+	return `ld-musl-${arch}.so.1`;
+};

--- a/packages/pkgconfig/tangram.tg.ts
+++ b/packages/pkgconfig/tangram.tg.ts
@@ -86,7 +86,7 @@ export let pkgconfig = tg.target(async (arg?: Arg) => {
 		std.flatten(rest.sdk ?? []).some((sdk) => sdk?.toolchain === "llvm")
 	) {
 		env.push({
-			CC: "clang -Wno-int-conversion",
+			CFLAGS: tg.Mutation.templatePrepend("-Wno-int-conversion", " "),
 		});
 	}
 
@@ -125,7 +125,6 @@ export let pkgconfig = tg.target(async (arg?: Arg) => {
 				fi
 			done
 
-			# Remove leading colon if it exists
 			PKG_CONFIG_PATH=$(echo "$PKG_CONFIG_PATH" | sed 's/^://')
 
 			export PKG_CONFIG_PATH

--- a/packages/python/tangram.tg.ts
+++ b/packages/python/tangram.tg.ts
@@ -119,11 +119,20 @@ export let python = tg.target(async (arg?: ToolchainArg) => {
 	let configure = {
 		args: [
 			"--disable-test-modules",
-			"--enable-optimizations",
 			"--with-pkg-config=yes",
 			"--without-c-locale-coercion",
 		],
 	};
+
+	// Enable PGO on macOS and Linux only if the LLVm toolchain is not used.
+	if (
+		std.triple.os(build) === "darwin" ||
+		((await std.env.tryWhich({ env: env_, name: "clang" })) === undefined &&
+			std.flatten(rest.sdk ?? []).filter((sdk) => sdk?.toolchain === "llvm")
+				.length === 0)
+	) {
+		configure.args.push("--enable-optimizations");
+	}
 
 	let phases = { configure };
 

--- a/packages/ripgrep/tangram.tg.ts
+++ b/packages/ripgrep/tangram.tg.ts
@@ -65,10 +65,6 @@ export let ripgrep = tg.target(async (arg?: Arg) => {
 
 export default ripgrep;
 
-export let ripgrepLlvm = tg.target(() =>
-	ripgrep({ sdk: { toolchain: "llvm" } }),
-);
-
 export let test = tg.target(async () => {
 	await std.assert.pkg({
 		buildFunction: ripgrep,

--- a/packages/ripgrep/tangram.tg.ts
+++ b/packages/ripgrep/tangram.tg.ts
@@ -65,6 +65,10 @@ export let ripgrep = tg.target(async (arg?: Arg) => {
 
 export default ripgrep;
 
+export let ripgrepLlvm = tg.target(() =>
+	ripgrep({ sdk: { toolchain: "llvm" } }),
+);
+
 export let test = tg.target(async () => {
 	await std.assert.pkg({
 		buildFunction: ripgrep,

--- a/packages/std/sdk/gcc/toolchain.tg.ts
+++ b/packages/std/sdk/gcc/toolchain.tg.ts
@@ -1,7 +1,6 @@
 /** This package takes a bootstrap C/C++ compiler and some utilities and canadian-crosses up a sizzling plate of farm-fresh GCC. The output of this package can then be used to build other compilers like LLVM. */
 
 import * as bootstrap from "../../bootstrap.tg.ts";
-import { canonicalTriple } from "../../sdk.tg.ts";
 import * as std from "../../tangram.tg.ts";
 import binutils from "../binutils.tg.ts";
 import * as gcc from "../gcc.tg.ts";
@@ -16,8 +15,8 @@ export type ToolchainArg = std.sdk.BuildEnvArg & {
 /** Construct a complete binutils + libc + gcc toolchain. */
 export let toolchain = tg.target(async (arg: ToolchainArg) => {
 	let { host: host_, target: target_, ...rest } = arg;
-	let host = await canonicalTriple(host_ ?? (await std.triple.host()));
-	let target = await canonicalTriple(target_ ?? host);
+	let host = std.sdk.canonicalTriple(host_ ?? (await std.triple.host()));
+	let target = std.sdk.canonicalTriple(target_ ?? host);
 
 	// Always build a native toolchain.
 	let nativeToolchain = await canadianCross(host);
@@ -162,7 +161,7 @@ export let buildSysroot = tg.target(async (arg: std.sdk.BuildEnvArg) => {
 });
 
 export let canadianCross = tg.target(async (hostArg?: string) => {
-	let host = await canonicalTriple(hostArg ?? (await std.triple.host()));
+	let host = std.sdk.canonicalTriple(hostArg ?? (await std.triple.host()));
 
 	let target = host;
 	let build = bootstrap.toolchainTriple(host);
@@ -203,7 +202,7 @@ export let canadianCross = tg.target(async (hostArg?: string) => {
 });
 
 export let buildToHostCrossToolchain = async (hostArg?: string) => {
-	let host = await canonicalTriple(hostArg ?? (await std.triple.host()));
+	let host = std.sdk.canonicalTriple(hostArg ?? (await std.triple.host()));
 	let build = bootstrap.toolchainTriple(host);
 
 	let sdkArg = bootstrap.sdk.arg(host);

--- a/packages/std/sdk/kernel_headers.tg.ts
+++ b/packages/std/sdk/kernel_headers.tg.ts
@@ -6,13 +6,13 @@ export let metadata = {
 	license: "GPLv2",
 	name: "linux",
 	repository: "https://git.kernel.org",
-	version: "6.8.7",
+	version: "6.8.8",
 };
 
 export let source = tg.target(async () => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:291d1a1faf4e87b3b0ea9729080db887aafd1ff2fac1430ceca921e46bc22fae";
+		"sha256:1c4cdcb9d560fad1fb95db2cb8afbedc922f9ead848371fe40363b13f9f631ba";
 	let extension = ".tar.xz";
 	let packageArchive = std.download.packageArchive({
 		name,

--- a/packages/std/sdk/llvm.tg.ts
+++ b/packages/std/sdk/llvm.tg.ts
@@ -55,7 +55,6 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 	sysroot = tg.Directory.expect(await sysroot.get(host));
 	console.log("llvm sysroot", await sysroot.id());
 
-	let zlibArtifact = await dependencies.zlib.build({ host: build });
 	let deps: tg.Unresolved<std.env.Arg> = [
 		std.utils.env({ host: build }),
 		git({ host: build }),
@@ -63,7 +62,6 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 			host: build,
 			sdk: bootstrap.sdk.arg(build),
 		}),
-		zlibArtifact,
 	];
 
 	let env = [...deps, env_];
@@ -91,7 +89,6 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 			"-DLLVM_INSTALL_BINUTILS_SYMLINKS=ON",
 			"-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON",
 			"-DLLVM_PARALLEL_LINK_JOBS=1",
-			tg`-DZLIB_ROOT=${zlibArtifact}`,
 		],
 	};
 

--- a/packages/std/sdk/llvm.tg.ts
+++ b/packages/std/sdk/llvm.tg.ts
@@ -1,5 +1,4 @@
 import * as bootstrap from "../bootstrap.tg.ts";
-import { canonicalTriple } from "../sdk.tg.ts";
 import * as std from "../tangram.tg.ts";
 import * as cmake from "./cmake.tg.ts";
 import * as dependencies from "./dependencies.tg.ts";
@@ -39,7 +38,7 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 		source: source_,
 		...rest
 	} = arg ?? {};
-	let host = await canonicalTriple(host_ ?? (await std.triple.host()));
+	let host = std.sdk.canonicalTriple(host_ ?? (await std.triple.host()));
 	let build = build_ ?? host;
 
 	if (std.triple.os(host) === "darwin") {
@@ -156,7 +155,7 @@ export let wrapArgs = async (arg: WrapArgsArg) => {
 
 export let test = async () => {
 	// Build a triple for the detected host.
-	let host = await canonicalTriple(await std.triple.host());
+	let host = std.sdk.canonicalTriple(await std.triple.host());
 	let hostArch = std.triple.arch(host);
 	let os = std.triple.os(std.triple.archAndOs(host));
 

--- a/packages/std/sdk/llvm.tg.ts
+++ b/packages/std/sdk/llvm.tg.ts
@@ -55,6 +55,7 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 	sysroot = tg.Directory.expect(await sysroot.get(host));
 	console.log("llvm sysroot", await sysroot.id());
 
+	let zlibArtifact = await dependencies.zlib.build({ host: build });
 	let deps: tg.Unresolved<std.env.Arg> = [
 		std.utils.env({ host: build }),
 		git({ host: build }),
@@ -62,6 +63,7 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 			host: build,
 			sdk: bootstrap.sdk.arg(build),
 		}),
+		zlibArtifact,
 	];
 
 	let env = [...deps, env_];
@@ -89,6 +91,7 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 			"-DLLVM_INSTALL_BINUTILS_SYMLINKS=ON",
 			"-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON",
 			"-DLLVM_PARALLEL_LINK_JOBS=1",
+			tg`-DZLIB_ROOT=${zlibArtifact}`,
 		],
 	};
 

--- a/packages/xz/tangram.tg.ts
+++ b/packages/xz/tangram.tg.ts
@@ -77,9 +77,8 @@ export let xz = tg.target(async (arg?: Arg) => {
 export default xz;
 
 export let test = tg.target(async () => {
-	let xzArtifact = xz();
 	await std.assert.pkg({
-		directory: xzArtifact,
+		buildFunction: xz,
 		binaries: [
 			"lzmadec",
 			"lzmainfo",
@@ -93,5 +92,5 @@ export let test = tg.target(async () => {
 		libraries: ["lzma"],
 		metadata,
 	});
-	return xzArtifact;
+	return true;
 });

--- a/packages/zlib/tangram.tg.ts
+++ b/packages/zlib/tangram.tg.ts
@@ -74,8 +74,6 @@ export let zlib = tg.target(async (arg?: Arg) => {
 
 export default zlib;
 
-export let zlibLlvm = tg.target(() => zlib({ sdk: { toolchain: "llvm" } }));
-
 export let test = tg.target(async () => {
 	await std.assert.pkg({
 		buildFunction: zlib,


### PR DESCRIPTION
This PR rolls up changes to support building the `testLlvm` target in the `demo` package on Linux, which builds all packages and transitive dependencies with `clang`/`lld`/`libc++`.

- Correct `gettext` wrapping
- Ensure `rust.build` can use `-lgcc`
- Add `std.sdk.canonicalTriple`
- Re-enable asserting multiple SDKs at once
- Disable PGO on Python when using LLVM on Linux until our build of compiler-rt supports this
- Prevent dropping `libm.so.1` from the library paths in `icu`
- Allow `zlib` to build shared libraries with clang/lld

Additionally, this change includes new package definitions for `binutils`, `musl`, `glibc`, `libxml2`, and `linux`.