### PR TITLE
feat(bzip2): build dylib on macOS

### DIFF
--- a/packages/bzip2/bzip2_dylib_detect_os.patch
+++ b/packages/bzip2/bzip2_dylib_detect_os.patch
@@ -1,3 +1,42 @@
+diff --git a/Makefile b/Makefile
+index f8a1772..f66e318 100644
+--- a/Makefile
++++ b/Makefile
+@@ -12,6 +12,13 @@
+ # in the file LICENSE.
+ # ------------------------------------------------------------------
+ 
++OS:=$(shell uname -s)
++ifeq ($(OS),Darwin)
++	SHARED_EXT:=dylib
++else ifeq ($(OS),Linux)
++	SHARED_EXT:=so
++endif
++
+ SHELL=/bin/sh
+ 
+ # To assist in cross-compiling
+@@ -90,14 +97,16 @@ install: bzip2 bzip2recover
+ 	cp -f libbz2.a $(PREFIX)/lib
+ 	chmod a+r $(PREFIX)/lib/libbz2.a
+ 	cp -f bzgrep $(PREFIX)/bin/bzgrep
+-	ln -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzegrep
+-	ln -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzfgrep
++	cp -f libbz2.$(SHARED_EXT)* $(PREFIX)/lib
++	chmod a+r $(PREFIX)/lib/libbz2.$(SHARED_EXT)*
+ 	chmod a+x $(PREFIX)/bin/bzgrep
++	ln -s -f bzgrep $(PREFIX)/bin/bzegrep
++	ln -s -f bzgrep $(PREFIX)/bin/bzfgrep
+ 	cp -f bzmore $(PREFIX)/bin/bzmore
+-	ln -s -f $(PREFIX)/bin/bzmore $(PREFIX)/bin/bzless
++	ln -s -f bzmore $(PREFIX)/bin/bzless
+ 	chmod a+x $(PREFIX)/bin/bzmore
+ 	cp -f bzdiff $(PREFIX)/bin/bzdiff
+-	ln -s -f $(PREFIX)/bin/bzdiff $(PREFIX)/bin/bzcmp
++	ln -s -f bzdiff $(PREFIX)/bin/bzcmp
+ 	chmod a+x $(PREFIX)/bin/bzdiff
+ 	cp -f bzgrep.1 bzmore.1 bzdiff.1 $(PREFIX)/man/man1
+ 	chmod a+r $(PREFIX)/man/man1/bzgrep.1
 diff --git a/Makefile-libbz2_so b/Makefile-libbz2_so
 index fb0f230..20a1e4a 100644
 --- a/Makefile-libbz2_so

--- a/packages/bzip2/bzip2_dylib_detect_os.patch
+++ b/packages/bzip2/bzip2_dylib_detect_os.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile-libbz2_so b/Makefile-libbz2_so
-index fb0f230..b28735f 100644
+index fb0f230..20a1e4a 100644
 --- a/Makefile-libbz2_so
 +++ b/Makefile-libbz2_so
 @@ -20,6 +20,21 @@
@@ -32,7 +32,7 @@ index fb0f230..b28735f 100644
 -	$(CC) $(CFLAGS) -o bzip2-shared bzip2.c libbz2.so.1.0.8
 -	rm -f libbz2.so.1.0
 -	ln -s libbz2.so.1.0.8 libbz2.so.1.0
-+	$(CC) -shared $(SOFLAG) -Wl,$(DYLIB_NAME).MAJOR_MINOR -o $(DYLIB_NAME).$(PKG_VERSION) $(OBJS)
++	$(CC) -shared $(SOFLAG) -Wl,$(DYLIB_NAME).$(MAJOR_MINOR) -o $(DYLIB_NAME).$(PKG_VERSION) $(OBJS)
 +	$(CC) $(CFLAGS) -o $(PKG_NAME)-shared bzip2.c $(DYLIB_NAME).$(PKG_VERSION)
 +	ln -s $(DYLIB_NAME).$(PKG_VERSION) $(DYLIB_NAME).$(MAJOR_MINOR)
  

