### PR TITLE
fix(ld_proxy): correctly handle non-artifact library paths

### DIFF
--- a/packages/acl/tangram.tg.ts
+++ b/packages/acl/tangram.tg.ts
@@ -60,7 +60,7 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 	};
 	let phases = { configure };
 
-	let output = await std.autotools.build(
+	return std.autotools.build(
 		{
 			...(await std.triple.rotate({ build, host })),
 			env,
@@ -70,17 +70,6 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		},
 		autotools,
 	);
-
-	// Remove .la files.
-	for await (let [name, _] of await output
-		.get("lib")
-		.then(tg.Directory.expect)) {
-		if (name.endsWith(".la")) {
-			output = await tg.directory(output, { [`lib/${name}`]: undefined });
-		}
-	}
-
-	return output;
 });
 
 export default build;

--- a/packages/attr/tangram.tg.ts
+++ b/packages/attr/tangram.tg.ts
@@ -46,7 +46,7 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 	};
 	let phases = { configure };
 
-	let output = await std.autotools.build(
+	return std.autotools.build(
 		{
 			...(await std.triple.rotate({ build, host })),
 			phases,
@@ -55,17 +55,6 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		},
 		autotools,
 	);
-
-	// Remove .la files.
-	for await (let [name, _] of await output
-		.get("lib")
-		.then(tg.Directory.expect)) {
-		if (name.endsWith(".la")) {
-			output = await tg.directory(output, { [`lib/${name}`]: undefined });
-		}
-	}
-
-	return output;
 });
 
 export default build;

--- a/packages/curl/tangram.tg.ts
+++ b/packages/curl/tangram.tg.ts
@@ -76,23 +76,16 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 	};
 	let phases = { prepare, configure };
 
-	let openSslDir = await openssl.build(
-		{ build, env: env_, host, sdk },
-		opensslArg,
-	);
-	let zlibDir = await zlib.build({ build, env: env_, host, sdk }, zlibArg);
-	let zstdDir = await zstd.build({ build, env: env_, host, sdk }, zstdArg);
-
 	let env = [
 		perl.build({ build, host: build }),
 		pkgconfig.build({ build, host: build }),
-		openSslDir,
-		zlibDir,
-		zstdDir,
+		openssl.build({ build, env: env_, host, sdk }, opensslArg),
+		zlib.build({ build, env: env_, host, sdk }, zlibArg),
+		zstd.build({ build, env: env_, host, sdk }, zstdArg),
 		env_,
 	];
 
-	let output = await std.autotools.build(
+	return std.autotools.build(
 		{
 			...(await std.triple.rotate({ build, host })),
 			env: std.env.arg(env),
@@ -102,20 +95,6 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		},
 		autotools,
 	);
-
-	// Wrap binary to always include the certificates and libdir.
-	let curlExe = tg.File.expect(await output.get("bin/curl"));
-	let libDir = tg.Directory.expect(await output.get("lib"));
-	let openSslLibDir = tg.Directory.expect(await openSslDir.get("lib"));
-	let zlibLibDir = tg.Directory.expect(await zlibDir.get("lib"));
-	let zsdtLibDir = tg.Directory.expect(await zstdDir.get("lib"));
-	let wrappedCurl = std.wrap(curlExe, {
-		libraryPaths: [libDir, openSslLibDir, zlibLibDir, zsdtLibDir],
-	});
-	output = await tg.directory(output, {
-		["bin/curl"]: wrappedCurl,
-	});
-	return output;
 });
 
 export default build;

--- a/packages/curl/tangram.tg.ts
+++ b/packages/curl/tangram.tg.ts
@@ -62,7 +62,7 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 	let os = std.triple.os(host);
 
 	let runtimeLibEnvVar =
-		os === "darwin" ? "DYLD_FALLBACK_LIBRARY_PATH" : "LT_SYS_LIBRARY_PATH";
+		os === "darwin" ? "DYLD_FALLBACK_LIBRARY_PATH" : "LD_LIBRARY_PATH";
 	let prepare = `export ${runtimeLibEnvVar}="$LIBRARY_PATH"`;
 
 	let configure = {

--- a/packages/fftw/tangram.tg.ts
+++ b/packages/fftw/tangram.tg.ts
@@ -33,7 +33,7 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 	let {
 		autotools = {},
 		build,
-		env: env_,
+		env,
 		host,
 		sdk,
 		source: source_,
@@ -53,9 +53,7 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		configure.args.push("--enable-openmp");
 	}
 
-	let env = [{ TANGRAM_LINKER_LIBRARY_PATH_OPT_LEVEL: "filter" }, env_];
-
-	let output = await std.autotools.build(
+	return std.autotools.build(
 		{
 			...(await std.triple.rotate({ build, host })),
 			env: std.env.arg(env),
@@ -65,17 +63,6 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		},
 		autotools,
 	);
-
-	// Wrap output binaries.
-	let libDir = tg.Directory.expect(await output.get("lib"));
-	let binDir = tg.Directory.expect(await output.get("bin"));
-	for await (let [name, artifact] of binDir) {
-		let file = tg.File.expect(artifact);
-		let wrappedBin = await std.wrap(file, { libraryPaths: [libDir] });
-		output = await tg.directory(output, { [`bin/${name}`]: wrappedBin });
-	}
-
-	return output;
 });
 
 export default build;

