### PR TITLE
refactor: symlink target variant

### DIFF
--- a/packages/cmake/tangram.ts
+++ b/packages/cmake/tangram.ts
@@ -13,13 +13,13 @@ export const metadata = {
 	license: "BSD-3-Clause",
 	name: "cmake",
 	repository: "https://gitlab.kitware.com/cmake/cmake",
-	version: "3.30.5",
+	version: "3.31.1",
 };
 
 export const source = tg.target(() => {
 	const { version } = metadata;
 	const checksum =
-		"sha256:9f55e1a40508f2f29b7e065fa08c29f82c402fa0402da839fffe64a25755a86d";
+		"sha256:c4fc2a9bd0cd5f899ccb2fb81ec422e175090bc0de5d90e906dd453b53065719";
 	const owner = "Kitware";
 	const repo = "CMake";
 	const tag = `v${version}`;

--- a/packages/curl/tangram.ts
+++ b/packages/curl/tangram.ts
@@ -12,13 +12,13 @@ export const metadata = {
 	license: "MIT",
 	name: "curl",
 	repository: "https://github.com/curl/curl",
-	version: "8.10.0",
+	version: "8.11.0",
 };
 
 export const source = tg.target(() => {
 	const { name, version } = metadata;
 	const checksum =
-		"sha256:58c9dcf73493ae9d181fd334b3b3987ff73124621565187ade237bff1064a716";
+		"sha256:264537d90e58d2b09dddc50944baf3c38e7089151c8986715e2aaeaaf2b8118f";
 	const owner = name;
 	const repo = name;
 	const tag = `curl-${version.replace(/\./g, "_")}`;

--- a/packages/git/tangram.ts
+++ b/packages/git/tangram.ts
@@ -10,7 +10,7 @@ export const metadata = {
 	license: "GPL-2.0-only",
 	name: "git",
 	repository: "https://github.com/git/git",
-	version: "2.47.0",
+	version: "2.47.1",
 };
 
 export const source = tg.target(async () => {
@@ -18,7 +18,7 @@ export const source = tg.target(async () => {
 	const extension = ".tar.xz";
 	const base = `https://mirrors.edge.kernel.org/pub/software/scm/${name}`;
 	const checksum =
-		"sha256:1ce114da88704271b43e027c51e04d9399f8c88e9ef7542dae7aebae7d87bc4e";
+		"sha256:f3d8f9bb23ae392374e91cd9d395970dabc5b9c5ee72f39884613cd84a6ed310";
 	return await std
 		.download({ base, checksum, name, version, extension })
 		.then(tg.Directory.expect)

--- a/packages/libxml2/tangram.ts
+++ b/packages/libxml2/tangram.ts
@@ -13,13 +13,13 @@ export const metadata = {
 	license: "https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright",
 	name: "libxml2",
 	repository: "https://gitlab.gnome.org/GNOME/libxml2/-/tree/master",
-	version: "2.13.4",
+	version: "2.13.5",
 };
 
 export const source = tg.target(async (): Promise<tg.Directory> => {
 	const { name, version } = metadata;
 	const checksum =
-		"sha256:65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650";
+		"sha256:74fc163217a3964257d3be39af943e08861263c4231f9ef5b496b6f6d4c7b2b6";
 	const extension = ".tar.xz";
 	const majorMinor = version.split(".").slice(0, 2).join(".");
 	const base = `https://download.gnome.org/sources/${name}/${majorMinor}`;

--- a/packages/linux/tangram.ts
+++ b/packages/linux/tangram.ts
@@ -6,13 +6,13 @@ export const metadata = {
 	license: "GPLv2",
 	name: "linux",
 	repository: "https://git.kernel.org",
-	version: "6.9.6",
+	version: "6.12.1",
 };
 
 export const source = tg.target(async () => {
 	const { name, version } = metadata;
 	const checksum =
-		"sha256:5d4366e2b89998f274abe03557ef3bc78b58e47fc62c102d51e6f49e5ed96b4b";
+		"sha256:0193b1d86dd372ec891bae799f6da20deef16fc199f30080a4ea9de8cef0c619";
 	const extension = ".tar.xz";
 	const base = `https://cdn.kernel.org/pub/linux/kernel/v6.x`;
 	return await std

--- a/packages/mold/tangram.ts
+++ b/packages/mold/tangram.ts
@@ -9,13 +9,13 @@ export const metadata = {
 	license: "MIT",
 	name: "mold",
 	repository: "https://github.com/rui314/mold",
-	version: "2.32.1",
+	version: "2.34.1",
 };
 
 export const source = () => {
 	const { name, version } = metadata;
 	const checksum =
-		"sha256:f3c9a527d884c635834fe7d79b3de959b00783bf9446280ea274d996f0335825";
+		"sha256:a8cf638045b4a4b2697d0bcc77fd96eae93d54d57ad3021bf03b0333a727a59d";
 	const owner = "rui314";
 	const repo = name;
 	const tag = `v${version}`;

--- a/packages/python/tangram.ts
+++ b/packages/python/tangram.ts
@@ -6,6 +6,7 @@ import * as bzip2 from "bzip2" with { path: "../bzip2" };
 import * as libffi from "libffi" with { path: "../libffi" };
 import * as libxcrypt from "libxcrypt" with { path: "../libxcrypt" };
 import * as m4 from "m4" with { path: "../m4" };
+import * as mpdecimal from "mpdecimal" with { path: "../mpdecimal" };
 import * as ncurses from "ncurses" with { path: "../ncurses" };
 import * as openssl from "openssl" with { path: "../openssl" };
 import * as pkgConfig from "pkgconf" with { path: "../pkgconf" };
@@ -53,6 +54,7 @@ export type Arg = {
 		bzip2?: bzip2.Arg;
 		libffi?: libffi.Arg;
 		libxcrypt?: libxcrypt.Arg;
+		mpdecimal?: mpdecimal.Arg;
 		ncurses?: ncurses.Arg;
 		openssl?: openssl.Arg;
 		readline?: readline.Arg;
@@ -91,6 +93,7 @@ export const toolchain = tg.target(async (...args: std.Args<Arg>) => {
 			bzip2: bzip2Arg = {},
 			libffi: libffiArg = {},
 			libxcrypt: libxcryptArg = {},
+			mpdecimal: mpdecimalArg = {},
 			ncurses: ncursesArg = {},
 			openssl: opensslArg = {},
 			readline: readlineArg = {},
@@ -145,6 +148,10 @@ export const toolchain = tg.target(async (...args: std.Args<Arg>) => {
 		.default_({ build, host, sdk }, opensslArg)
 		.then((d) => std.directory.keepSubdirectories(d, "include", "lib"));
 	hostDependencies.push(opensslForHost);
+	const mpdecimalForHost = await mpdecimal
+		.default_({ build, host, sdk }, mpdecimalArg)
+		.then((d) => std.directory.keepSubdirectories(d, "include", "lib"));
+	hostDependencies.push(mpdecimalForHost);
 	const readlineForHost = await readline
 		.default_({ build, host, sdk }, readlineArg)
 		.then((d) => std.directory.keepSubdirectories(d, "include", "lib"));
@@ -190,6 +197,11 @@ export const toolchain = tg.target(async (...args: std.Args<Arg>) => {
 	if (os === "darwin") {
 		env.push({ MACOSX_DEPLOYMENT_TARGET: "15.1" });
 	}
+	if (os === "linux") {
+		env.push({
+			CFLAGS: tg.Mutation.suffix("-Wno-implicit-function-declaration", " "),
+		});
+	}
 
 	const configureArgs: Array<string> = [];
 
@@ -222,9 +234,12 @@ export const toolchain = tg.target(async (...args: std.Args<Arg>) => {
 		autotools,
 	);
 
-	const libraryPaths = [libffiForHost, opensslForHost, zlibForHost].map((dir) =>
-		dir.get("lib").then(tg.Directory.expect),
-	);
+	const libraryPaths = [
+		libffiForHost,
+		mpdecimalForHost,
+		opensslForHost,
+		zlibForHost,
+	].map((dir) => dir.get("lib").then(tg.Directory.expect));
 
 	const pythonInterpreter = await std.wrap(
 		tg.symlink(tg`${output}/bin/python${versionString()}`),

--- a/packages/python/tangram.ts
+++ b/packages/python/tangram.ts
@@ -197,11 +197,6 @@ export const toolchain = tg.target(async (...args: std.Args<Arg>) => {
 	if (os === "darwin") {
 		env.push({ MACOSX_DEPLOYMENT_TARGET: "15.1" });
 	}
-	if (os === "linux") {
-		env.push({
-			CFLAGS: tg.Mutation.suffix("-Wno-implicit-function-declaration", " "),
-		});
-	}
 
 	const configureArgs: Array<string> = [];
 

--- a/packages/rust/cargo.tg.ts
+++ b/packages/rust/cargo.tg.ts
@@ -294,10 +294,7 @@ const vendoredSources = async (
 		const sourcePath = manifestSubdir
 			? source.get(manifestSubdir).then(tg.Directory.expect)
 			: source;
-		const cargoLock = await (
-			await tg.symlink(sourcePath, "Cargo.lock")
-		).resolve();
-		tg.assert(cargoLock instanceof tg.File);
+		const cargoLock = sourcePath.get("Cargo.lock").then(tg.File.expect);
 		const vendoredSources = vendorDependencies(cargoLock);
 		return tg`
 [source.crates-io]

--- a/packages/rust/proxy/Cargo.lock
+++ b/packages/rust/proxy/Cargo.lock
@@ -186,9 +186,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -230,7 +230,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -241,7 +241,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -312,7 +312,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "unicode-xid",
 ]
 
@@ -334,7 +334,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -439,7 +439,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -532,9 +532,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hermit-abi"
@@ -768,7 +768,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -816,7 +816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -837,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a73e9fe3c49d7afb2ace819fa181a287ce54a0983eda4e0eb05c22f82ffe534"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
@@ -858,15 +858,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.165"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "fcb4d3d38eab6c5239a362fa8bae48c03baf980a6e7079f063942d563ef3533e"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -1086,7 +1086,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1109,9 +1109,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1198,7 +1198,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1221,7 +1221,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1263,7 +1263,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1351,9 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1362,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -1374,13 +1374,13 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=4bf875fd46d30093480dfb5d7afd166e3dccba98#4bf875fd46d30093480dfb5d7afd166e3dccba98"
+source = "git+https://github.com/tangramdotdev/tangram?rev=870458978819174b491efc873ad4531c3f85fe74#870458978819174b491efc873ad4531c3f85fe74"
 dependencies = [
  "blake3",
  "bytes",
@@ -1423,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "tangram_either"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=4bf875fd46d30093480dfb5d7afd166e3dccba98#4bf875fd46d30093480dfb5d7afd166e3dccba98"
+source = "git+https://github.com/tangramdotdev/tangram?rev=870458978819174b491efc873ad4531c3f85fe74#870458978819174b491efc873ad4531c3f85fe74"
 dependencies = [
  "serde",
 ]
@@ -1431,7 +1431,7 @@ dependencies = [
 [[package]]
 name = "tangram_futures"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=4bf875fd46d30093480dfb5d7afd166e3dccba98#4bf875fd46d30093480dfb5d7afd166e3dccba98"
+source = "git+https://github.com/tangramdotdev/tangram?rev=870458978819174b491efc873ad4531c3f85fe74#870458978819174b491efc873ad4531c3f85fe74"
 dependencies = [
  "dashmap",
  "futures",
@@ -1444,7 +1444,7 @@ dependencies = [
 [[package]]
 name = "tangram_http"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=4bf875fd46d30093480dfb5d7afd166e3dccba98#4bf875fd46d30093480dfb5d7afd166e3dccba98"
+source = "git+https://github.com/tangramdotdev/tangram?rev=870458978819174b491efc873ad4531c3f85fe74#870458978819174b491efc873ad4531c3f85fe74"
 dependencies = [
  "bytes",
  "erased-serde",
@@ -1479,7 +1479,7 @@ dependencies = [
 [[package]]
 name = "tangram_uri"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=4bf875fd46d30093480dfb5d7afd166e3dccba98#4bf875fd46d30093480dfb5d7afd166e3dccba98"
+source = "git+https://github.com/tangramdotdev/tangram?rev=870458978819174b491efc873ad4531c3f85fe74#870458978819174b491efc873ad4531c3f85fe74"
 dependencies = [
  "derive_more",
  "once_cell",
@@ -1490,7 +1490,7 @@ dependencies = [
 [[package]]
 name = "tangram_version"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=4bf875fd46d30093480dfb5d7afd166e3dccba98#4bf875fd46d30093480dfb5d7afd166e3dccba98"
+source = "git+https://github.com/tangramdotdev/tangram?rev=870458978819174b491efc873ad4531c3f85fe74#870458978819174b491efc873ad4531c3f85fe74"
 dependencies = [
  "derive_more",
  "winnow",
@@ -1574,7 +1574,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1625,14 +1625,14 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1714,9 +1714,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1800,7 +1800,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "wasm-bindgen-shared",
 ]
 
@@ -1822,7 +1822,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1960,9 +1960,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -1972,34 +1972,34 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "synstructure",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "synstructure",
 ]
 
@@ -2022,5 +2022,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]

--- a/packages/rust/proxy/Cargo.toml
+++ b/packages/rust/proxy/Cargo.toml
@@ -20,7 +20,7 @@ futures = "0.3"
 itertools = "0.13"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "4bf875fd46d30093480dfb5d7afd166e3dccba98" }
+tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "870458978819174b491efc873ad4531c3f85fe74" }
 tokio = { version = "1", default-features = false, features = [
   "rt",
   "fs",

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -186,9 +186,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -230,7 +230,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -241,7 +241,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -312,7 +312,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "unicode-xid",
 ]
 
@@ -334,7 +334,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -455,7 +455,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -559,9 +559,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hermit-abi"
@@ -795,7 +795,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -843,7 +843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -864,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a73e9fe3c49d7afb2ace819fa181a287ce54a0983eda4e0eb05c22f82ffe534"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
@@ -885,9 +885,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.165"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "fcb4d3d38eab6c5239a362fa8bae48c03baf980a6e7079f063942d563ef3533e"
 
 [[package]]
 name = "linux-raw-sys"
@@ -897,9 +897,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -1119,7 +1119,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1148,9 +1148,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1250,7 +1250,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1270,7 +1270,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1293,7 +1293,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1335,7 +1335,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1423,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1434,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -1446,7 +1446,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=4bf875fd46d30093480dfb5d7afd166e3dccba98#4bf875fd46d30093480dfb5d7afd166e3dccba98"
+source = "git+https://github.com/tangramdotdev/tangram?rev=870458978819174b491efc873ad4531c3f85fe74#870458978819174b491efc873ad4531c3f85fe74"
 dependencies = [
  "blake3",
  "bytes",
@@ -1508,7 +1508,7 @@ dependencies = [
 [[package]]
 name = "tangram_either"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=4bf875fd46d30093480dfb5d7afd166e3dccba98#4bf875fd46d30093480dfb5d7afd166e3dccba98"
+source = "git+https://github.com/tangramdotdev/tangram?rev=870458978819174b491efc873ad4531c3f85fe74#870458978819174b491efc873ad4531c3f85fe74"
 dependencies = [
  "serde",
 ]
@@ -1516,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "tangram_futures"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=4bf875fd46d30093480dfb5d7afd166e3dccba98#4bf875fd46d30093480dfb5d7afd166e3dccba98"
+source = "git+https://github.com/tangramdotdev/tangram?rev=870458978819174b491efc873ad4531c3f85fe74#870458978819174b491efc873ad4531c3f85fe74"
 dependencies = [
  "dashmap",
  "futures",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "tangram_http"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=4bf875fd46d30093480dfb5d7afd166e3dccba98#4bf875fd46d30093480dfb5d7afd166e3dccba98"
+source = "git+https://github.com/tangramdotdev/tangram?rev=870458978819174b491efc873ad4531c3f85fe74#870458978819174b491efc873ad4531c3f85fe74"
 dependencies = [
  "bytes",
  "erased-serde",
@@ -1593,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "tangram_uri"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=4bf875fd46d30093480dfb5d7afd166e3dccba98#4bf875fd46d30093480dfb5d7afd166e3dccba98"
+source = "git+https://github.com/tangramdotdev/tangram?rev=870458978819174b491efc873ad4531c3f85fe74#870458978819174b491efc873ad4531c3f85fe74"
 dependencies = [
  "derive_more",
  "once_cell",
@@ -1604,7 +1604,7 @@ dependencies = [
 [[package]]
 name = "tangram_version"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=4bf875fd46d30093480dfb5d7afd166e3dccba98#4bf875fd46d30093480dfb5d7afd166e3dccba98"
+source = "git+https://github.com/tangramdotdev/tangram?rev=870458978819174b491efc873ad4531c3f85fe74#870458978819174b491efc873ad4531c3f85fe74"
 dependencies = [
  "derive_more",
  "winnow",
@@ -1715,7 +1715,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1766,14 +1766,14 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1856,9 +1856,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1942,7 +1942,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "wasm-bindgen-shared",
 ]
 
@@ -1964,7 +1964,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2111,9 +2111,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -2123,34 +2123,34 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "synstructure",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "synstructure",
 ]
 
@@ -2173,5 +2173,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -33,7 +33,7 @@ itertools = "0.13"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "4bf875fd46d30093480dfb5d7afd166e3dccba98" }
+tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "870458978819174b491efc873ad4531c3f85fe74" }
 tempfile = "3"
 tokio = { version = "1", default-features = false, features = [
   "rt",

--- a/packages/std/packages/std/lib.rs
+++ b/packages/std/packages/std/lib.rs
@@ -13,21 +13,20 @@ pub fn template_data_to_symlink_data(
 ) -> tg::Result<tg::symlink::Data> {
 	let components = template.components;
 	match components.as_slice() {
-		[tg::template::component::Data::String(s)] => Ok(tg::symlink::Data::Normal {
-			artifact: None,
-			subpath: Some(s.into()),
-		}),
+		[tg::template::component::Data::String(s)] => {
+			Ok(tg::symlink::Data::Target { target: s.into() })
+		},
 		[tg::template::component::Data::Artifact(id)]
 		| [tg::template::component::Data::String(_), tg::template::component::Data::Artifact(id)] => {
-			Ok(tg::symlink::Data::Normal {
-				artifact: Some(id.clone()),
+			Ok(tg::symlink::Data::Artifact {
+				artifact: id.clone(),
 				subpath: None,
 			})
 		},
 		[tg::template::component::Data::Artifact(artifact_id), tg::template::component::Data::String(s)]
 		| [tg::template::component::Data::String(_), tg::template::component::Data::Artifact(artifact_id), tg::template::component::Data::String(s)] => {
-			Ok(tg::symlink::Data::Normal {
-				artifact: Some(artifact_id.clone()),
+			Ok(tg::symlink::Data::Artifact {
+				artifact: artifact_id.clone(),
 				subpath: Some(s.chars().skip(1).collect::<String>().into()),
 			})
 		},

--- a/packages/std/packages/std/manifest.rs
+++ b/packages/std/packages/std/manifest.rs
@@ -226,7 +226,7 @@ impl TryFrom<tg::template::Data> for ArtifactPath {
 impl From<ArtifactPath> for tg::Symlink {
 	fn from(artifact_path: ArtifactPath) -> Self {
 		let artifact = tg::Artifact::with_id(artifact_path.artifact);
-		tg::Symlink::with_artifact_and_subpath(Some(artifact), artifact_path.subpath)
+		tg::Symlink::with_artifact_and_subpath(artifact, artifact_path.subpath)
 	}
 }
 

--- a/packages/std/packages/strip_proxy/src/main.rs
+++ b/packages/std/packages/strip_proxy/src/main.rs
@@ -158,10 +158,12 @@ async fn run_proxy(
 		#[cfg(feature = "tracing")]
 		tracing::info!(?stripped_file_id, "checked in the stripped executable");
 
+		#[cfg(feature = "tracing")]
 		if let Err(e) = tmpdir.close() {
-			#[cfg(feature = "tracing")]
 			tracing::warn!(?e, "failed to close tempdir");
 		}
+		#[cfg(not(feature = "tracing"))]
+		let _ = tmpdir.close();
 
 		// Produce a new manifest with the stripped executable, and the rest of the manifest unchanged.
 		let new_manifest = Manifest {

--- a/packages/std/sdk/cmake.tg.ts
+++ b/packages/std/sdk/cmake.tg.ts
@@ -7,13 +7,13 @@ export const metadata = {
 	license: "BSD-3-Clause",
 	name: "cmake",
 	repository: "https://gitlab.kitware.com/cmake/cmake",
-	version: "3.30.5",
+	version: "3.31.1",
 };
 
 export const source = tg.target(() => {
 	const { version } = metadata;
 	const checksum =
-		"sha256:9f55e1a40508f2f29b7e065fa08c29f82c402fa0402da839fffe64a25755a86d";
+		"sha256:c4fc2a9bd0cd5f899ccb2fb81ec422e175090bc0de5d90e906dd453b53065719";
 	const owner = "Kitware";
 	const repo = "CMake";
 	const tag = `v${version}`;

--- a/packages/std/sdk/kernel_headers.tg.ts
+++ b/packages/std/sdk/kernel_headers.tg.ts
@@ -6,13 +6,13 @@ export const metadata = {
 	license: "GPLv2",
 	name: "linux",
 	repository: "https://git.kernel.org",
-	version: "6.11.7",
+	version: "6.12.1",
 };
 
 export const source = tg.target(async () => {
 	const { name, version } = metadata;
 	const checksum =
-		"sha256:0bf5ec644817d7928920f763581311f5bf258a92759cf2f30985da743af3ebb2";
+		"sha256:0193b1d86dd372ec891bae799f6da20deef16fc199f30080a4ea9de8cef0c619";
 	const extension = ".tar.xz";
 	const majorVersion = version.split(".")[0];
 	const base = `https://cdn.kernel.org/pub/linux/kernel/v${majorVersion}.x`;

--- a/packages/std/sdk/libc/musl.tg.ts
+++ b/packages/std/sdk/libc/musl.tg.ts
@@ -70,7 +70,9 @@ export const build = tg.target(async (arg?: Arg) => {
 	};
 
 	// The ld-musl symlink installed by default points to a broken absolute path that cannot be checked in. Replace with a relative symlink.
-	const fixup = `cd $OUTPUT/${host}/lib && rm ${interpreterName(host)} && ln -s libc.so ${interpreterName(host)}`;
+	const fixup = `cd $OUTPUT/${host}/lib && rm ${interpreterName(
+		host,
+	)} && ln -s libc.so ${interpreterName(host)}`;
 
 	const phases = {
 		configure,

--- a/packages/std/sdk/llvm.tg.ts
+++ b/packages/std/sdk/llvm.tg.ts
@@ -24,13 +24,13 @@ export const metadata = {
 	license:
 		"https://github.com/llvm/llvm-project/blob/991cfd1379f7d5184a3f6306ac10cabec742bbd2/LICENSE.TXT",
 	repository: "https://github.com/llvm/llvm-project/",
-	version: "18.1.8",
+	version: "19.1.4",
 };
 
 export const source = tg.target(async () => {
 	const { name, version } = metadata;
 	const checksum =
-		"sha256:0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a";
+		"sha256:3aa2d2d2c7553164ad5c6f3b932b31816e422635e18620c9349a7da95b98d811";
 	const owner = name;
 	const repo = "llvm-project";
 	const tag = `llvmorg-${version}`;
@@ -78,6 +78,11 @@ export const toolchain = tg.target(async (arg?: LLVMArg) => {
 		host: build,
 		env: m4ForBuild,
 	});
+	const perlForBuild = dependencies.perl.build({
+		build,
+		host: build,
+		env: std.env.arg(m4ForBuild, bisonForBuild)
+	});
 	const pythonForBuild = dependencies.python.build({
 		build,
 		host: build,
@@ -89,6 +94,7 @@ export const toolchain = tg.target(async (arg?: LLVMArg) => {
 		git({ build, host: build }),
 		bisonForBuild,
 		m4ForBuild,
+		perlForBuild,
 		pythonForBuild,
 		ncursesArtifact,
 		zlibArtifact,

--- a/packages/std/sdk/llvm.tg.ts
+++ b/packages/std/sdk/llvm.tg.ts
@@ -81,7 +81,7 @@ export const toolchain = tg.target(async (arg?: LLVMArg) => {
 	const perlForBuild = dependencies.perl.build({
 		build,
 		host: build,
-		env: std.env.arg(m4ForBuild, bisonForBuild)
+		env: std.env.arg(m4ForBuild, bisonForBuild),
 	});
 	const pythonForBuild = dependencies.python.build({
 		build,

--- a/packages/std/sdk/llvm/git.tg.ts
+++ b/packages/std/sdk/llvm/git.tg.ts
@@ -3,7 +3,7 @@ import zlib from "../dependencies/zlib.tg.ts";
 
 const metadata = {
 	name: "git",
-	version: "2.47.0",
+	version: "2.47.1",
 };
 
 export const source = tg.target(async () => {
@@ -11,7 +11,7 @@ export const source = tg.target(async () => {
 	const extension = ".tar.xz";
 	const base = `https://mirrors.edge.kernel.org/pub/software/scm/git`;
 	const checksum =
-		"sha256:1ce114da88704271b43e027c51e04d9399f8c88e9ef7542dae7aebae7d87bc4e";
+		"sha256:f3d8f9bb23ae392374e91cd9d395970dabc5b9c5ee72f39884613cd84a6ed310";
 	return await std
 		.download({ base, checksum, name, version, extension })
 		.then(tg.Directory.expect)

--- a/packages/std/sdk/mold.tg.ts
+++ b/packages/std/sdk/mold.tg.ts
@@ -11,13 +11,13 @@ export const metadata = {
 	license: "MIT",
 	name: "mold",
 	repository: "https://github.com/rui314/mold",
-	version: "2.34.0",
+	version: "2.34.1",
 };
 
 export const source = tg.target(() => {
 	const { name, version } = metadata;
 	const checksum =
-		"sha256:6067f41f624c32cb0f4e959ae7fabee5dd71dd06771e2c069c2b3a6a8eca3c8c";
+		"sha256:a8cf638045b4a4b2697d0bcc77fd96eae93d54d57ad3021bf03b0333a727a59d";
 	const owner = "rui314";
 	const repo = name;
 	const tag = `v${version}`;

--- a/packages/std/sdk/proxy.tg.ts
+++ b/packages/std/sdk/proxy.tg.ts
@@ -74,7 +74,6 @@ export const env = tg.target(async (arg?: Arg): Promise<std.env.Arg> => {
 
 	let cc: tg.File | tg.Symlink = cc_;
 	let cxx: tg.File | tg.Symlink = cxx_;
-	console.log("cc id", await cc.id());
 	const isLlvm = flavor === "llvm";
 
 	if (proxyLinker) {

--- a/packages/std/tangram.ts
+++ b/packages/std/tangram.ts
@@ -125,6 +125,7 @@ const testActions = (): Record<string, () => Promise<any>> => {
 		sdkDepsZstd: sdk.dependencies.zlib.test,
 		sdkDepsCmake: sdk.cmake.test,
 		sdkDepsNinja: sdk.ninja.test,
+		sdkDepsMoldSource: sdk.mold.source,
 		sdkDepsMold: sdk.mold.test,
 		sdkDefault: sdk.testDefault,
 		sdkGccCross: sdk.testCrossGcc,

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -1123,17 +1123,11 @@ export const defaultShellInterpreter = async (
 const symlinkFromManifestArtifactPath = async (
 	artifactPath: wrap.Manifest.ArtifactPath,
 ): Promise<tg.Symlink> => {
-	if (artifactPath.artifact) {
-		const artifact = tg.Artifact.withId(artifactPath.artifact);
-		if (artifactPath.subpath !== undefined) {
-			return tg.symlink({ artifact, subpath: artifactPath.subpath });
-		}
-		return tg.symlink({ artifact });
-	} else if (artifactPath.subpath !== undefined) {
-		return tg.symlink({ subpath: artifactPath.subpath });
-	} else {
-		return tg.symlink();
+	const artifact = tg.Artifact.withId(artifactPath.artifact);
+	if (artifactPath.subpath !== undefined) {
+		return tg.symlink({ artifact, subpath: artifactPath.subpath });
 	}
+	return tg.symlink({ artifact });
 };
 
 const manifestSymlinkFromArg = async (


### PR DESCRIPTION
Reflects the change from [tangramdotdev/tangram#348](https://github.com/tangramdotdev/tangram/pull/348) through the packages repo. Closes #114.

- [x] update Rust packages in `std` and `rust/proxy`
- [x] audit each usage
- [x] identify Linux libattr build failure (unrelated to change)