### PR TITLE
fix(std): ensure SDK is not referenced in standard env

### DIFF
--- a/packages/std/autotools.tg.ts
+++ b/packages/std/autotools.tg.ts
@@ -110,6 +110,10 @@ export let target = tg.target(async (...args: std.Args<Arg>) => {
 	let target = target_ ?? host;
 	let os = std.triple.os(host);
 
+	if (os === "darwin") {
+		buildInTree = true;
+	}
+
 	// Determine SDK configuration.
 	let sdkArgs: Array<std.sdk.ArgObject> | undefined = undefined;
 	// If any SDk arg is `false`, we don't want to include the SDK.
@@ -228,7 +232,7 @@ export let target = tg.target(async (...args: std.Args<Arg>) => {
 
 	if (buildInTree) {
 		let defaultPrepare = {
-			command: tg`cp -RaT ${source}/. . && chmod -R u+w .`,
+			command: tg`cp -R ${source}/. . && chmod -R u+w . && find . -exec touch -t 197001010000 {} +`,
 		};
 		defaultPhases.prepare = defaultPrepare;
 	}

--- a/packages/std/tangram.tg.ts
+++ b/packages/std/tangram.tg.ts
@@ -18,7 +18,7 @@ export { default as wrap } from "./wrap.tg.ts";
 
 export let metadata = {
 	name: "std",
-	version: "0.0.0",
+	version: "0.0.1",
 };
 
 export let flatten = <T>(value: tg.MaybeNestedArray<T>): Array<T> => {
@@ -372,4 +372,9 @@ export let testOciBasicEnvImage = tg.target(async () => {
 import { test as testDollar_ } from "./dollar.tg.ts";
 export let testDollar = tg.target(async () => {
 	return await testDollar_();
+});
+
+import { env as stdEnv } from "./env.tg.ts";
+export let testBaseEnv = tg.target(async () => {
+	return await stdEnv({ FOO: "bar" });
 });

--- a/packages/std/utils/coreutils.tg.ts
+++ b/packages/std/utils/coreutils.tg.ts
@@ -86,14 +86,7 @@ export let build = tg.target(async (arg?: Arg) => {
 			}),
 		);
 	}
-	let env = [
-		env_,
-		...dependencies,
-		{
-			// Don't use the "combine" LD proxy library path optimization. The newly created path won't be available during the build, but the existing library paths are.
-			TANGRAM_LINKER_LIBRARY_PATH_OPT_LEVEL: "none",
-		},
-	];
+	let env = [env_, ...dependencies];
 	if (staticBuild) {
 		env.push({ CC: "gcc -static" });
 	}

--- a/packages/std/utils/diffutils.tg.ts
+++ b/packages/std/utils/diffutils.tg.ts
@@ -60,12 +60,6 @@ export default build;
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = await bootstrap.toolchainTriple(await std.triple.host());
-	let sdkArg = await bootstrap.sdk.arg(host);
-	await std.assert.pkg({
-		buildFunction: build,
-		binaries: ["cmp", "diff"],
-		metadata,
-		sdk: sdkArg,
-	});
-	return true;
+	let sdk = await bootstrap.sdk.arg(host);
+	return build({ host, sdk });
 });

--- a/packages/std/utils/gawk.tg.ts
+++ b/packages/std/utils/gawk.tg.ts
@@ -61,12 +61,6 @@ export default build;
 import * as bootstrap from "../bootstrap.tg.ts";
 export let test = tg.target(async () => {
 	let host = await bootstrap.toolchainTriple(await std.triple.host());
-	let sdkArg = await bootstrap.sdk.arg(host);
-	await std.assert.pkg({
-		buildFunction: build,
-		binaries: ["gawk"],
-		metadata,
-		sdk: sdkArg,
-	});
-	return true;
+	let sdk = await bootstrap.sdk.arg(host);
+	return build({ host, sdk });
 });

--- a/packages/std/utils/make.tg.ts
+++ b/packages/std/utils/make.tg.ts
@@ -23,7 +23,15 @@ export type Arg = {
 };
 
 export let build = tg.target(async (arg?: Arg) => {
-	let { build, env: env_, host, sdk, source: source_ } = arg ?? {};
+	let {
+		build: build_,
+		env: env_,
+		host: host_,
+		sdk,
+		source: source_,
+	} = arg ?? {};
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let configure = {
 		args: ["--disable-dependency-tracking"],

--- a/packages/std/utils/patch.tg.ts
+++ b/packages/std/utils/patch.tg.ts
@@ -27,8 +27,16 @@ export type Arg = {
 	source?: tg.Directory;
 };
 
-export let build = tg.target((arg?: Arg) => {
-	let { build, env: env_, host, sdk, source: source_ } = arg ?? {};
+export let build = tg.target(async (arg?: Arg) => {
+	let {
+		build: build_,
+		env: env_,
+		host: host_,
+		sdk,
+		source: source_,
+	} = arg ?? {};
+	let host = host_ ?? (await std.triple.host());
+	let build = build_ ?? host;
 
 	let configure = {
 		args: ["--disable-dependency-tracking"],

--- a/packages/std/utils/tar.tg.ts
+++ b/packages/std/utils/tar.tg.ts
@@ -42,16 +42,6 @@ export let build = tg.target(async (arg?: Arg) => {
 		prerequisites(host),
 	];
 	let additionalEnv = {};
-	if (std.triple.os(host) === "darwin") {
-		dependencies.push(libiconv({ build, env: env_, host, sdk }));
-		// Bug: https://savannah.gnu.org/bugs/?64441.
-		// Fix http://git.savannah.gnu.org/cgit/tar.git/commit/?id=8632df39
-		// Remove in next release.
-		additionalEnv = {
-			...additionalEnv,
-			LDFLAGS: tg.Mutation.prefix(`-liconv`, " "),
-		};
-	}
 
 	let configure = {
 		args: ["--disable-dependency-tracking"],


### PR DESCRIPTION
This PR prevents the SDK from being referenced by the standard utils on macOS, greatly reducing the size of these outputs. Closes #70.