--- a/packages/bzip2/bzip2_dylib_detect_os.patch
+++ b/packages/bzip2/bzip2_dylib_detect_os.patch
@@ -1,0 +1,44 @@
+diff --git a/Makefile-libbz2_so b/Makefile-libbz2_so
+index fb0f230..b28735f 100644
+--- a/Makefile-libbz2_so
++++ b/Makefile-libbz2_so
+@@ -20,6 +20,21 @@
+ # in the file LICENSE.
+ # ------------------------------------------------------------------
+ 
++# Add additional variables
++OS:=$(shell uname -s)
++PKG_NAME:=bzip2
++LIB_NAME:=libbz2
++ifeq ($(OS),Darwin)
++	SHARED_EXT:=dylib
++	SOFLAG:=-Wl,-install_name
++else ifeq ($(OS),Linux)
++	SHARED_EXT:=so
++	SOFLAG:= -Wl,-soname
++endif
++
++PKG_VERSION:=1.0.8
++MAJOR_MINOR:=1.0
++DYLIB_NAME:=$(LIB_NAME).$(SHARED_EXT)
+ 
+ SHELL=/bin/sh
+ CC=gcc
+@@ -35,13 +50,12 @@ OBJS= blocksort.o  \
+       bzlib.o
+ 
+ all: $(OBJS)
+-	$(CC) -shared -Wl,-soname -Wl,libbz2.so.1.0 -o libbz2.so.1.0.8 $(OBJS)
+-	$(CC) $(CFLAGS) -o bzip2-shared bzip2.c libbz2.so.1.0.8
+-	rm -f libbz2.so.1.0
+-	ln -s libbz2.so.1.0.8 libbz2.so.1.0
++	$(CC) -shared $(SOFLAG) -Wl,$(DYLIB_NAME).MAJOR_MINOR -o $(DYLIB_NAME).$(PKG_VERSION) $(OBJS)
++	$(CC) $(CFLAGS) -o $(PKG_NAME)-shared bzip2.c $(DYLIB_NAME).$(PKG_VERSION)
++	ln -s $(DYLIB_NAME).$(PKG_VERSION) $(DYLIB_NAME).$(MAJOR_MINOR)
+ 
+ clean: 
+-	rm -f $(OBJS) bzip2.o libbz2.so.1.0.8 libbz2.so.1.0 bzip2-shared
++	rm -f $(OBJS) bzip2.o $(DYLIB_NAME).$(PKG_VERSION) $(DYLIB_NAME).$(MAJOR_MINOR) $(PKG_NAME)-shared
+ 
+ blocksort.o: blocksort.c
+ 	$(CC) $(CFLAGS) -c blocksort.c

--- a/packages/bzip2/tangram.tg.ts
+++ b/packages/bzip2/tangram.tg.ts
@@ -52,16 +52,12 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 	} = await std.args.apply<Arg>(...args);
 	let host = host_ ?? (await std.triple.host());
 
-	let os = std.triple.os(std.triple.archAndOs(host));
-	let dylibExt = os === "darwin" ? "dylib" : "so";
-
 	let sourceDir = source_ ?? source();
 
 	// Define phases.
 	let buildPhase = `make CC="$CC" SHELL="$SHELL" -f Makefile-libbz2_so && make CC="$CC" SHELL="$SHELL"`;
 	let install = {
-		command: `make install PREFIX="$OUTPUT" SHELL="$SHELL" && cp libbz2.${dylibExt}.* $OUTPUT/lib`,
-		args: tg.Mutation.unset(),
+		args: [`PREFIX="$OUTPUT" SHELL="$SHELL"`],
 	};
 	let phases = {
 		configure: tg.Mutation.unset(),
@@ -90,14 +86,6 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 			[`bin/${script}`]: bash.wrapScript(file),
 		});
 	}
-
-	// Replace absolute symlinks with relative ones.
-	output = await tg.directory(output, {
-		["bin/bzcmp"]: tg.symlink("bzdiff"),
-		["bin/bzegrep"]: tg.symlink("bzgrep"),
-		["bin/bzfgrep"]: tg.symlink("bzgrep"),
-		["bin/bzless"]: tg.symlink("bzmore"),
-	});
 
 	return output;
 });

