### PR TITLE
refactor(std/sdk/llvm): 2-stage LLVM build with LTO

### DIFF
--- a/packages/git/tangram.tg.ts
+++ b/packages/git/tangram.tg.ts
@@ -7,7 +7,7 @@ export let metadata = {
 	license: "GPL-2.0-only",
 	name: "git",
 	repository: "https://github.com/git/git",
-	version: "2.44.0",
+	version: "2.45.0",
 };
 
 export let source = tg.target(async () => {
@@ -20,7 +20,7 @@ export let source = tg.target(async () => {
 	});
 	let url = `https://mirrors.edge.kernel.org/pub/software/scm/git/${packageArchive}`;
 	let checksum =
-		"sha256:e358738dcb5b5ea340ce900a0015c03ae86e804e7ff64e47aa4631ddee681de3";
+		"sha256:0aac200bd06476e7df1ff026eb123c6827bc10fe69d2823b4bf2ebebe5953429";
 	let outer = tg.Directory.expect(await std.download({ url, checksum }));
 	return std.directory.unwrap(outer);
 });
@@ -76,7 +76,7 @@ export default git;
 
 export let test = tg.target(async () => {
 	await std.assert.pkg({
-		directory: await git(),
+		buildFunction: git,
 		binaries: ["git"],
 		metadata,
 	});

--- a/packages/linux/tangram.tg.ts
+++ b/packages/linux/tangram.tg.ts
@@ -5,13 +5,13 @@ export let metadata = {
 	license: "GPLv2",
 	name: "linux",
 	repository: "https://git.kernel.org",
-	version: "6.8.8",
+	version: "6.8.9",
 };
 
 export let source = tg.target(async () => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:1c4cdcb9d560fad1fb95db2cb8afbedc922f9ead848371fe40363b13f9f631ba";
+		"sha256:f905f1238ea7a8e85314bacf283302e8097006010d25fcea726d0de0ea5bc9b6";
 	let extension = ".tar.xz";
 	let packageArchive = std.download.packageArchive({
 		name,

--- a/packages/rust/tangram.tg.ts
+++ b/packages/rust/tangram.tg.ts
@@ -12,7 +12,7 @@ export let metadata = {
 	version: "0.0.0",
 };
 
-let VERSION = "1.77.2" as const;
+let VERSION = "1.78.0" as const;
 let PROFILE = "minimal" as const;
 
 type ToolchainArg = {

--- a/packages/std/packages/ld_proxy/src/main.rs
+++ b/packages/std/packages/ld_proxy/src/main.rs
@@ -517,7 +517,7 @@ async fn create_manifest<H: BuildHasher>(
 struct AnalyzeOutputFileOutput {
 	/// Is the output file executable?
 	is_executable: bool,
-	/// Does the output file need an interpreter? On macOS, This should always get `Some(None)`. On Linux, None indicates a statically-linked executable, `Some(None)` indicates a dynamically-linked executable with a default ldso path, and `Some(Some(symlink))` indicates the PT_INTERP field has been explicitly set to point at a non-standard path we need to retain.
+	/// Does the output file need an interpreter? On macOS, This should always get `Some(None)`. On Linux, None indicates a statically-linked executable, `Some(None)` indicates a dynamically-linked executable with a default ldso path, and `Some(Some(symlink))` indicates the `PT_INTERP` field has been explicitly set to point at a non-standard path we need to retain.
 	interpreter: InterpreterRequirement,
 	/// Does the output file specify libraries required at runtime?
 	needed_libraries: Vec<String>,

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -262,10 +262,9 @@ export namespace sdk {
 				targetPrefix = `${target}-`;
 			}
 		}
-		let llvmPrefix = llvm && os !== "darwin" ? "llvm-" : "";
 		await std.env.assertProvides({
 			env,
-			names: requiredUtils.map((name) => `${targetPrefix}${llvmPrefix}${name}`),
+			names: requiredUtils.map((name) => `${targetPrefix}${name}`),
 		});
 		let compilerComponents = requiredCompilerComponents(
 			os,

--- a/packages/std/sdk/binutils.tg.ts
+++ b/packages/std/sdk/binutils.tg.ts
@@ -121,6 +121,7 @@ export let build = tg.target(async (arg?: Arg) => {
 			...rest,
 			...std.triple.rotate({ build, host }),
 			env,
+			opt: "3",
 			phases,
 			sdk,
 			source: source_ ?? source(build),

--- a/packages/std/sdk/gcc.tg.ts
+++ b/packages/std/sdk/gcc.tg.ts
@@ -171,7 +171,7 @@ export let build = tg.target(async (arg: Arg) => {
 			debug,
 			env,
 			phases,
-			opt: "2",
+			opt: "3",
 			source: source_ ?? source(),
 		},
 		autotools,

--- a/packages/std/sdk/git.tg.ts
+++ b/packages/std/sdk/git.tg.ts
@@ -3,7 +3,7 @@ import zlib from "./dependencies/zlib.tg.ts";
 
 let metadata = {
 	name: "git",
-	version: "2.44.0",
+	version: "2.45.0",
 };
 
 export let source = tg.target(async () => {
@@ -16,7 +16,7 @@ export let source = tg.target(async () => {
 	});
 	let url = `https://mirrors.edge.kernel.org/pub/software/scm/git/${packageArchive}`;
 	let checksum =
-		"sha256:e358738dcb5b5ea340ce900a0015c03ae86e804e7ff64e47aa4631ddee681de3";
+		"sha256:0aac200bd06476e7df1ff026eb123c6827bc10fe69d2823b4bf2ebebe5953429";
 	let outer = tg.Directory.expect(await std.download({ url, checksum }));
 	return await std.directory.unwrap(outer);
 });

--- a/packages/std/sdk/kernel_headers.tg.ts
+++ b/packages/std/sdk/kernel_headers.tg.ts
@@ -6,13 +6,13 @@ export let metadata = {
 	license: "GPLv2",
 	name: "linux",
 	repository: "https://git.kernel.org",
-	version: "6.8.8",
+	version: "6.8.9",
 };
 
 export let source = tg.target(async () => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:1c4cdcb9d560fad1fb95db2cb8afbedc922f9ead848371fe40363b13f9f631ba";
+		"sha256:f905f1238ea7a8e85314bacf283302e8097006010d25fcea726d0de0ea5bc9b6";
 	let extension = ".tar.xz";
 	let packageArchive = std.download.packageArchive({
 		name,

--- a/packages/std/sdk/libc/glibc.tg.ts
+++ b/packages/std/sdk/libc/glibc.tg.ts
@@ -107,7 +107,7 @@ export default tg.target(async (arg: Arg) => {
 			...rest,
 			...std.triple.rotate({ build, host }),
 			env,
-			opt: "2",
+			opt: "3",
 			phases,
 			prefixPath: "/",
 			source: source_ ?? source(version),

--- a/packages/std/sdk/llvm.tg.ts
+++ b/packages/std/sdk/llvm.tg.ts
@@ -75,8 +75,6 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 	// https://github.com/llvm/llvm-project/blob/main/clang/cmake/caches/DistributionExample.cmake
 	/*
  for bootstrap cmake args.
-				-DLLVM_TOOLCHAIN_TOOLS='dsymutil;llvm-cov;llvm-darfdump;llvm-profdata;llvm-objdump;llvm-nm;llvm-size';\
-				-DLLVM_DISTRIBUTION_COMPONENTS='clang;LTO;clang-format;clang-resource-headers;builtins;runtimes;dsymutil;llvm-cov;llvm-darfdump;llvm-profdata;llvm-objdump;llvm-nm;llvm-size'"`,
 */
 
 	let configure = {
@@ -96,12 +94,15 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 				-DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;lld';\
 				-DLLVM_ENABLE_RUNTIMES='compiler-rt;libcxx;libcxxabi;libunwind';\
 				-DLLVM_TARGETS_TO_BUILD='X86;ARM;AARCH64';\
-				-DCMAKE_BUILD_TYPE=Release;\
-				-DCMAKE_C_FLAGS_RELEASE='-O3 -gline-tables-only -DNDEBUG';\
-				-DCMAKE_CXX_FLAGS_RELEASE='-O3 -gline-tables-only -DNDEBUG';\
-				-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON;"`,
+				-DCMAKE_BUILD_TYPE=RelWithDebInfo;\
+				-DCMAKE_C_FLAGS_RELWITHDEBINFO='-O3 -gline-tables-only -DNDEBUG';\
+				-DCMAKE_CXX_FLAGS_RELWITHDEBINFO='-O3 -gline-tables-only -DNDEBUG';\
+				-DCOMPILER_RT_BUILD_PROFILE=ON;\
+				-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON;\
+				-DLLVM_TOOLCHAIN_TOOLS='dsymutil;llvm-cov;llvm-darfdump;llvm-profdata;llvm-objdump;llvm-nm;llvm-size';\
+				-DLLVM_DISTRIBUTION_COMPONENTS='clang;LTO;clang-format;clang-resource-headers;builtins;runtimes;dsymutil;llvm-cov;llvm-darfdump;llvm-profdata;llvm-objdump;llvm-nm;llvm-size'"`,
 			`-DCLANG_BOOTSTRAP_PASSTHROUGH="DEFAULT_SYSROOT;LLVM_PARALLEL_LINK_JOBS"`,
-			`-DCLANG_BOOTSTRAP_TARGET='check-all;check-llvm;check-clang;llvm-config;test-suite;test-depends;llvm-test-depends;clang-test-depends;distribution;install-distribution;clang'`,
+			`-DCLANG_BOOTSTRAP_TARGETS='check-all;check-llvm;check-clang;llvm-config;test-suite;test-depends;llvm-test-depends;clang-test-depends;distribution;install-distribution;clang'`,
 			"-DCLANG_DEFAULT_CXX_STDLIB=libc++",
 			"-DCLANG_DEFAULT_RTLIB=compiler-rt",
 			"-DCLANG_ENABLE_BOOTSTRAP=ON",
@@ -131,10 +132,10 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 		],
 	};
 
-	// let buildPhase = tg.Mutation.set("ninja stage2-distribution");
-	// let install = tg.Mutation.set("ninja stage2-install-distribution");
-	let buildPhase = tg.Mutation.set("ninja stage2");
-	let install = tg.Mutation.set("ninja stage2-install");
+	let buildPhase = tg.Mutation.set("ninja stage2-distribution");
+	let install = tg.Mutation.set("ninja stage2-install-distribution");
+	// let buildPhase = tg.Mutation.set("ninja stage2");
+	// let install = tg.Mutation.set("ninja stage2-install");
 	let phases = { configure, build: buildPhase, install };
 
 	let llvmArtifact = await cmake.build(

--- a/packages/std/sdk/llvm.tg.ts
+++ b/packages/std/sdk/llvm.tg.ts
@@ -54,6 +54,7 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 	sysroot = tg.Directory.expect(await sysroot.get(host));
 	console.log("llvm sysroot", await sysroot.id());
 
+	//let zlibArtifact = await dependencies.zlib.build({ host: build });
 	let deps: tg.Unresolved<std.env.Arg> = [
 		std.utils.env({ host: build }),
 		git({ host: build }),
@@ -61,18 +62,52 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 			host: build,
 			sdk: bootstrap.sdk.arg(build),
 		}),
+		//{ TANGRAM_LINKER_PASSTHROUGH: "1" },
+		//zlibArtifact,
 	];
 
 	let env = [...deps, env_];
 
-	let configureLlvm = {
+	let ldsoName = libc.interpreterName(host);
+	let stage2Ldflags = tg`-Wl,-rpath=${sysroot}/lib:/home/tangram/work/lib:/home/tangram/work/lib/${host} -Wl,-dynamic-linker=${sysroot}/lib/${ldsoName} -unwindlib=libunwind`;
+
+	// TODO - use cmake cache files.
+	// https://github.com/llvm/llvm-project/blob/main/clang/cmake/caches/DistributionExample.cmake
+	/*
+ for bootstrap cmake args.
+				-DLLVM_TOOLCHAIN_TOOLS='dsymutil;llvm-cov;llvm-darfdump;llvm-profdata;llvm-objdump;llvm-nm;llvm-size';\
+				-DLLVM_DISTRIBUTION_COMPONENTS='clang;LTO;clang-format;clang-resource-headers;builtins;runtimes;dsymutil;llvm-cov;llvm-darfdump;llvm-profdata;llvm-objdump;llvm-nm;llvm-size'"`,
+*/
+
+	let configure = {
 		args: [
+			tg`-DBOOTSTRAP_CMAKE_EXE_LINKER_FLAGS='${stage2Ldflags}'`,
+			`-DBOOTSTRAP_CMAKE_SHARED_LINKER_FLAGS='-unwindlib=libunwind'`,
+			"-DBOOTSTRAP_CMAKE_BUILD_TYPE=Release",
+			"-DBOOTSTRAP_CLANG_DEFAULT_CXX_STDLIB=libc++",
+			"-DBOOTSTRAP_CLANG_DEFAULT_RTLIB=compiler-rt",
+			"-DBOOTSTRAP_LIBCXX_USE_COMPILER_RT=YES",
+			"-DBOOTSTRAP_LIBCXXABI_USE_COMPILER_RT=YES",
+			"-DBOOTSTRAP_LIBCXXABI_USE_LLVM_UNWINDER=YES",
+			"-DBOOTSTRAP_LIBUNWIND_USE_COMPILER_RT=Yes",
+			"-DBOOTSTRAP_LLVM_ENABLE_LTO=ON",
+			"-DBOOTSTRAP_LLVM_USE_LINKER=lld",
+			`-DCLANG_BOOTSTRAP_CMAKE_ARGS="\
+				-DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;lld';\
+				-DLLVM_ENABLE_RUNTIMES='compiler-rt;libcxx;libcxxabi;libunwind';\
+				-DLLVM_TARGETS_TO_BUILD='X86;ARM;AARCH64';\
+				-DCMAKE_BUILD_TYPE=Release;\
+				-DCMAKE_C_FLAGS_RELEASE='-O3 -gline-tables-only -DNDEBUG';\
+				-DCMAKE_CXX_FLAGS_RELEASE='-O3 -gline-tables-only -DNDEBUG';\
+				-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON;"`,
+			`-DCLANG_BOOTSTRAP_PASSTHROUGH="DEFAULT_SYSROOT;LLVM_PARALLEL_LINK_JOBS"`,
+			`-DCLANG_BOOTSTRAP_TARGET='check-all;check-llvm;check-clang;llvm-config;test-suite;test-depends;llvm-test-depends;clang-test-depends;distribution;install-distribution;clang'`,
 			"-DCLANG_DEFAULT_CXX_STDLIB=libc++",
 			"-DCLANG_DEFAULT_RTLIB=compiler-rt",
+			"-DCLANG_ENABLE_BOOTSTRAP=ON",
 			"-DCMAKE_BUILD_TYPE=Release",
 			"-DCMAKE_INSTALL_LIBDIR=lib",
 			"-DCMAKE_SKIP_INSTALL_RPATH=ON",
-			"-DCOMPILER_RT_BUILD_PROFILE=ON",
 			tg`-DDEFAULT_SYSROOT=${sysroot}`,
 			"-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON",
 			"-DLIBCXX_USE_COMPILER_RT=YES",
@@ -82,23 +117,32 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 			"-DLLVM_ENABLE_EH=ON",
 			"-DLLVM_ENABLE_LIBXML2=OFF",
 			"-DLLVM_ENABLE_PIC=ON",
-			"-DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;lld;lldb'",
+			"-DLLVM_ENABLE_PROJECTS='clang;clang-tools-extra;lld'",
 			"-DLLVM_ENABLE_RTTI=ON",
 			"-DLLVM_ENABLE_RUNTIMES='compiler-rt;libcxx;libcxxabi;libunwind'",
 			"-DLLVM_INSTALL_BINUTILS_SYMLINKS=ON",
 			"-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON",
+			//`-DLLVM_TOOLCHAIN_TOOLS='dsymutil;llvm-cov;llvm-darfdump;llvm-profdata;llvm-objdump;llvm-nm;llvm-size'`,
+			//`-DLLVM_DISTRIBUTION_COMPONENTS='clang;LTO;clang-format;clang-resource-headers;builtins;runtimes;dsymutil;llvm-cov;llvm-darfdump;llvm-profdata;llvm-objdump;llvm-nm;llvm-size'`,
 			"-DLLVM_PARALLEL_LINK_JOBS=1",
+			"-DLLVM_TARGETS_TO_BUILD=Native", // This only applies to stage1, which we throw away.
+			"-DPACKAGE_VENDOR=Tangram",
+			//tg`-DZLIB_ROOT=${zlibArtifact}`,
 		],
 	};
+
+	// let buildPhase = tg.Mutation.set("ninja stage2-distribution");
+	// let install = tg.Mutation.set("ninja stage2-install-distribution");
+	let buildPhase = tg.Mutation.set("ninja stage2");
+	let install = tg.Mutation.set("ninja stage2-install");
+	let phases = { configure, build: buildPhase, install };
 
 	let llvmArtifact = await cmake.build(
 		{
 			...rest,
 			...std.triple.rotate({ build, host }),
 			env,
-			phases: {
-				configure: configureLlvm,
-			},
+			phases,
 			source: tg`${sourceDir}/llvm`,
 		},
 		autotools,

--- a/packages/std/sdk/llvm/cmake/Distribution-stage2.cmake
+++ b/packages/std/sdk/llvm/cmake/Distribution-stage2.cmake
@@ -1,7 +1,5 @@
 # This file defines the stage2 of the distribution build for the LLVM SDK.
 # Adapted from the example in the LLVM documentation: https://github.com/llvm/llvm-project/blob/main/clang/cmake/caches/DistributionExample-stage2.cmake
-# In addition to the basic example this build uses the LLVM libc++, compiler-rt, and libunwind in both stages.
-# bootstrap build.
 
 set(LLVM_ENABLE_PROJECTS "clang;clang-tools-extra;lld" CACHE STRING "")
 set(LLVM_ENABLE_RUNTIMES "compiler-rt;libcxx;libcxxabi;libunwind" CACHE STRING "")
@@ -19,16 +17,22 @@ set(COMPILER_RT_BUILD_PROFILE ON CACHE BOOL "")
 set(LLVM_INSTALL_TOOLCHAIN_ONLY ON CACHE BOOL "")
 set(LLVM_TOOLCHAIN_TOOLS
   dsymutil
+  llvm-ar
   llvm-cov
   llvm-dwarfdump
-  llvm-profdata
-  llvm-objdump
   llvm-nm
+  llvm-objcopy
+  llvm-objdump
+  llvm-profdata
+  llvm-readobj
   llvm-size
+  llvm-strip
+  llvm-strings
   CACHE STRING "")
 
 set(LLVM_DISTRIBUTION_COMPONENTS
   clang
+  lld
   LTO
   clang-format
   clang-resource-headers

--- a/packages/std/sdk/llvm/cmake/Distribution-stage2.cmake
+++ b/packages/std/sdk/llvm/cmake/Distribution-stage2.cmake
@@ -1,0 +1,40 @@
+# This file defines the stage2 of the distribution build for the LLVM SDK.
+# Adapted from the example in the LLVM documentation: https://github.com/llvm/llvm-project/blob/main/clang/cmake/caches/DistributionExample-stage2.cmake
+# In addition to the basic example this build uses the LLVM libc++, compiler-rt, and libunwind in both stages.
+# bootstrap build.
+
+set(LLVM_ENABLE_PROJECTS "clang;clang-tools-extra;lld" CACHE STRING "")
+set(LLVM_ENABLE_RUNTIMES "compiler-rt;libcxx;libcxxabi;libunwind" CACHE STRING "")
+
+set(LLVM_TARGETS_TO_BUILD X86;ARM;AArch64 CACHE STRING "")
+
+set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -gline-tables-only -DNDEBUG" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -gline-tables-only -DNDEBUG" CACHE STRING "")
+
+# Ensure the profiling feature of compiler-rt is included.
+set(COMPILER_RT_BUILD_PROFILE ON CACHE BOOL "")
+
+# setup toolchain
+set(LLVM_INSTALL_TOOLCHAIN_ONLY ON CACHE BOOL "")
+set(LLVM_TOOLCHAIN_TOOLS
+  dsymutil
+  llvm-cov
+  llvm-dwarfdump
+  llvm-profdata
+  llvm-objdump
+  llvm-nm
+  llvm-size
+  CACHE STRING "")
+
+set(LLVM_DISTRIBUTION_COMPONENTS
+  clang
+  LTO
+  clang-format
+  clang-resource-headers
+  builtins
+  runtimes
+  ${LLVM_TOOLCHAIN_TOOLS}
+  CACHE STRING "")
+
+set(LLVM_INSTALL_BINUTILS_SYMLINKS ON CACHE BOOL "")

--- a/packages/std/sdk/llvm/cmake/Distribution-stage2.cmake
+++ b/packages/std/sdk/llvm/cmake/Distribution-stage2.cmake
@@ -4,16 +4,35 @@
 set(LLVM_ENABLE_PROJECTS "clang;clang-tools-extra;lld" CACHE STRING "")
 set(LLVM_ENABLE_RUNTIMES "compiler-rt;libcxx;libcxxabi;libunwind" CACHE STRING "")
 
+# Set architectures to support.
 set(LLVM_TARGETS_TO_BUILD X86;ARM;AArch64 CACHE STRING "")
 
+# Set compiler flags.
 set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -gline-tables-only -DNDEBUG" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -gline-tables-only -DNDEBUG" CACHE STRING "")
 
-# Ensure the profiling feature of compiler-rt is included.
-set(COMPILER_RT_BUILD_PROFILE ON CACHE BOOL "")
+# Mirror the stage1 configuration to use all LLVM components.
+set(CLANG_DEFAULT_CXX_STDLIB "libc++" CACHE STRING "")
+set(CLANG_DEFAULT_RTLIB "compiler-rt" CACHE STRING "")
+set(LIBCXX_USE_COMPILER_RT ON CACHE BOOL "")
+set(LIBCXXABI_USE_COMPILER_RT ON CACHE BOOL "")
+set(LIBCXXABI_USE_LLVM_UNWINDER ON CACHE BOOL "")
+set(LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
 
-# setup toolchain
+# NOTE - the coresponding CMAKE_EXE_LINKER_FLAGS is set in `llvm.tg.ts`.
+set(CMAKE_SHARED_LINKER_FLAGS "-unwindlib=libunwind" CACHE STRING "")
+
+# Set up LLVM configuration.
+set(LLVM_ENABLE_EH ON CACHE BOOL "")
+set(LLVM_ENABLE_PIC ON CACHE BOOL "")
+set(LLVM_ENABLE_RTTI ON CACHE BOOL "")
+set(LLVM_ENABLE_LIBEDIT OFF CACHE BOOL "")
+set(LLVM_ENABLE_LIBXML2 OFF CACHE BOOL "")
+set(CMAKE_INSTALL_LIBDIR lib CACHE STRING "")
+set(CMAKE_SKIP_INSTALL_RPATH ON CACHE BOOL "")
+
+# Define toolchain components.
 set(LLVM_INSTALL_TOOLCHAIN_ONLY ON CACHE BOOL "")
 set(LLVM_TOOLCHAIN_TOOLS
   dsymutil
@@ -40,5 +59,3 @@ set(LLVM_DISTRIBUTION_COMPONENTS
   runtimes
   ${LLVM_TOOLCHAIN_TOOLS}
   CACHE STRING "")
-
-set(LLVM_INSTALL_BINUTILS_SYMLINKS ON CACHE BOOL "")

--- a/packages/std/sdk/llvm/cmake/Distribution.cmake
+++ b/packages/std/sdk/llvm/cmake/Distribution.cmake
@@ -17,56 +17,31 @@ set(PACKAGE_VENDOR Tangram CACHE STRING "")
 # Setting up the stage2 LTO option needs to be done on the stage1 build so that the proper LTO library dependencies can be connected.
 set(BOOTSTRAP_LLVM_ENABLE_LTO ON CACHE BOOL "")
 
-set(LLVM_INSTALL_BINUTILS_SYMLINKS ON CACHE BOOL "")
-
 if (NOT APPLE)
   # Since LLVM_ENABLE_LTO is ON we need a LTO capable linker
   set(BOOTSTRAP_LLVM_ENABLE_LLD ON CACHE BOOL "")
 endif()
 
-# Configure the stage1 and 2 builds to both use LLVM components, avoiding dependencies on the build toolchain.
+# Configure the stage1 buidl to use all LLVm components.
 set(CLANG_DEFAULT_CXX_STDLIB "libc++" CACHE STRING "")
-set(BOOTSTRAP_CLANG_DEFAULT_CXX_STDLIB "libc++" CACHE STRING "")
 set(CLANG_DEFAULT_RTLIB "compiler-rt" CACHE STRING "")
-set(BOOTSTRAP_CLANG_DEFAULT_RTLIB "compiler-rt" CACHE STRING "")
-
 set(LIBCXX_USE_COMPILER_RT ON CACHE BOOL "")
-set(BOOTSTRAP_LIBCXX_USE_COMPILER_RT ON CACHE BOOL "")
-
 set(LIBCXXABI_USE_COMPILER_RT ON CACHE BOOL "")
-set(BOOTSTRAP_LIBCXXABI_USE_COMPILER_RT ON CACHE BOOL "")
 set(LIBCXXABI_USE_LLVM_UNWINDER ON CACHE BOOL "")
-set(BOOTSTRAP_LIBCXXABI_USE_LLVM_UNWINDER ON CACHE BOOL "")
-
 set(LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
-set(BOOTSTRAP_LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
 
-# Ensure we build a static libc++abi library.
-set(LIBCXX_ENABLE_STATIC_ABI_LIBRARY ON CACHE BOOL "")
-set(BOOTSTRAP_LIBCXX_ENABLE_STATIC_ABI_LIBRARY ON CACHE BOOL "")
-
-# Ensure libunwind is used throughout stage2.
-set(BOOTSTRAP_CMAKE_SHARED_LINKER_FLAGS "-unwindlib=libunwind" CACHE STRING "")
-
-# Set up LLVM.
+# Set up LLVM configuration.
 set(LLVM_ENABLE_EH ON CACHE BOOL "")
-set(BOOTSTRAP_LLVM_ENABLE_EH ON CACHE BOOL "")
 set(LLVM_ENABLE_PIC ON CACHE BOOL "")
-set(BOOTSTRAP_LLVM_ENABLE_PIC ON CACHE BOOL "")
 set(LLVM_ENABLE_RTTI ON CACHE BOOL "")
-set(BOOTSTRAP_LLVM_ENABLE_RTTI ON CACHE BOOL "")
+set(LLVM_ENABLE_LIBEDIT OFF CACHE BOOL "")
 set(LLVM_ENABLE_LIBXML2 OFF CACHE BOOL "")
-set(BOOTSTRAP_LLVM_ENABLE_LIBXML2 OFF CACHE BOOL "")
-set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")
-set(BOOTSTRAP_LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")
 
 # Install libraries to lib
 set(CMAKE_INSTALL_LIBDIR lib CACHE STRING "")
-set(BOOTSTRAP_CMAKE_INSTALL_LIBDIR lib CACHE STRING "")
 
 # Skip the rpath install step, as the Tangram ld proxy may have made this impossible for some targets, and circumvents the need.
 set(CMAKE_SKIP_INSTALL_RPATH ON CACHE BOOL "")
-set(BOOTSTRAP_CMAKE_SKIP_INSTALL_RPATH ON CACHE BOOL "")
 
 # Expose stage2 targets through the stage1 build configuration.
 set(CLANG_BOOTSTRAP_TARGETS

--- a/packages/std/sdk/llvm/cmake/Distribution.cmake
+++ b/packages/std/sdk/llvm/cmake/Distribution.cmake
@@ -1,0 +1,88 @@
+# This file defines the bootstrapping distribution build for the LLVM SDK.
+# Adapted from the example in the LLVM documentation: https://github.com/llvm/llvm-project/blob/main/clang/cmake/caches/DistributionExample.cmake
+# In addition to the basic example this build uses the LLVM libc++, compiler-rt, and libunwind in both stages.
+
+#  Enable LLVM projects and runtimes
+set(LLVM_ENABLE_PROJECTS "clang;clang-tools-extra;lld" CACHE STRING "")
+set(LLVM_ENABLE_RUNTIMES "compiler-rt;libcxx;libcxxabi;libunwind" CACHE STRING "")
+
+# Only build the native target in stage1 since it is a throwaway build.
+set(LLVM_TARGETS_TO_BUILD Native CACHE STRING "")
+
+# Optimize the stage1 compiler, but don't LTO it because that wastes time.
+set(CMAKE_BUILD_TYPE Release CACHE STRING "")
+
+# Setup vendor-specific settings.
+set(PACKAGE_VENDOR Tangram CACHE STRING "")
+
+# Setting up the stage2 LTO option needs to be done on the stage1 build so that the proper LTO library dependencies can be connected.
+set(BOOTSTRAP_LLVM_ENABLE_LTO ON CACHE BOOL "")
+
+if (NOT APPLE)
+  # Since LLVM_ENABLE_LTO is ON we need a LTO capable linker
+  set(BOOTSTRAP_LLVM_ENABLE_LLD ON CACHE BOOL "")
+endif()
+
+# Configure the stage1 and 2 builds to both use LLVM components, avoiding dependencies on the build toolchain.
+set(CLANG_DEFAULT_CXX_STDLIB "libc++" CACHE STRING "")
+set(BOOTSTRAP_CLANG_DEFAULT_CXX_STDLIB "libc++" CACHE STRING "")
+set(CLANG_DEFAULT_RTLIB "compiler-rt" CACHE STRING "")
+set(BOOTSTRAP_CLANG_DEFAULT_RTLIB "compiler-rt" CACHE STRING "")
+
+set(LIBCXX_USE_COMPILER_RT ON CACHE BOOL "")
+set(BOOTSTRAP_LIBCXX_USE_COMPILER_RT ON CACHE BOOL "")
+
+set(LIBCXXABI_USE_COMPILER_RT ON CACHE BOOL "")
+set(BOOTSTRAP_LIBCXXABI_USE_COMPILER_RT ON CACHE BOOL "")
+set(LIBCXXABI_USE_LLVM_UNWINDER ON CACHE BOOL "")
+set(BOOTSTRAP_LIBCXXABI_USE_LLVM_UNWINDER ON CACHE BOOL "")
+
+set(LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
+set(BOOTSTRAP_LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
+
+# Ensure we build a static libc++abi library in stage 1.
+set(LIBCXX_ENABLE_STATIC_ABI_LIBRARY ON CACHE BOOL "")
+
+# Set up LLVM to handle static builds.
+# see https://github.com/ClangBuiltLinux/tc-build/issues/150#issuecomment-1005053204
+set(LLVM_BUILD_STATIC ON CACHE BOOL "")
+set(LLVM_ENABLE_PIC OFF CACHE BOOL "")
+set(LLVM_ENABLE_LIBXML2 OFF CACHE BOOL "")
+set(LLVM_ENABLE_ZLIB OFF CACHE BOOL "")
+set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")
+set(CMAKE_EXE_LINKER_FLAGS "-static" CACHE STRING "")
+set(BOOTSTRAP_CMAKE_EXE_LINKER_FLAGS "-static -unwindlib=libunwind" CACHE STRING "")
+set(BOOTSTRAP_CMAKE_SHARED_LINKER_FLAGS "-unwindlib=libunwind" CACHE STRING "")
+
+# Install libraries to lib
+set(CMAKE_INSTALL_LIBDIR lib CACHE STRING "")
+
+# Skip the rpath install step, as the Tangram ld proxy may have made this impossible for some targets, and circumvents the need.
+set(CMAKE_SKIP_INSTALL_RPATH ON CACHE BOOL "")
+
+# Expose stage2 targets through the stage1 build configuration.
+set(CLANG_BOOTSTRAP_TARGETS
+  check-all
+  check-llvm
+  check-clang
+  llvm-config
+  test-suite
+  test-depends
+  llvm-test-depends
+  clang-test-depends
+  distribution
+  install-distribution
+  clang CACHE STRING "")
+
+# Setup the bootstrap build.
+set(CLANG_ENABLE_BOOTSTRAP ON CACHE BOOL "")
+
+if(STAGE2_CACHE_FILE)
+  set(CLANG_BOOTSTRAP_CMAKE_ARGS
+    -C ${STAGE2_CACHE_FILE}
+    CACHE STRING "")
+else()
+  set(CLANG_BOOTSTRAP_CMAKE_ARGS
+    -C ${CMAKE_CURRENT_LIST_DIR}/Distribution-stage2.cmake
+    CACHE STRING "")
+endif()

--- a/packages/std/sdk/llvm/cmake/Distribution.cmake
+++ b/packages/std/sdk/llvm/cmake/Distribution.cmake
@@ -1,6 +1,5 @@
 # This file defines the bootstrapping distribution build for the LLVM SDK.
 # Adapted from the example in the LLVM documentation: https://github.com/llvm/llvm-project/blob/main/clang/cmake/caches/DistributionExample.cmake
-# In addition to the basic example this build uses the LLVM libc++, compiler-rt, and libunwind in both stages.
 
 #  Enable LLVM projects and runtimes
 set(LLVM_ENABLE_PROJECTS "clang;clang-tools-extra;lld" CACHE STRING "")
@@ -17,6 +16,8 @@ set(PACKAGE_VENDOR Tangram CACHE STRING "")
 
 # Setting up the stage2 LTO option needs to be done on the stage1 build so that the proper LTO library dependencies can be connected.
 set(BOOTSTRAP_LLVM_ENABLE_LTO ON CACHE BOOL "")
+
+set(LLVM_INSTALL_BINUTILS_SYMLINKS ON CACHE BOOL "")
 
 if (NOT APPLE)
   # Since LLVM_ENABLE_LTO is ON we need a LTO capable linker
@@ -40,25 +41,32 @@ set(BOOTSTRAP_LIBCXXABI_USE_LLVM_UNWINDER ON CACHE BOOL "")
 set(LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
 set(BOOTSTRAP_LIBUNWIND_USE_COMPILER_RT ON CACHE BOOL "")
 
-# Ensure we build a static libc++abi library in stage 1.
+# Ensure we build a static libc++abi library.
 set(LIBCXX_ENABLE_STATIC_ABI_LIBRARY ON CACHE BOOL "")
+set(BOOTSTRAP_LIBCXX_ENABLE_STATIC_ABI_LIBRARY ON CACHE BOOL "")
 
-# Set up LLVM to handle static builds.
-# see https://github.com/ClangBuiltLinux/tc-build/issues/150#issuecomment-1005053204
-set(LLVM_BUILD_STATIC ON CACHE BOOL "")
-set(LLVM_ENABLE_PIC OFF CACHE BOOL "")
-set(LLVM_ENABLE_LIBXML2 OFF CACHE BOOL "")
-set(LLVM_ENABLE_ZLIB OFF CACHE BOOL "")
-set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")
-set(CMAKE_EXE_LINKER_FLAGS "-static" CACHE STRING "")
-set(BOOTSTRAP_CMAKE_EXE_LINKER_FLAGS "-static -unwindlib=libunwind" CACHE STRING "")
+# Ensure libunwind is used throughout stage2.
 set(BOOTSTRAP_CMAKE_SHARED_LINKER_FLAGS "-unwindlib=libunwind" CACHE STRING "")
+
+# Set up LLVM.
+set(LLVM_ENABLE_EH ON CACHE BOOL "")
+set(BOOTSTRAP_LLVM_ENABLE_EH ON CACHE BOOL "")
+set(LLVM_ENABLE_PIC ON CACHE BOOL "")
+set(BOOTSTRAP_LLVM_ENABLE_PIC ON CACHE BOOL "")
+set(LLVM_ENABLE_RTTI ON CACHE BOOL "")
+set(BOOTSTRAP_LLVM_ENABLE_RTTI ON CACHE BOOL "")
+set(LLVM_ENABLE_LIBXML2 OFF CACHE BOOL "")
+set(BOOTSTRAP_LLVM_ENABLE_LIBXML2 OFF CACHE BOOL "")
+set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")
+set(BOOTSTRAP_LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")
 
 # Install libraries to lib
 set(CMAKE_INSTALL_LIBDIR lib CACHE STRING "")
+set(BOOTSTRAP_CMAKE_INSTALL_LIBDIR lib CACHE STRING "")
 
 # Skip the rpath install step, as the Tangram ld proxy may have made this impossible for some targets, and circumvents the need.
 set(CMAKE_SKIP_INSTALL_RPATH ON CACHE BOOL "")
+set(BOOTSTRAP_CMAKE_SKIP_INSTALL_RPATH ON CACHE BOOL "")
 
 # Expose stage2 targets through the stage1 build configuration.
 set(CLANG_BOOTSTRAP_TARGETS

--- a/packages/std/tangram.tg.ts
+++ b/packages/std/tangram.tg.ts
@@ -270,6 +270,11 @@ export let testMoldBuild = tg.target(async () => {
 	return await mold.test();
 });
 
+import * as ncurses from "./sdk/llvm/ncurses.tg.ts";
+export let testNcurses = tg.target(async () => {
+	return await ncurses.test();
+});
+
 import {
 	testExplicitGlibcVersionSdk,
 	testLLVMMoldSdk,

--- a/packages/std/wrap/workspace.tg.ts
+++ b/packages/std/wrap/workspace.tg.ts
@@ -50,7 +50,7 @@ export let tgld = async (arg: Arg) =>
 export let wrapper = async (arg: Arg) =>
 	tg.File.expect(await (await workspace(arg)).get("bin/wrapper"));
 
-let version = "1.77.2";
+let version = "1.78.0";
 
 type ToolchainArg = {
 	target?: string;


### PR DESCRIPTION
This PR improves the LLVM SDK build in the following ways:

- Performs a 2-stage bootstrapping build
- Utilizes CMake cache files instead of CLI arguments for most configuration
- Includes the `zlib` and `terminfo` dependencies, which were omitted previously due to build failures
- Utilizes the `distribution` build and install targets to minimize the installed components
- Performs the stage 2 build using LTO for increased performance at the cost of build time
- Performs the stage 2 build using `-gline-tables-only` for increased debugging information
- Reduces the supported target architectures to those required by Tangram
- Prunes superfluous configuration
- Includes `Tangram` in the version string for increased snazziness
- Version bumps: git 2.45.0, rust 1.78.0, linux headers 6.8.9, LLVM 18.1.5