--- a/packages/findutils/tangram.tg.ts
+++ b/packages/findutils/tangram.tg.ts
@@ -6,13 +6,13 @@ export let metadata = {
 	name: "findutils",
 	license: "GPL-3.0-or-later",
 	repository: "https://git.savannah.gnu.org/cgit/findutils.git",
-	version: "4.9.0",
+	version: "4.10.0",
 };
 
 export let source = tg.target(() => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:a2bfb8c09d436770edc59f50fa483e785b161a3b7b9d547573cb08065fd462fe";
+		"sha256:1387e0b67ff247d2abde998f90dfbf70c1491391a59ddfecb8ae698789f0a4f5";
 	return std.download.fromGnu({ name, version, checksum });
 });
 

--- a/packages/gettext/tangram.tg.ts
+++ b/packages/gettext/tangram.tg.ts
@@ -103,9 +103,7 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 	hostDependencies.push(ncursesForHost);
 
 	// Resolve env.
-	let env = await std.env.arg(...buildDependencies, ...hostDependencies, env_, {
-		TANGRAM_LD_PROXY_TRACING: "tangram=trace",
-	});
+	let env = await std.env.arg(...buildDependencies, ...hostDependencies, env_);
 
 	// Add final build dependencies to env.
 	let resolvedBuildDependencies = [];

--- a/packages/gettext/tangram.tg.ts
+++ b/packages/gettext/tangram.tg.ts
@@ -141,7 +141,7 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 	}
 	let phases = { configure };
 
-	let output = await std.autotools.build(
+	return std.autotools.build(
 		{
 			...(await std.triple.rotate({ build, host })),
 			env,
@@ -151,29 +151,6 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		},
 		autotools,
 	);
-
-	// Wrap output binaries.
-	let libDir = tg.Directory.expect(await output.get("lib"));
-	let libraryPaths = [
-		libDir,
-		tg.Directory.expect(await ncursesForHost.get("lib")),
-	];
-	if (os === "linux") {
-		let aclDir = tg.Directory.expect(await aclForHost?.get("lib"));
-		let attrDir = tg.Directory.expect(await attrForHost?.get("lib"));
-		libraryPaths.push(aclDir);
-		libraryPaths.push(attrDir);
-	}
-	let libiconvDir = tg.Directory.expect(await libiconvForHost.get("lib"));
-	libraryPaths.push(libiconvDir);
-	let binDir = tg.Directory.expect(await output.get("bin"));
-	for await (let [name, artifact] of binDir) {
-		let file = tg.File.expect(artifact);
-		let wrappedBin = await std.wrap(file, { libraryPaths });
-		output = await tg.directory(output, { [`bin/${name}`]: wrappedBin });
-	}
-
-	return output;
 });
 
 export default build;

--- a/packages/icu/tangram.tg.ts
+++ b/packages/icu/tangram.tg.ts
@@ -61,7 +61,7 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 				0)
 	) {
 		env.push({
-			TANGRAM_LINKER_LIBRARY_PATH_OPT_LEVEL: "filter", // FIXME - is this necessary?
+			TANGRAM_LINKER_LIBRARY_PATH_OPT_LEVEL: "filter",
 		});
 	}
 

--- a/packages/icu/tangram.tg.ts
+++ b/packages/icu/tangram.tg.ts
@@ -71,7 +71,7 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 	};
 	let phases = { configure };
 
-	let output = await std.autotools.build(
+	return std.autotools.build(
 		{
 			...(await std.triple.rotate({ build, host })),
 			env: std.env.arg(env),
@@ -81,21 +81,6 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		},
 		autotools,
 	);
-
-	// // Every file in bin/ needs to get wrapped to include lib/.
-	// let libDir = tg.Directory.expect(await output.get("lib"));
-	// let binDir = tg.Directory.expect(await output.get("bin"));
-	// for await (let [name, artifact] of binDir) {
-	// 	let unwrappedBin = tg.File.expect(artifact);
-	// 	let wrappedBin = std.wrap(unwrappedBin, {
-	// 		libraryPaths: [libDir],
-	// 	});
-	// 	output = await tg.directory(output, {
-	// 		[`bin/${name}`]: wrappedBin,
-	// 	});
-	// }
-
-	return output;
 });
 
 export default build;

--- a/packages/icu/tangram.tg.ts
+++ b/packages/icu/tangram.tg.ts
@@ -61,7 +61,7 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 				0)
 	) {
 		env.push({
-			TANGRAM_LINKER_LIBRARY_PATH_OPT_LEVEL: "filter",
+			TANGRAM_LINKER_LIBRARY_PATH_OPT_LEVEL: "filter", // FIXME - is this necessary?
 		});
 	}
 
@@ -82,18 +82,18 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		autotools,
 	);
 
-	// Every file in bin/ needs to get wrapped to include lib/.
-	let libDir = tg.Directory.expect(await output.get("lib"));
-	let binDir = tg.Directory.expect(await output.get("bin"));
-	for await (let [name, artifact] of binDir) {
-		let unwrappedBin = tg.File.expect(artifact);
-		let wrappedBin = std.wrap(unwrappedBin, {
-			libraryPaths: [libDir],
-		});
-		output = await tg.directory(output, {
-			[`bin/${name}`]: wrappedBin,
-		});
-	}
+	// // Every file in bin/ needs to get wrapped to include lib/.
+	// let libDir = tg.Directory.expect(await output.get("lib"));
+	// let binDir = tg.Directory.expect(await output.get("bin"));
+	// for await (let [name, artifact] of binDir) {
+	// 	let unwrappedBin = tg.File.expect(artifact);
+	// 	let wrappedBin = std.wrap(unwrappedBin, {
+	// 		libraryPaths: [libDir],
+	// 	});
+	// 	output = await tg.directory(output, {
+	// 		[`bin/${name}`]: wrappedBin,
+	// 	});
+	// }
 
 	return output;
 });

