### PR TITLE
chore: roll up pre-roll forward changes

### DIFF
--- a/packages/attr/tangram.tg.ts
+++ b/packages/attr/tangram.tg.ts
@@ -61,6 +61,14 @@ export let attr = tg.target(async (arg?: Arg) => {
 	for (let [binName, binFile] of bins) {
 		output = await tg.directory(output, { [`bin/${binName}`]: binFile });
 	}
+
+	// Remove .la files.
+	for await (let [name, _] of libDir) {
+		if (name.endsWith(".la")) {
+			output = await tg.directory(output, { [`lib/${name}`]: undefined });
+		}
+	}
+
 	return output;
 });
 

--- a/packages/bash/tangram.tg.ts
+++ b/packages/bash/tangram.tg.ts
@@ -1,3 +1,4 @@
+import gettext from "tg:gettext" with { path: "../gettext" };
 import ncurses from "tg:ncurses" with { path: "../ncurses" };
 import pkgconfig from "tg:pkgconfig" with { path: "../pkgconfig" };
 import * as std from "tg:std" with { path: "../std" };
@@ -61,6 +62,7 @@ export let bash = tg.target((arg?: Arg) => {
 	let phases = { configure };
 
 	let dependencies = [
+		gettext({ ...rest, build, env: env_, host }),
 		ncurses({ ...rest, build, env: env_, host }),
 		pkgconfig({ ...rest, build, env: env_, host }),
 	];

--- a/packages/cmake/ninja.tg.ts
+++ b/packages/cmake/ninja.tg.ts
@@ -6,13 +6,13 @@ export let metadata = {
 	license: "Apache-2.0",
 	name: "ninja",
 	repository: "https://github.com/ninja-build/ninja",
-	version: "1.12.0",
+	version: "1.12.1",
 };
 
 export let source = () => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:8b2c86cd483dc7fcb7975c5ec7329135d210099a89bc7db0590a07b0bbfe49a5";
+		"sha256:821bdff48a3f683bc4bb3b6f0b5fe7b2d647cf65d52aeb63328c91a6c6df285a";
 	let owner = "ninja-build";
 	let repo = name;
 	let tag = `v${version}`;

--- a/packages/git/tangram.tg.ts
+++ b/packages/git/tangram.tg.ts
@@ -1,3 +1,4 @@
+import gettext from "tg:gettext" with { path: "../gettext" };
 import openssl from "tg:openssl" with { path: "../openssl" };
 import * as std from "tg:std" with { path: "../std" };
 import zlib from "tg:zlib" with { path: "../zlib" };
@@ -59,6 +60,7 @@ export let git = tg.target(async (arg?: Arg) => {
 	};
 
 	let env = [
+		gettext({ ...rest, build, env: env_, host }),
 		openssl({ ...rest, build, env: env_, host }),
 		zlib({ ...rest, build, env: env_, host }),
 		env_,

--- a/packages/mold/tangram.tg.ts
+++ b/packages/mold/tangram.tg.ts
@@ -35,7 +35,7 @@ type Arg = {
 	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
 	source?: tg.Directory;
 };
-export let mold = async (arg?: Arg) => {
+export let mold = tg.target(async (arg?: Arg) => {
 	let {
 		cmake: cmake_ = [],
 		build: build_,
@@ -69,7 +69,7 @@ export let mold = async (arg?: Arg) => {
 	);
 
 	return result;
-};
+});
 
 export default mold;
 

--- a/packages/pkgconfig/tangram.tg.ts
+++ b/packages/pkgconfig/tangram.tg.ts
@@ -122,7 +122,7 @@ export let pkgconfig = tg.target(async (arg?: Arg) => {
 			PKG_CONFIG_PATH=$(echo "$PKG_CONFIG_PATH" | sed 's/^://')
 
 			export PKG_CONFIG_PATH
-			${pkgConfig} "$@"
+			exec ${pkgConfig} "$@"
 		`;
 	}
 

--- a/packages/postgresql/tangram.tg.ts
+++ b/packages/postgresql/tangram.tg.ts
@@ -14,13 +14,13 @@ export let metadata = {
 	license: "https://www.postgresql.org/about/licence/",
 	name: "postgresql",
 	repository: "https://git.postgresql.org/gitweb/?p=postgresql.git;a=summary",
-	version: "16.2",
+	version: "16.3",
 };
 
 export let source = tg.target(async (os: string) => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:446e88294dbc2c9085ab4b7061a646fa604b4bec03521d5ea671c2e5ad9b2952";
+		"sha256:331963d5d3dc4caf4216a049fa40b66d6bcb8c730615859411b9518764e60585";
 	let extension = ".tar.bz2";
 	let packageArchive = std.download.packageArchive({
 		name,

--- a/packages/std/autotools.tg.ts
+++ b/packages/std/autotools.tg.ts
@@ -198,6 +198,11 @@ export let target = async (...args: tg.Args<Arg>) => {
 	// Make sure the the arguments provided a source.
 	tg.assert(source !== undefined, `source must be defined`);
 
+	// Detect the host system from the environment.
+	let host = host_ ?? (await std.triple.host());
+	let target = target_ ?? host;
+	let os = std.triple.os(host);
+
 	// Determine SDK configuration.
 	let sdkArgs: Array<std.sdk.Arg> | undefined = undefined;
 	// If any SDk arg is `false`, we don't want to include the SDK.
@@ -207,12 +212,13 @@ export let target = async (...args: tg.Args<Arg>) => {
 		sdkArgs =
 			sdkArgs_?.filter((arg): arg is std.sdk.Arg => typeof arg !== "boolean") ??
 			([] as Array<std.sdk.Arg>);
+		if (
+			sdkArgs.length === 0 ||
+			sdkArgs.every((arg) => arg?.host === undefined)
+		) {
+			sdkArgs = std.flatten([{ host, target }, sdkArgs]);
+		}
 	}
-
-	// Detect the host system from the environment.
-	let host = host_ ?? (await std.triple.host());
-	let target = target_ ?? host;
-	let os = std.triple.os(host);
 
 	// Set up env.
 	let env: std.env.Arg = {};

--- a/packages/std/sdk/ninja.tg.ts
+++ b/packages/std/sdk/ninja.tg.ts
@@ -3,13 +3,13 @@ import * as cmake from "./cmake.tg.ts";
 
 export let metadata = {
 	name: "ninja",
-	version: "1.12.0",
+	version: "1.12.1",
 };
 
 export let source = () => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:8b2c86cd483dc7fcb7975c5ec7329135d210099a89bc7db0590a07b0bbfe49a5";
+		"sha256:821bdff48a3f683bc4bb3b6f0b5fe7b2d647cf65d52aeb63328c91a6c6df285a";
 	let owner = "ninja-build";
 	let repo = name;
 	let tag = `v${version}`;
@@ -63,6 +63,7 @@ export let test = tg.target(async () => {
 		buildFunction: ninja,
 		binaries: ["ninja"],
 		metadata,
+		sdk: {},
 	});
 	return true;
 });

--- a/packages/zsh/tangram.tg.ts
+++ b/packages/zsh/tangram.tg.ts
@@ -1,0 +1,98 @@
+// import gettext from "tg:gettext" with { path: "../gettext" };
+import libiconv from "tg:libiconv" with { path: "../libiconv" };
+import ncurses from "tg:ncurses" with { path: "../ncurses" };
+import pcre2 from "tg:pcre2" with { path: "../pcre2" };
+import pkgconfig from "tg:pkgconfig" with { path: "../pkgconfig" };
+import * as std from "tg:std" with { path: "../std" };
+
+export let metadata = {
+	homepage: "https://www.zsh.org/",
+	license: "https://sourceforge.net/p/zsh/code/ci/master/tree/LICENCE",
+	name: "zsh",
+	repository: "https://sourceforge.net/p/zsh/code/ci/master/tree/",
+	version: "5.9",
+};
+
+export let source = tg.target(async (arg?: Arg) => {
+	let { name, version } = metadata;
+	let url = `https://sourceforge.net/projects/zsh/files/zsh/5.9/${name}-${version}.tar.xz/download`;
+	let checksum =
+		"sha256:9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5";
+	return await std
+		.download({ url, checksum, decompress: "xz", extract: "tar" })
+		.then(tg.Directory.expect)
+		.then(std.directory.unwrap);
+});
+
+type Arg = {
+	autotools?: tg.MaybeNestedArray<std.autotools.Arg>;
+	build?: string;
+	env?: std.env.Arg;
+	host?: string;
+	sdk?: tg.MaybeNestedArray<std.sdk.Arg>;
+	source?: tg.Directory;
+};
+
+export let zsh = tg.target((arg?: Arg) => {
+	let {
+		autotools = [],
+		build,
+		env: env_,
+		host,
+		source: source_,
+		...rest
+	} = arg ?? {};
+
+	let configure = {
+		args: [
+			"--enable-pcre",
+			"--enable-multibyte",
+			`--with-term-lib="tinfow ncursesw"`,
+		],
+	};
+	let phases = { configure };
+
+	let dependencies = [
+		libiconv({ ...rest, build, env: env_, host }),
+		pcre2({ ...rest, build, env: env_, host }),
+		pkgconfig({ ...rest, build, env: env_, host }),
+		ncurses({ ...rest, build, env: env_, host }),
+	];
+	let env = [...dependencies, env_];
+
+	return std.autotools.build(
+		{
+			...rest,
+			...std.triple.rotate({ build, host }),
+			debug: true,
+			env,
+			phases,
+			source: source_ ?? source(),
+		},
+		autotools,
+	);
+});
+
+export default zsh;
+
+/** Wrap a shebang'd bash script to use this package's bach as the interpreter.. */
+export let wrapScript = async (script: tg.File) => {
+	let scriptMetadata = await std.file.executableMetadata(script);
+	if (
+		scriptMetadata?.format !== "shebang" ||
+		!scriptMetadata.interpreter.includes("sh")
+	) {
+		throw new Error("Expected a shebang sh, bash, or zsh script");
+	}
+	let interpreter = tg.File.expect(await (await zsh()).get("bin/zsh"));
+	return std.wrap(script, { interpreter, identity: "executable" });
+};
+
+export let test = tg.target(async () => {
+	await std.assert.pkg({
+		buildFunction: zsh,
+		binaries: ["zsh"],
+		metadata,
+	});
+	return true;
+});


### PR DESCRIPTION
This PR commits a handful of outstanding changes before rolling forward the repo to the new API.

- omit unused `.la` files which hardcode the output dir from `attr` install directory
- re-add `gettext` dependency to packages where it had been removed
- wrap `mold` top-level build function in a target
- fix pkg-config proxy to call main program with `exec`
- fix auto-detected SDK args
- add zsh package
- bump ninja to v1.12.1, postgres to v16.3