--- a/packages/sqlite/tangram.tg.ts
+++ b/packages/sqlite/tangram.tg.ts
@@ -12,7 +12,7 @@ export let metadata = {
 	version: "3.46.0",
 };
 
-export let source = tg.target(async () => {
+export let source = tg.target(() => {
 	let { name, version } = metadata;
 	let checksum =
 		"sha256:6f8e6a7b335273748816f9b3b62bbdc372a889de8782d7f048c653a447417a7d";
@@ -28,8 +28,10 @@ export let source = tg.target(async () => {
 
 	let pkgName = `${name}-autoconf-${produceVersion(version)}`;
 	let url = `https://www.sqlite.org/2024/${pkgName}${extension}`;
-	let download = tg.Directory.expect(await std.download({ checksum, url }));
-	return std.directory.unwrap(download);
+	return std
+		.download({ checksum, url })
+		.then(tg.Directory.expect)
+		.then(std.directory.unwrap);
 });
 
 export type Arg = {

--- a/packages/std/tangram.tg.ts
+++ b/packages/std/tangram.tg.ts
@@ -32,6 +32,8 @@ export let flatten = <T>(value: tg.MaybeNestedArray<T>): Array<T> => {
 
 export let test = tg.target(() => testDefaultSdk());
 
+export default test;
+
 import * as triple from "./triple.tg.ts";
 export let testHostSystem = tg.target(async () => {
 	return triple.host();

--- a/packages/std/utils/bzip2.tg.ts
+++ b/packages/std/utils/bzip2.tg.ts
@@ -1,6 +1,9 @@
 import * as bootstrap from "../bootstrap.tg.ts";
 import * as std from "../tangram.tg.ts";
 import { buildUtil, prerequisites } from "../utils.tg.ts";
+import dylibDetectOsPatch from "./bzip2_dylib_detect_os.patch" with {
+	type: "file",
+};
 
 export let metadata = {
 	name: "bzip2",
@@ -18,10 +21,11 @@ export let source = tg.target(async () => {
 	let checksum =
 		"sha256:ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269";
 	let url = `https://sourceware.org/pub/bzip2/${packageArchive}`;
-	return await std
+	let source = await std
 		.download({ url, checksum })
 		.then(tg.Directory.expect)
 		.then(std.directory.unwrap);
+	return bootstrap.patch(source, dylibDetectOsPatch);
 });
 
 export type Arg = {
@@ -44,48 +48,24 @@ export let build = tg.target(async (arg?: Arg) => {
 	let host = host_ ?? (await std.triple.host());
 	let build = build_ ?? host;
 	let os = std.triple.os(host);
+	let dylibExt = os === "darwin" ? "dylib" : "so";
 	let sourceDir = source_ ?? source();
 
 	// Define phases.
-	let buildPhase =
-		os === "darwin"
-			? `make CC="$CC" SHELL="$SHELL"`
-			: `make CC="$CC" SHELL="$SHELL" -f Makefile-libbz2_so && make CC="$CC" SHELL="$SHELL"`;
-	let install =
-		os === "darwin"
-			? {
-					command: `make install PREFIX="$OUTPUT" SHELL="$SHELL"`,
-					args: tg.Mutation.unset(),
-			  }
-			: {
-					command: `make install PREFIX="$OUTPUT" SHELL="$SHELL" && cp libbz2.so.* $OUTPUT/lib`,
-					args: tg.Mutation.unset(),
-			  };
-	// NOTE - these symlinks get installed with absolute paths pointing to the ephermeral output directory. Use relative links instead.
-	let fixup = `
-		cd $OUTPUT/bin
-		rm bzcmp
-		ln -s bzdiff bzcmp
-		rm bzegrep bzfgrep
-		ln -s bzgrep bzegrep
-		ln -s bzgrep bzfgrep
-		rm bzless
-		ln -s bzmore bzless
-		cd $OUTPUT/lib
-	`;
-	if (os === "linux") {
-		fixup += `\nln -s libbz2.so.1.0 libbz2.so`;
-	}
+	let buildPhase = `make CC="$CC" SHELL="$SHELL" -f Makefile-libbz2_so && make CC="$CC" SHELL="$SHELL"`;
+	let install = {
+		command: `make install PREFIX="$OUTPUT" SHELL="$SHELL" && cp libbz2.${dylibExt}.* $OUTPUT/lib`,
+		args: tg.Mutation.unset(),
+	};
 	let phases = {
 		configure: tg.Mutation.unset(),
 		build: buildPhase,
 		install,
-		fixup,
 	};
 
 	let env = std.env.arg(env_, prerequisites(host));
 
-	let output = buildUtil({
+	let output = await buildUtil({
 		...std.triple.rotate({ build, host }),
 		buildInTree: true,
 		env,
@@ -94,6 +74,15 @@ export let build = tg.target(async (arg?: Arg) => {
 		source: sourceDir,
 		wrapBashScriptPaths: ["bin/bzdiff", "bin/bzgrep", "bin/bzmore"],
 	});
+
+	// Replace absolute symlinks with relative ones.
+	output = await tg.directory(output, {
+		["bin/bzcmp"]: tg.symlink("bzdiff"),
+		["bin/bzegrep"]: tg.symlink("bzgrep"),
+		["bin/bzfgrep"]: tg.symlink("bzgrep"),
+		["bin/bzless"]: tg.symlink("bzmore"),
+	});
+
 	return output;
 });
 

--- a/packages/std/utils/bzip2_dylib_detect_os.patch
+++ b/packages/std/utils/bzip2_dylib_detect_os.patch
@@ -1,3 +1,42 @@
+diff --git a/Makefile b/Makefile
+index f8a1772..f66e318 100644
+--- a/Makefile
++++ b/Makefile
+@@ -12,6 +12,13 @@
+ # in the file LICENSE.
+ # ------------------------------------------------------------------
+ 
++OS:=$(shell uname -s)
++ifeq ($(OS),Darwin)
++	SHARED_EXT:=dylib
++else ifeq ($(OS),Linux)
++	SHARED_EXT:=so
++endif
++
+ SHELL=/bin/sh
+ 
+ # To assist in cross-compiling
+@@ -90,14 +97,16 @@ install: bzip2 bzip2recover
+ 	cp -f libbz2.a $(PREFIX)/lib
+ 	chmod a+r $(PREFIX)/lib/libbz2.a
+ 	cp -f bzgrep $(PREFIX)/bin/bzgrep
+-	ln -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzegrep
+-	ln -s -f $(PREFIX)/bin/bzgrep $(PREFIX)/bin/bzfgrep
++	cp -f libbz2.$(SHARED_EXT)* $(PREFIX)/lib
++	chmod a+r $(PREFIX)/lib/libbz2.$(SHARED_EXT)*
+ 	chmod a+x $(PREFIX)/bin/bzgrep
++	ln -s -f bzgrep $(PREFIX)/bin/bzegrep
++	ln -s -f bzgrep $(PREFIX)/bin/bzfgrep
+ 	cp -f bzmore $(PREFIX)/bin/bzmore
+-	ln -s -f $(PREFIX)/bin/bzmore $(PREFIX)/bin/bzless
++	ln -s -f bzmore $(PREFIX)/bin/bzless
+ 	chmod a+x $(PREFIX)/bin/bzmore
+ 	cp -f bzdiff $(PREFIX)/bin/bzdiff
+-	ln -s -f $(PREFIX)/bin/bzdiff $(PREFIX)/bin/bzcmp
++	ln -s -f bzdiff $(PREFIX)/bin/bzcmp
+ 	chmod a+x $(PREFIX)/bin/bzdiff
+ 	cp -f bzgrep.1 bzmore.1 bzdiff.1 $(PREFIX)/man/man1
+ 	chmod a+r $(PREFIX)/man/man1/bzgrep.1
 diff --git a/Makefile-libbz2_so b/Makefile-libbz2_so
 index fb0f230..20a1e4a 100644
 --- a/Makefile-libbz2_so

--- a/packages/std/utils/bzip2_dylib_detect_os.patch
+++ b/packages/std/utils/bzip2_dylib_detect_os.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile-libbz2_so b/Makefile-libbz2_so
-index fb0f230..b28735f 100644
+index fb0f230..20a1e4a 100644
 --- a/Makefile-libbz2_so
 +++ b/Makefile-libbz2_so
 @@ -20,6 +20,21 @@
@@ -32,7 +32,7 @@ index fb0f230..b28735f 100644
 -	$(CC) $(CFLAGS) -o bzip2-shared bzip2.c libbz2.so.1.0.8
 -	rm -f libbz2.so.1.0
 -	ln -s libbz2.so.1.0.8 libbz2.so.1.0
-+	$(CC) -shared $(SOFLAG) -Wl,$(DYLIB_NAME).MAJOR_MINOR -o $(DYLIB_NAME).$(PKG_VERSION) $(OBJS)
++	$(CC) -shared $(SOFLAG) -Wl,$(DYLIB_NAME).$(MAJOR_MINOR) -o $(DYLIB_NAME).$(PKG_VERSION) $(OBJS)
 +	$(CC) $(CFLAGS) -o $(PKG_NAME)-shared bzip2.c $(DYLIB_NAME).$(PKG_VERSION)
 +	ln -s $(DYLIB_NAME).$(PKG_VERSION) $(DYLIB_NAME).$(MAJOR_MINOR)
  

--- a/packages/std/utils/bzip2_dylib_detect_os.patch
+++ b/packages/std/utils/bzip2_dylib_detect_os.patch
@@ -1,0 +1,44 @@
+diff --git a/Makefile-libbz2_so b/Makefile-libbz2_so
+index fb0f230..b28735f 100644
+--- a/Makefile-libbz2_so
++++ b/Makefile-libbz2_so
+@@ -20,6 +20,21 @@
+ # in the file LICENSE.
+ # ------------------------------------------------------------------
+ 
++# Add additional variables
++OS:=$(shell uname -s)
++PKG_NAME:=bzip2
++LIB_NAME:=libbz2
++ifeq ($(OS),Darwin)
++	SHARED_EXT:=dylib
++	SOFLAG:=-Wl,-install_name
++else ifeq ($(OS),Linux)
++	SHARED_EXT:=so
++	SOFLAG:= -Wl,-soname
++endif
++
++PKG_VERSION:=1.0.8
++MAJOR_MINOR:=1.0
++DYLIB_NAME:=$(LIB_NAME).$(SHARED_EXT)
+ 
+ SHELL=/bin/sh
+ CC=gcc
+@@ -35,13 +50,12 @@ OBJS= blocksort.o  \
+       bzlib.o
+ 
+ all: $(OBJS)
+-	$(CC) -shared -Wl,-soname -Wl,libbz2.so.1.0 -o libbz2.so.1.0.8 $(OBJS)
+-	$(CC) $(CFLAGS) -o bzip2-shared bzip2.c libbz2.so.1.0.8
+-	rm -f libbz2.so.1.0
+-	ln -s libbz2.so.1.0.8 libbz2.so.1.0
++	$(CC) -shared $(SOFLAG) -Wl,$(DYLIB_NAME).MAJOR_MINOR -o $(DYLIB_NAME).$(PKG_VERSION) $(OBJS)
++	$(CC) $(CFLAGS) -o $(PKG_NAME)-shared bzip2.c $(DYLIB_NAME).$(PKG_VERSION)
++	ln -s $(DYLIB_NAME).$(PKG_VERSION) $(DYLIB_NAME).$(MAJOR_MINOR)
+ 
+ clean: 
+-	rm -f $(OBJS) bzip2.o libbz2.so.1.0.8 libbz2.so.1.0 bzip2-shared
++	rm -f $(OBJS) bzip2.o $(DYLIB_NAME).$(PKG_VERSION) $(DYLIB_NAME).$(MAJOR_MINOR) $(PKG_NAME)-shared
+ 
+ blocksort.o: blocksort.c
+ 	$(CC) $(CFLAGS) -c blocksort.c


### PR DESCRIPTION
This PR augments the bzip2 build definitions to produce a shared dylib in addition to the static library on macOS, mirroring linux. Closes #56.

The first commit provides a working but suboptimal solution. Before merging, will address:

- [x] Instead of a separate Makefile, just patch the existing Linux one. The dylib extension and the CFLAGS need to change depending on the detected platform
- [x] Instead of a fixup phase, express the directory manipulation directly in Tangram