--- a/packages/libcap/tangram.tg.ts
+++ b/packages/libcap/tangram.tg.ts
@@ -75,7 +75,7 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		env_,
 	);
 
-	let output = await std.autotools.build(
+	return std.autotools.build(
 		{
 			...(await std.triple.rotate({ build, host })),
 			buildInTree: true,
@@ -86,18 +86,6 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		},
 		autotools,
 	);
-
-	let bins = ["capsh", "getcap", "setcap", "getpcaps"];
-	let libDir = tg.Directory.expect(await output.get("lib"));
-	let attrLibDir = tg.Directory.expect(await attrArtifact.get("lib"));
-	for (let bin of bins) {
-		let unwrappedBin = tg.File.expect(await output.get(`bin/${bin}`));
-		let wrappedBin = std.wrap(unwrappedBin, {
-			libraryPaths: [libDir, attrLibDir],
-		});
-		output = await tg.directory(output, { [`bin/${bin}`]: wrappedBin });
-	}
-	return output;
 });
 
 export default build;

--- a/packages/libcap/tangram.tg.ts
+++ b/packages/libcap/tangram.tg.ts
@@ -46,7 +46,18 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		source: source_,
 	} = await std.args.apply<Arg>(...args);
 
-	let install = tg.Mutation.set(`
+	let os = std.triple.os(host);
+	let runtimeLibEnvVar =
+		os === "darwin" ? "DYLD_FALLBACK_LIBRARY_PATH" : "LD_LIBRARY_PATH";
+	let prepare = {
+		command: tg.Mutation.suffix(
+			`export ${runtimeLibEnvVar}="$LIBRARY_PATH"`,
+			"\n",
+		),
+	};
+
+	let install = {
+		command: tg.Mutation.set(`
 		mkdir -p $OUTPUT/bin $OUTPUT/lib/pkgconfig
 		bins="capsh getcap setcap getpcaps"
 		for bin in $bins; do
@@ -59,21 +70,17 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		cd $OUTPUT/lib
 		ln -s libcap.so.${metadata.version} libcap.so.2
 		ln -s libcap.so.2 libcap.so
-	`);
-	let phases = { configure: tg.Mutation.unset(), install };
+	`),
+		args: tg.Mutation.unset(),
+	};
+	let phases = { prepare, configure: tg.Mutation.unset(), install };
 
 	let attrArtifact = await attr.build({ build, env: env_, host, sdk }, attrArg);
 	let dependencies = [
 		attrArtifact,
 		perl.build({ build, env: env_, host, sdk }, perlArg),
 	];
-	let env = std.env.arg(
-		...dependencies,
-		{
-			LDFLAGS: tg.Mutation.prefix(`-L${attrArtifact}/lib`, " "),
-		},
-		env_,
-	);
+	let env = std.env.arg(...dependencies, env_);
 
 	return std.autotools.build(
 		{

--- a/packages/pcre2/tangram.tg.ts
+++ b/packages/pcre2/tangram.tg.ts
@@ -45,14 +45,18 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		source: source_,
 	} = await std.args.apply<Arg>(...args);
 
-	let phases = {};
+	let configureArgs = [
+		"--disable-dependency-tracking",
+		"--enable-fast-install=no",
+	];
 	if (build !== host) {
-		phases = {
-			configure: {
-				args: [`--build=${build}`, `--host=${host}`],
-			},
-		};
+		configureArgs = configureArgs.concat([
+			`--build=${build}`,
+			`--host=${host}`,
+		]);
 	}
+	let configure = { args: configureArgs };
+	let phases = { configure };
 
 	return std.autotools.build(
 		{

--- a/packages/postgresql/tangram.tg.ts
+++ b/packages/postgresql/tangram.tg.ts
@@ -124,35 +124,34 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		},
 		autotools,
 	);
-	console.log("postgres", await output.id());
 
-	// Wrap output binaries.
-	let libDir = tg.Directory.expect(await output.get("lib"));
-	let libraryPaths = [libDir];
-	if (os === "darwin") {
-		let ncursesLibDir = tg.Directory.expect(
-			await (await ncursesArtifact).get("lib"),
-		);
-		let readlineLibDir = tg.Directory.expect(
-			await (await readlineArtifact).get("lib"),
-		);
-		let icuLibDir = tg.Directory.expect(await (await icuArtifact).get("lib"));
-		let lz4LibDir = tg.Directory.expect(await (await lz4Artifact).get("lib"));
-		let zlibLibDir = tg.Directory.expect(await (await zlibArtifact).get("lib"));
-		let zstdLibDir = tg.Directory.expect(await (await zstdArtifact).get("lib"));
-		libraryPaths.push(icuLibDir);
-		libraryPaths.push(lz4LibDir);
-		libraryPaths.push(ncursesLibDir);
-		libraryPaths.push(readlineLibDir);
-		libraryPaths.push(zlibLibDir);
-		libraryPaths.push(zstdLibDir);
-	}
-	let binDir = tg.Directory.expect(await output.get("bin"));
-	for await (let [name, artifact] of binDir) {
-		let file = tg.File.expect(artifact);
-		let wrappedBin = await std.wrap(file, { libraryPaths });
-		output = await tg.directory(output, { [`bin/${name}`]: wrappedBin });
-	}
+	// // Wrap output binaries.
+	// let libDir = tg.Directory.expect(await output.get("lib"));
+	// let libraryPaths = [libDir];
+	// if (os === "darwin") {
+	// 	let ncursesLibDir = tg.Directory.expect(
+	// 		await (await ncursesArtifact).get("lib"),
+	// 	);
+	// 	let readlineLibDir = tg.Directory.expect(
+	// 		await (await readlineArtifact).get("lib"),
+	// 	);
+	// 	let icuLibDir = tg.Directory.expect(await (await icuArtifact).get("lib"));
+	// 	let lz4LibDir = tg.Directory.expect(await (await lz4Artifact).get("lib"));
+	// 	let zlibLibDir = tg.Directory.expect(await (await zlibArtifact).get("lib"));
+	// 	let zstdLibDir = tg.Directory.expect(await (await zstdArtifact).get("lib"));
+	// 	libraryPaths.push(icuLibDir);
+	// 	libraryPaths.push(lz4LibDir);
+	// 	libraryPaths.push(ncursesLibDir);
+	// 	libraryPaths.push(readlineLibDir);
+	// 	libraryPaths.push(zlibLibDir);
+	// 	libraryPaths.push(zstdLibDir);
+	// }
+	// let binDir = tg.Directory.expect(await output.get("bin"));
+	// for await (let [name, artifact] of binDir) {
+	// 	let file = tg.File.expect(artifact);
+	// 	let wrappedBin = await std.wrap(file, { libraryPaths });
+	// 	output = await tg.directory(output, { [`bin/${name}`]: wrappedBin });
+	// }
 
 	return output;
 });

--- a/packages/postgresql/tangram.tg.ts
+++ b/packages/postgresql/tangram.tg.ts
@@ -112,7 +112,7 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		});
 	}
 
-	let output = await std.autotools.build(
+	return std.autotools.build(
 		{
 			...(await std.triple.rotate({ build, host })),
 			buildInTree: true,
@@ -124,36 +124,6 @@ export let build = tg.target(async (...args: std.Args<Arg>) => {
 		},
 		autotools,
 	);
-
-	// // Wrap output binaries.
-	// let libDir = tg.Directory.expect(await output.get("lib"));
-	// let libraryPaths = [libDir];
-	// if (os === "darwin") {
-	// 	let ncursesLibDir = tg.Directory.expect(
-	// 		await (await ncursesArtifact).get("lib"),
-	// 	);
-	// 	let readlineLibDir = tg.Directory.expect(
-	// 		await (await readlineArtifact).get("lib"),
-	// 	);
-	// 	let icuLibDir = tg.Directory.expect(await (await icuArtifact).get("lib"));
-	// 	let lz4LibDir = tg.Directory.expect(await (await lz4Artifact).get("lib"));
-	// 	let zlibLibDir = tg.Directory.expect(await (await zlibArtifact).get("lib"));
-	// 	let zstdLibDir = tg.Directory.expect(await (await zstdArtifact).get("lib"));
-	// 	libraryPaths.push(icuLibDir);
-	// 	libraryPaths.push(lz4LibDir);
-	// 	libraryPaths.push(ncursesLibDir);
-	// 	libraryPaths.push(readlineLibDir);
-	// 	libraryPaths.push(zlibLibDir);
-	// 	libraryPaths.push(zstdLibDir);
-	// }
-	// let binDir = tg.Directory.expect(await output.get("bin"));
-	// for await (let [name, artifact] of binDir) {
-	// 	let file = tg.File.expect(artifact);
-	// 	let wrappedBin = await std.wrap(file, { libraryPaths });
-	// 	output = await tg.directory(output, { [`bin/${name}`]: wrappedBin });
-	// }
-
-	return output;
 });
 
 export default build;

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -613,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-util",
@@ -1307,6 +1307,7 @@ dependencies = [
  "tangram_client",
  "tangram_wrapper",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
 ]

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -977,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { version = "1", default-features = false, features = [
   "fs",
   "parking_lot",
 ] }
+tokio-stream = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "parking_lot"] }
 

--- a/packages/std/packages/ld_proxy/Cargo.toml
+++ b/packages/std/packages/ld_proxy/Cargo.toml
@@ -24,5 +24,6 @@ serde_json = { workspace = true }
 tangram_client = { workspace = true }
 tangram_wrapper = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/packages/std/packages/ld_proxy/src/main.rs
+++ b/packages/std/packages/ld_proxy/src/main.rs
@@ -67,9 +67,6 @@ struct Options {
 	/// Paths which may contain additional dynamic libraries passed on the command line, not via a library path.
 	additional_library_candidate_paths: Vec<PathBuf>,
 
-	/// Allow producing wrappers with required libraries missing. Pass specific names or "all" to disable the check entirely.
-	allow_missing_libraries: bool,
-
 	/// Library path optimization strategy. Select `resolve`, `filter`, `combine`, or `none`. Defaults to `combine`.
 	library_path_optimization: LibraryPathOptimizationLevel,
 
@@ -145,10 +142,6 @@ fn read_options() -> tg::Result<Options> {
 				.collect_vec()
 		});
 
-	// Check if we should allow producing wrappers that don't account for all needed libraries.
-	let mut allow_missing_libraries =
-		std::env::var("TANGRAM_LINKER_ALLOW_MISSING_LIBRARIES").is_ok();
-
 	// Get the max depth.
 	let mut max_depth = std::env::var("TANGRAM_LINKER_MAX_DEPTH")
 		.ok()
@@ -194,8 +187,6 @@ fn read_options() -> tg::Result<Options> {
 				}
 			} else if arg.starts_with("--tg-passthrough") {
 				passthrough = true;
-			} else if arg.starts_with("--tg-allow-missing-libraries") {
-				allow_missing_libraries = true;
 			} else {
 				command_args.push(arg.clone());
 			}
@@ -239,7 +230,6 @@ fn read_options() -> tg::Result<Options> {
 
 	let options = Options {
 		additional_library_candidate_paths,
-		allow_missing_libraries,
 		library_path_optimization: library_optimization_strategy,
 		command_path,
 		command_args,
@@ -380,7 +370,6 @@ async fn create_wrapper(options: &Options) -> tg::Result<()> {
 			&mut needed_libraries,
 			options.library_path_optimization,
 			options.max_depth,
-			options.allow_missing_libraries,
 		)
 		.await?;
 
@@ -728,7 +717,6 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 	needed_libraries: &mut HashMap<String, Option<tg::directory::Id>, H>,
 	strategy: LibraryPathOptimizationLevel,
 	max_depth: usize,
-	allow_missing_libraries: bool,
 ) -> tg::Result<HashSet<tg::symlink::Id, H>> {
 	if matches!(strategy, LibraryPathOptimizationLevel::None) || library_paths.is_empty() {
 		return Ok(library_paths);
@@ -738,13 +726,7 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 	let resolved_dirs: HashSet<tg::directory::Id, H> = resolve_paths(tg, &library_paths).await?;
 	tracing::trace!(?resolved_dirs, "post-resolve");
 	if matches!(strategy, LibraryPathOptimizationLevel::Resolve) {
-		return finalize_library_paths(
-			tg,
-			resolved_dirs,
-			needed_libraries,
-			allow_missing_libraries,
-		)
-		.await;
+		return finalize_library_paths(tg, resolved_dirs, needed_libraries).await;
 	}
 
 	// Find all the transitive needed libraries of the output file we can locate in the library path.
@@ -753,13 +735,7 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 	tracing::trace!(?needed_libraries, "post-find");
 	if matches!(strategy, LibraryPathOptimizationLevel::Filter) {
 		let resolved_dirs = needed_libraries.values().flatten().cloned().collect();
-		return finalize_library_paths(
-			tg,
-			resolved_dirs,
-			needed_libraries,
-			allow_missing_libraries,
-		)
-		.await;
+		return finalize_library_paths(tg, resolved_dirs, needed_libraries).await;
 	}
 
 	if !matches!(strategy, LibraryPathOptimizationLevel::Combine) {
@@ -781,15 +757,13 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 	let dir_id = directory.id(tg).await?;
 	let resolved_dirs = std::iter::once(dir_id.clone()).collect();
 
-	return finalize_library_paths(tg, resolved_dirs, needed_libraries, allow_missing_libraries)
-		.await;
+	return finalize_library_paths(tg, resolved_dirs, needed_libraries).await;
 }
 
 async fn finalize_library_paths<H: BuildHasher + Default>(
 	tg: &impl tg::Handle,
 	resolved_dirs: HashSet<tg::directory::Id, H>,
 	needed_libraries: &HashMap<String, Option<tg::directory::Id>, H>,
-	allow_missing_libraries: bool,
 ) -> tg::Result<HashSet<tg::symlink::Id, H>> {
 	futures::future::try_join_all(resolved_dirs.iter().map(|id| async {
 		tg::Artifact::from(tg::Directory::with_id(id.clone()))
@@ -799,7 +773,7 @@ async fn finalize_library_paths<H: BuildHasher + Default>(
 	}))
 	.await?;
 	let result = store_dirs_as_symlinks(tg, resolved_dirs).await?;
-	report_missing_libraries(tg, needed_libraries, &result, allow_missing_libraries).await?;
+	report_missing_libraries(tg, needed_libraries, &result).await?;
 	Ok(result)
 }
 
@@ -808,7 +782,6 @@ async fn report_missing_libraries<H: BuildHasher + Default>(
 	tg: &impl tg::Handle,
 	needed_libraries: &HashMap<String, Option<tg::directory::Id>, H>,
 	library_paths: &HashSet<tg::symlink::Id, H>,
-	allow_missing_libraries: bool,
 ) -> tg::Result<()> {
 	let mut found_libraries = HashSet::default();
 	for library in needed_libraries.keys() {
@@ -837,10 +810,7 @@ async fn report_missing_libraries<H: BuildHasher + Default>(
 		.difference(&found_libraries)
 		.collect_vec();
 	if !missing_libs.is_empty() {
-		tracing::error!("Could not find the following required libraries: {missing_libs:?}");
-		if !allow_missing_libraries {
-			return Err(tg::error!("missing libraries: {missing_libs:?}"));
-		}
+		tracing::warn!("Could not find the following required libraries: {missing_libs:?}");
 	}
 	Ok(())
 }

--- a/packages/std/packages/ld_proxy/src/main.rs
+++ b/packages/std/packages/ld_proxy/src/main.rs
@@ -488,7 +488,16 @@ async fn checkin_local_library_path(
 			tracing::debug!(?library_candidate_path, "analyzing library candidate path");
 
 			// Skip any non-files.
-			if !library_candidate_path.is_file() {
+			let metadata = tokio::fs::symlink_metadata(&library_candidate_path)
+				.await
+				.map_err(|error| {
+					tg::error!(
+						source = error,
+						?library_candidate_path,
+						"could not read metadata for path"
+					)
+				})?;
+			if !metadata.is_file() {
 				tracing::debug!("Skipping non-file entry.");
 				return Ok(None);
 			}

--- a/packages/std/packages/ld_proxy/src/main.rs
+++ b/packages/std/packages/ld_proxy/src/main.rs
@@ -145,7 +145,7 @@ fn read_options() -> tg::Result<Options> {
 				.collect_vec()
 		});
 
-	// Get the optional comma-separated list of allowed missing libraries.
+	// Check if we should allow producing wrappers that don't account for all needed libraries.
 	let mut allow_missing_libraries =
 		std::env::var("TANGRAM_LINKER_ALLOW_MISSING_LIBRARIES").is_ok();
 

--- a/packages/std/sdk/binutils.tg.ts
+++ b/packages/std/sdk/binutils.tg.ts
@@ -3,14 +3,14 @@ import * as std from "../tangram.tg.ts";
 
 export let metadata = {
 	name: "binutils",
-	version: "2.42",
+	version: "2.43",
 };
 
 export let source = tg.target(async (build: string) => {
 	let { name, version } = metadata;
 
 	let checksum =
-		"sha256:f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800";
+		"sha256:b53606f443ac8f01d1d5fc9c39497f2af322d99e14cea5c0b4b124d630379365";
 
 	return std.download.fromGnu({
 		name,

--- a/packages/std/sdk/cmake.tg.ts
+++ b/packages/std/sdk/cmake.tg.ts
@@ -7,13 +7,13 @@ export let metadata = {
 	license: "BSD-3-Clause",
 	name: "cmake",
 	repository: "https://gitlab.kitware.com/cmake/cmake",
-	version: "3.30.1",
+	version: "3.30.2",
 };
 
 export let source = tg.target(() => {
 	let { version } = metadata;
 	let checksum =
-		"sha256:df9b3c53e3ce84c3c1b7c253e5ceff7d8d1f084ff0673d048f260e04ccb346e1";
+		"sha256:46074c781eccebc433e98f0bbfa265ca3fd4381f245ca3b140e7711531d60db2";
 	let owner = "Kitware";
 	let repo = "CMake";
 	let tag = `v${version}`;

--- a/packages/std/sdk/gcc.tg.ts
+++ b/packages/std/sdk/gcc.tg.ts
@@ -12,7 +12,7 @@ export let metadata = {
 	license: "GPL-3.0-or-later",
 	name: "gcc",
 	repository: "https://gcc.gnu.org/git.html",
-	version: "14.1.0",
+	version: "14.2.0",
 };
 
 /** Produce a GCC source directory with the gmp, mpfr, isl, and mpc sources optionally included. */
@@ -22,7 +22,7 @@ export let source = tg.target((bundledSources?: boolean) => {
 	// Download and unpack the GCC source.
 	let extension = ".tar.xz";
 	let checksum =
-		"sha256:e283c654987afe3de9d8080bc0bd79534b5ca0d681a73a11ff2b5d3767426840";
+		"sha256:a7b39bc69cbf9e25826c5a60ab26477001f7c08d85cec04bc0e29cabed6f3cc9";
 	let base = `https://mirrors.ocf.berkeley.edu/gnu/${name}/${name}-${version}`;
 	let sourceDir = std
 		.download({ checksum, base, name, version, extension })

--- a/packages/std/sdk/kernel_headers.tg.ts
+++ b/packages/std/sdk/kernel_headers.tg.ts
@@ -6,13 +6,13 @@ export let metadata = {
 	license: "GPLv2",
 	name: "linux",
 	repository: "https://git.kernel.org",
-	version: "6.10.2",
+	version: "6.10.3",
 };
 
 export let source = tg.target(async () => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:73d8520dd9cba5acfc5e7208e76b35d9740b8aae38210a9224e32ec4c0d29b70";
+		"sha256:fa5f22fd67dd05812d39dca579320c493048e26c4a556048a12385e7ae6fc698";
 	let extension = ".tar.xz";
 	let majorVersion = version.split(".")[0];
 	let base = `https://cdn.kernel.org/pub/linux/kernel/v${majorVersion}.x`;

--- a/packages/std/sdk/libc/glibc.tg.ts
+++ b/packages/std/sdk/libc/glibc.tg.ts
@@ -3,7 +3,7 @@ import * as std from "../../tangram.tg.ts";
 // Define supported versions.
 type GlibcVersion = "2.37" | "2.38" | "2.39" | "2.40";
 export let AllGlibcVersions = ["2.37", "2.38", "2.39", "2.40"];
-export let defaultGlibcVersion: GlibcVersion = "2.40";
+export let defaultGlibcVersion: GlibcVersion = "2.39";
 
 export let metadata = {
 	homepage: "https://www.gnu.org/software/libc/",

--- a/packages/std/sdk/llvm.tg.ts
+++ b/packages/std/sdk/llvm.tg.ts
@@ -88,14 +88,9 @@ export let toolchain = tg.target(async (arg?: LLVMArg) => {
 
 	// Obtain a sysroot for the requested host.
 
-	// For gnu hosts, pin to glibc2.39.
-	let sysrootHost =
-		std.triple.environment(host) === "gnu"
-			? std.triple.create(host, { environmentVersion: "2.39" })
-			: host;
 	let sysroot = await constructSysroot({
 		env: std.env.arg(bisonForBuild, m4ForBuild, pythonForBuild),
-		host: sysrootHost,
+		host,
 	})
 		.then((dir) => dir.get(host))
 		.then(tg.Directory.expect);

--- a/packages/std/sdk/proxy.tg.ts
+++ b/packages/std/sdk/proxy.tg.ts
@@ -382,6 +382,8 @@ let makeShared = async (arg: tg.Unresolved<MakeSharedArg>) => {
 /** This test further exercises the the proxy by providing transitive dynamic dependencies both via -L and via -Wl,-rpath. */
 export let testTransitive = tg.target(async () => {
 	let bootstrapSDK = await bootstrap.sdk();
+	let dylibExt =
+		std.triple.os(await std.triple.host()) === "darwin" ? "dylib" : "so";
 	let constantsSourceA = await tg.file(`
 const char* getGreeting() {
 	return "Hello from transitive constants A!";
@@ -486,7 +488,7 @@ const char* getGreeting() {
 		`);
 	let output = await tg
 		.target(
-			tg`cc -v -L${greetA}/lib -L${constantsA}/lib -lconstantsa -I${greetA}/include -lgreeta -I${constantsB}/include -L${constantsB}/lib -I${greetB}/include -L${greetB}/lib -Wl,-rpath,${greetB}/lib ${greetB}/lib/libgreetb.so -lgreetb -xc ${mainSource} -o $OUTPUT`,
+			tg`cc -v -L${greetA}/lib -L${constantsA}/lib -lconstantsa -I${greetA}/include -lgreeta -I${constantsB}/include -L${constantsB}/lib -I${greetB}/include -L${greetB}/lib -Wl,-rpath,${greetB}/lib ${greetB}/lib/libgreetb.${dylibExt} -lgreetb -xc ${mainSource} -o $OUTPUT`,
 			{
 				env: await std.env.arg(bootstrapSDK, {
 					TANGRAM_LD_PROXY_TRACING: "tangram=trace",

--- a/packages/std/sdk/proxy.tg.ts
+++ b/packages/std/sdk/proxy.tg.ts
@@ -308,6 +308,15 @@ export let ldProxy = async (arg: LdProxyArg) => {
 };
 
 export let test = tg.target(async () => {
+	let basicResult = await testBasic();
+	console.log("basic result", await basicResult.id());
+	let transitiveResult = await testTransitive();
+	console.log("transitive result", await transitiveResult.id());
+	return transitiveResult;
+});
+
+/** This test ensures the proxy produces a correct wrapper for a basic case with no transitive dynamic dependencies. */
+export let testBasic = tg.target(async () => {
 	let bootstrapSDK = await bootstrap.sdk();
 	let helloSource = await tg.file(`
 #include <stdio.h>
@@ -316,23 +325,177 @@ int main() {
 	return 0;
 }
 	`);
-	let output = tg.File.expect(
-		await (
-			await tg.target(
-				tg`
+	let output = await tg
+		.target(
+			tg`
 				set -x
 				/usr/bin/env
 				cc -v -xc ${helloSource} -o $OUTPUT`,
-				{
-					env: await std.env.arg(bootstrapSDK, {
-						TANGRAM_LD_PROXY_TRACING: "tangram=trace",
-						TANGRAM_LINKER_LIBRARY_PATH_OPT_LEVEL: "combine",
-						TANGRAM_WRAPPER_TRACING: "tangram=trace",
-					}),
-				},
-			)
-		).output(),
-	);
+			{
+				env: await std.env.arg(bootstrapSDK, {
+					TANGRAM_LD_PROXY_TRACING: "tangram=trace",
+					TANGRAM_LINKER_LIBRARY_PATH_OPT_LEVEL: "combine",
+					TANGRAM_WRAPPER_TRACING: "tangram=trace",
+				}),
+			},
+		)
+		.then((t) => t.output())
+		.then(tg.File.expect);
+	let manifest = await std.wrap.Manifest.read(output);
+	console.log("\n\nMANIFEST", manifest);
+	let result = await tg
+		.target(tg`${output} > $OUTPUT`, {
+			env: {
+				TANGRAM_WRAPPER_TRACING: "tangram=trace",
+			},
+		})
+		.then((t) => t.output())
+		.then(tg.File.expect);
+	let text = await result.text();
+	tg.assert(text.includes("Hello from a TGLD-wrapped binary!"));
+	return output;
+});
+
+type MakeSharedArg = {
+	flags?: Array<tg.Template.Arg>;
+	libName: string;
+	sdk: std.env.Arg;
+	source: tg.File;
+};
+
+let makeShared = async (arg: tg.Unresolved<MakeSharedArg>) => {
+	let { flags: flagArgs = [], libName, sdk, source } = await tg.resolve(arg);
+	let flags = tg.Template.join(" ", ...flagArgs);
+	let dylibExt =
+		std.triple.os(await std.triple.host()) === "darwin" ? "dylib" : "so";
+	return await tg
+		.target(
+			tg`mkdir -p $OUTPUT/lib && cc -shared -xc ${source} -o $OUTPUT/lib/${libName}.${dylibExt} ${flags}`,
+			{
+				env: std.env.arg(sdk),
+			},
+		)
+		.then((t) => t.output())
+		.then(tg.Directory.expect);
+};
+
+/** This test further exercises the the proxy by providing transitive dynamic dependencies both via -L and via -Wl,-rpath. */
+export let testTransitive = tg.target(async () => {
+	let bootstrapSDK = await bootstrap.sdk();
+	let constantsSourceA = await tg.file(`
+const char* getGreeting() {
+	return "Hello from transitive constants A!";
+}
+	`);
+	let constantsHeader = await tg.file(`
+const char* getGreeting();
+	`);
+
+	let constantsA = await makeShared({
+		libName: "libconstantsa",
+		sdk: bootstrapSDK,
+		source: constantsSourceA,
+	});
+	constantsA = await tg.directory(constantsA, {
+		include: {
+			"constants.h": constantsHeader,
+		},
+	});
+	console.log("STRING CONSTANTS A", await constantsA.id());
+
+	let constantsSourceB = await tg.file(`
+const char* getGreeting() {
+	return "Hello from transitive constants B!";
+}
+		`);
+	let constantsB = await makeShared({
+		libName: "libconstantsb",
+		sdk: bootstrapSDK,
+		source: constantsSourceB,
+	});
+	constantsB = await tg.directory(constantsB, {
+		include: {
+			"constants.h": constantsHeader,
+		},
+	});
+	console.log("STRING CONSTANTS B", await constantsB.id());
+
+	let greetSourceA = await tg.file(`
+	#include <stdio.h>
+	#include <constants.h>
+	void greet_a() {
+		printf("%s\\n", getGreeting());
+	}
+			`);
+	let greetHeaderA = await tg.file(`
+	const char* greet_a();
+			`);
+	let greetA = await makeShared({
+		flags: [
+			tg`-L${constantsA}/lib`,
+			tg`-I${constantsA}/include`,
+			"-lconstantsa",
+		],
+		libName: "libgreeta",
+		sdk: bootstrapSDK,
+		source: greetSourceA,
+	});
+	greetA = await tg.directory(greetA, {
+		include: {
+			"greeta.h": greetHeaderA,
+		},
+	});
+	console.log("GREET A", await greetA.id());
+
+	let greetSourceB = await tg.file(`
+	#include <stdio.h>
+	#include <constants.h>
+	void greet_b() {
+		printf("%s\\n", getGreeting());
+	}
+			`);
+	let greetHeaderB = await tg.file(`
+	const char* greet_b();
+			`);
+	let greetB = await makeShared({
+		flags: [
+			tg`-L${constantsB}/lib`,
+			tg`-I${constantsB}/include`,
+			"-lconstantsb",
+		],
+		libName: "libgreetb",
+		sdk: bootstrapSDK,
+		source: greetSourceB,
+	});
+	greetB = await tg.directory(greetB, {
+		include: {
+			"greetb.h": greetHeaderB,
+		},
+	});
+	console.log("GREET B", await greetB.id());
+
+	let mainSource = await tg.file(`
+	#include <stdio.h>
+	#include <greeta.h>
+	#include <greetb.h>
+	int main() {
+		greet_a();
+		greet_b();
+		return 0;
+	}
+		`);
+	let output = await tg
+		.target(
+			tg`cc -v -L${greetA}/lib -L${constantsA}/lib -lconstantsa -I${greetA}/include -lgreeta -I${constantsB}/include -L${constantsB}/lib -I${greetB}/include -L${greetB}/lib -Wl,-rpath,${greetB}/lib ${greetB}/lib/libgreetb.so -lgreetb -xc ${mainSource} -o $OUTPUT`,
+			{
+				env: await std.env.arg(bootstrapSDK, {
+					TANGRAM_LD_PROXY_TRACING: "tangram=trace",
+					TANGRAM_LINKER_LIBRARY_PATH_OPT_LEVEL: "combine",
+				}),
+			},
+		)
+		.then((t) => t.output())
+		.then(tg.File.expect);
 	let manifest = await std.wrap.Manifest.read(output);
 	console.log("\n\nMANIFEST", manifest);
 	let result = tg.File.expect(
@@ -345,6 +508,10 @@ int main() {
 		).output(),
 	);
 	let text = await result.text();
-	tg.assert(text.includes("Hello from a TGLD-wrapped binary!"));
+	tg.assert(
+		text.includes(
+			"Hello from transitive constants A!\nHello from transitive constants B!",
+		),
+	);
 	return output;
 });

--- a/packages/std/utils/findutils.tg.ts
+++ b/packages/std/utils/findutils.tg.ts
@@ -7,13 +7,13 @@ import disableLocatePatch from "./findutils-disable-locate.diff" with {
 
 export let metadata = {
 	name: "findutils",
-	version: "4.9.0",
+	version: "4.10.0",
 };
 
 export let source = tg.target(async (os: string) => {
 	let { name, version } = metadata;
 	let checksum =
-		"sha256:a2bfb8c09d436770edc59f50fa483e785b161a3b7b9d547573cb08065fd462fe";
+		"sha256:1387e0b67ff247d2abde998f90dfbf70c1491391a59ddfecb8ae698789f0a4f5";
 	let source = await std.download.fromGnu({
 		name,
 		version,


### PR DESCRIPTION
This PR updates the LD proxy to correctly produce wrappers which pull in libraries from library paths in the working build tree.

It additionally cleans up additional now-unnecessary post-processing for package builds which depended on this behavior: `curl`, `fftw`, `gettext`, `icu`, `libcap`, `postgresql`.

Additional fixes:

- Strip libtool archives by default from autotools builds, with option to retain
- Correct curl build
- More robust ld proxy tests
- findutils v4.10, GCC 14.2, binutils 2.43, linux 6.10.3, cmake 3.30.2