### PR TITLE
feat(script): automate database syncing

### DIFF
--- a/jq/tangram.ts
+++ b/jq/tangram.ts
@@ -1,0 +1,3 @@
+import autobuild from "/Users/benlovy/code/packages/packages/autobuild";
+import source from "." with { type: "directory" };
+export default tg.target(() => autobuild({ source }));

--- a/jq/tangram.ts
+++ b/jq/tangram.ts
@@ -1,3 +1,0 @@
-import autobuild from "/Users/benlovy/code/packages/packages/autobuild";
-import source from "." with { type: "directory" };
-export default tg.target(() => autobuild({ source }));

--- a/packages/webdemo/tangram.ts
+++ b/packages/webdemo/tangram.ts
@@ -1,0 +1,3 @@
+import * as std from "std";
+import m4 from "m4";
+export default tg.target(() => std.env(m4()));

--- a/scripts/local-remote.sh
+++ b/scripts/local-remote.sh
@@ -47,7 +47,7 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 FLY_APP="tangram-api"
-REGION="bos"
+#REGION="bos"
 DB_PATH="$REMOTE/.tangram/database"
 CLOUD_DB_PATH="/data/.tangram/database"
 
@@ -117,57 +117,74 @@ push_to_cloud() {
 
 		CLOUD_MACHINE_ID=$(get_cloud_machine_id)
 
-		# Locate the volume
-    VOLUME_INFO=$(get_volume_info "$CLOUD_MACHINE_ID")
-		if [ -z "$VOLUME_INFO" ]; then
-			echo "No volume found for machine ${CLOUD_MACHINE_ID}"
-			exit 1
-		fi
-		ORIGINAL_VOLUME_ID=$(echo "$VOLUME_INFO" | cut -d'|' -f1)
-		MOUNT_PATH=$(echo "$VOLUME_INFO" | cut -d'|' -f2)
-		echo "Found volume ${ORIGINAL_VOLUME_ID} mounted at path ${MOUNT_PATH} attached to machine ${CLOUD_MACHINE_ID}"
+    # Create a backup of the database in the cloud
+    fly ssh console -a "$FLY_APP" --machine "$CLOUD_MACHINE_ID" -C "cp ${CLOUD_DB_PATH} ${CLOUD_DB_PATH}.backup-`date +%Y%m%d_%H%M%S`"
 
-		# Fork the volume
-		echo "Forking volume $ORIGINAL_VOLUME_ID..."
-		CLONED_VOLUME_ID=$(fly volumes fork "${ORIGINAL_VOLUME_ID}" --region "$REGION" -a "$FLY_APP" | grep -o "vol_[[:alnum:]]*")
-
-		echo "Created clone volume $CLONED_VOLUME_ID"
-		
-		echo "Creating temporary machine with volume ${CLONED_VOLUME_ID}..."
-		# TEMP_MACHINE_ID=$(fly machine clone "$CLOUD_MACHINE_ID" \
-		# 	--app "$FLY_APP" \
-		# 	--attach-volume "$CLONED_VOLUME_ID:$MOUNT_PATH" \
-		# 	--override-cmd "sleep infinity" \
-		# 	--region "$REGION" | grep -o "machine [[:alnum:]]*" | cut -d' ' -f2)
-		TEMP_MACHINE_ID=$(fly machine run alpine \
-			--app "$FLY_APP" \
-			--volume "$CLONED_VOLUME_ID:$MOUNT_PATH" \
-			--region "$REGION" \
-			 "sleep inf"  2>&1 | tee /dev/stderr | sed -n 's/.*Machine ID: \([^ ]*\).*/\1/p')
-		wait_for_state "$TEMP_MACHINE_ID" "started"
+ 		# Push both the main database and WAL files
+    echo "put ${DB_PATH} ${CLOUD_DB_PATH}.tmp" | fly sftp shell -a "$FLY_APP"
     
-    # Swap the database
-    echo "Swapping..."
-    fly ssh console -a "$FLY_APP" "$TEMP_MACHINE_ID" -C "ls .tangram"
-    # TODO
-
-    # Stop and destroy the maintenence machine
-    echo "Cleaning up temporary machine..."
-		fly machines stop "$TEMP_MACHINE_ID" -a "$FLY_APP"
-		wait_for_state "$TEMP_MACHINE_ID" "stopped"
-		fly machines destroy "$TEMP_MACHINE_ID" -a "$FLY_APP" --force
-
-    # Stop the original fly machine
-    echo "Stopping original machine to apply changes..."
-    fly machines stop "$CLOUD_MACHINE_ID" -a "$FLY_APP"
+    # Atomically move files into place
+    fly ssh console -a "$FLY_APP" --machine "$CLOUD_MACHINE_ID" -C "mv ${CLOUD_DB_PATH}.tmp ${CLOUD_DB_PATH}"
+    
+    # Restart the server
+    fly -a "$FLY_APP" machine stop "$CLOUD_MACHINE_ID"
     wait_for_state "$CLOUD_MACHINE_ID" "stopped"
-    
-    # Create a new machine with identical configuration but new volume
-    echo "Creating new machine with modified volume..."
-    NEW_MACHINE_ID=$(fly machine clone -a "$FLY_APP" "$CLOUD_MACHINE_ID" --attach-volume "$CLOUD_MACHINE_ID":"$MOUNT_PATH" | grep -o "machine [[:alnum:]]*" | cut -d' ' -f2)
 
-    # Wait for the new machine to start
-    wait_for_state "$NEW_MACHINE_ID" "started"
+    fly -a "$FLY_APP" machine start "$CLOUD_MACHINE_ID"
+    wait_for_state "$CLOUD_MACHINE_ID" "started"
+    
+		# # Locate the volume
+  #   VOLUME_INFO=$(get_volume_info "$CLOUD_MACHINE_ID")
+		# if [ -z "$VOLUME_INFO" ]; then
+		# 	echo "No volume found for machine ${CLOUD_MACHINE_ID}"
+		# 	exit 1
+		# fi
+		# ORIGINAL_VOLUME_ID=$(echo "$VOLUME_INFO" | cut -d'|' -f1)
+		# MOUNT_PATH=$(echo "$VOLUME_INFO" | cut -d'|' -f2)
+		# echo "Found volume ${ORIGINAL_VOLUME_ID} mounted at path ${MOUNT_PATH} attached to machine ${CLOUD_MACHINE_ID}"
+
+		# # Fork the volume
+		# echo "Forking volume $ORIGINAL_VOLUME_ID..."
+		# CLONED_VOLUME_ID=$(fly volumes fork "${ORIGINAL_VOLUME_ID}" --region "$REGION" -a "$FLY_APP" | grep -o "vol_[[:alnum:]]*")
+
+		# echo "Created clone volume $CLONED_VOLUME_ID"
+		
+		# echo "Creating temporary machine with volume ${CLONED_VOLUME_ID}..."
+		# # TEMP_MACHINE_ID=$(fly machine clone "$CLOUD_MACHINE_ID" \
+		# # 	--app "$FLY_APP" \
+		# # 	--attach-volume "$CLONED_VOLUME_ID:$MOUNT_PATH" \
+		# # 	--override-cmd "sleep infinity" \
+		# # 	--region "$REGION" | grep -o "machine [[:alnum:]]*" | cut -d' ' -f2)
+		# TEMP_MACHINE_ID=$(fly machine run alpine \
+		# 	--app "$FLY_APP" \
+		# 	--volume "$CLONED_VOLUME_ID:$MOUNT_PATH" \
+		# 	--region "$REGION" \
+		# 	--detach \
+		# 	 "sleep inf" 2>&1 | tee /dev/stderr | grep " Machine ID: " | awk '{print $3}')
+		# wait_for_state "$TEMP_MACHINE_ID" "started"
+    
+  #   # Swap the database
+  #   echo "Swapping..."
+  #   fly ssh console -a "$FLY_APP" "$TEMP_MACHINE_ID" -C "ls .tangram"
+  #   # TODO
+
+  #   # Stop and destroy the maintenence machine
+  #   echo "Cleaning up temporary machine..."
+		# fly machines stop "$TEMP_MACHINE_ID" -a "$FLY_APP"
+		# wait_for_state "$TEMP_MACHINE_ID" "stopped"
+		# fly machines destroy "$TEMP_MACHINE_ID" -a "$FLY_APP" --force
+
+  #   # Stop the original fly machine
+  #   echo "Stopping original machine to apply changes..."
+  #   fly machines stop "$CLOUD_MACHINE_ID" -a "$FLY_APP"
+  #   wait_for_state "$CLOUD_MACHINE_ID" "stopped"
+    
+  #   # Create a new machine with identical configuration but new volume
+  #   echo "Creating new machine with modified volume..."
+  #   NEW_MACHINE_ID=$(fly machine clone -a "$FLY_APP" "$CLOUD_MACHINE_ID" --attach-volume "$CLOUD_MACHINE_ID":"$MOUNT_PATH" | grep -o "machine [[:alnum:]]*" | cut -d' ' -f2)
+
+  #   # Wait for the new machine to start
+  #   wait_for_state "$NEW_MACHINE_ID" "started"
 
     # TODO - health check?
 
@@ -175,20 +192,6 @@ push_to_cloud() {
 		# TODO
 		# fly volumes destroy "$ORIGINAL_VOLUME_ID" -a "$FLY_APP"
 
- #    # Create a backup of the database in the cloud
- #    fly ssh console -a "$FLY_APP" -s -C "cp ${CLOUD_DB_PATH} ${CLOUD_DB_PATH}.backup-`date +%Y%m%d_%H%M%S`"
-
- #    # Stop the server
- #    fly ssh console -a "$FLY_APP" -s -C "/tangram-control stop"
-
- # # Push both the main database and WAL files
- #    echo "put ${DB_PATH} ${CLOUD_DB_PATH}.tmp" | fly sftp shell -a "$FLY_APP"
-    
- #    # Atomically move files into place
- #    fly ssh console -a "$FLY_APP" -s -C "mv ${CLOUD_DB_PATH}.tmp ${CLOUD_DB_PATH}"
-    
- #    # Start the server again
- #    fly ssh console -a "$FLY_APP" -s -C "/tangram-control start"
 
     echo "Successfully pushed to ${CLOUD_DB_PATH}"
 }

--- a/scripts/local-remote.sh
+++ b/scripts/local-remote.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+
+set -eux
+
+# Define tangram binary
+TG_EXE=${TG_EXE:=tangram}
+export TG_EXE
+
+# set up directories
+WORKDIR="$(mktemp -d)"
+export WORKDIR
+REMOTE=$WORKDIR/remote
+export REMOTE
+mkdir -p "$REMOTE"/.tangram
+LOCAL=$WORKDIR/local
+export LOCAL
+mkdir "$LOCAL"
+
+# Create wrapper scripts to append the correct args.
+cat <<EOF > "$REMOTE/tg_remote"
+#!/bin/sh
+exec $TG_EXE --config "$REMOTE/config.json" --path "$REMOTE/.tangram" "\$@"
+EOF
+chmod +x "$REMOTE/tg_remote"
+
+cat <<EOF > "$LOCAL/tg_local"
+#!/bin/sh
+exec $TG_EXE --config "$LOCAL/config.json" --path "$HOME/.tangram" "\$@"
+EOF
+chmod +x "$LOCAL/tg_local"
+
+cleanup() {
+    # Kill process groups to ensure all child processes are terminated
+    if [ ! -z ${LOCAL_PID+x} ]; then
+        pkill -P $LOCAL_PID 2>/dev/null || true
+        kill -TERM -$LOCAL_PID 2>/dev/null || true
+    fi
+    if [ ! -z ${REMOTE_PID+x} ]; then
+        pkill -P $REMOTE_PID 2>/dev/null || true
+        kill -TERM -$REMOTE_PID 2>/dev/null || true
+    fi
+    # Remove temporary directory
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT INT TERM
+
+FLY_APP="tangram-api"
+DB_PATH="$REMOTE/.tangram/database"
+CLOUD_DB_PATH="/data/.tangram/database"
+
+pull_from_cloud() {
+	echo "pulling from cloud..."
+	fly sftp get -a "$FLY_APP" "$CLOUD_DB_PATH" "$DB_PATH"
+	echo "Successfully pulled to ${DB_PATH}"
+}
+
+push_to_cloud() {
+    echo "pushing to cloud..."
+    # Use tangram get to ensure all blobs are stored
+    find "$REMOTE"/.tangram/blobs -type f -exec basename {} \; | while read -r blob_id; do
+        tg_remote get "$blob_id" > /dev/null 2>&1
+    done
+
+    pkill -P $REMOTE_PID 2>/dev/null || true
+    kill -TERM -$REMOTE_PID 2>/dev/null || true
+
+    sqlite3 "$DB_PATH" "PRAGMA wal_checkpoint(TRUNCATE);"
+
+    # Create a backup of the database in the cloud
+    fly ssh console -a "$FLY_APP" -s -C "cp ${CLOUD_DB_PATH} ${CLOUD_DB_PATH}.backup-`date +%Y%m%d_%H%M%S`"
+
+    # Stop the server
+    fly ssh console -a "$FLY_APP" -s -C "/tangram-control stop"
+
+ # Push both the main database and WAL files
+    echo "put ${DB_PATH} ${CLOUD_DB_PATH}.tmp" | fly sftp shell -a "$FLY_APP"
+    
+    # Atomically move files into place
+    fly ssh console -a "$FLY_APP" -s -C "mv ${CLOUD_DB_PATH}.tmp ${CLOUD_DB_PATH}"
+    
+    # Start the server again
+    fly ssh console -a "$FLY_APP" -s -C "/tangram-control start"
+
+    echo "Successfully pushed to ${CLOUD_DB_PATH}"
+
+    tg_remote serve &
+    REMOTE_PID=$!
+}
+
+# set up remote config
+cat <<EOF > "$REMOTE"/config.json
+{
+	"advanced": {
+		"error_trace_options": {
+			"internal": true
+		}
+	},
+	"build": null,
+	"remotes": null,
+	"tracing": {
+		"filter": "tangram_server=info",
+		"format": "pretty"
+	},
+	"url": "http://localhost:8476",
+	"vfs": null
+}
+EOF
+
+pull_from_cloud
+
+# start remote server
+tg_remote serve &
+REMOTE_PID=$!
+ps -o pid,pgid,command -p $REMOTE_PID || true
+
+# set up local config
+cat <<EOF > "$LOCAL"/config.json
+{
+	"advanced": {
+		"error_trace_options": {
+			"internal": true
+		}
+	},
+	"remotes": {
+	  "default": {
+	    "url": "http://localhost:8476"
+	  }
+	},
+	"tracing": {
+		"filter": "tangram_server=info",
+		"format": "pretty"
+	},
+	"vfs": null
+}
+EOF
+
+tg_local serve &
+LOCAL_PID=$!
+ps -o pid,pgid,command -p $LOCAL_PID || true
+
+# FIXME - uncomment remaining packages
+# PACKAGES="std jq m4 bison rust pcre2 ripgrep pkgconf pkg-config ncurses readline zlib sqlite"
+PACKAGES="std jq"
+
+bun run auto -pu --seq $PACKAGES
+
+push_to_cloud

--- a/scripts/local-remote.sh
+++ b/scripts/local-remote.sh
@@ -21,13 +21,13 @@ mkdir "$LOCAL"
 # Create wrapper scripts to append the correct args.
 cat <<EOF > "$REMOTE/tg_remote"
 #!/bin/sh
-exec $TANGRAM --config "$REMOTE/config.json" --path "$REMOTE/.tangram" "\$@"
+$TANGRAM --config "$REMOTE/config.json" --path "$REMOTE/.tangram" "\$@"
 EOF
 chmod +x "$REMOTE/tg_remote"
 
 cat <<EOF > "$LOCAL/tg_local"
 #!/bin/sh
-exec $TANGRAM --config "$LOCAL/config.json" --path "$HOME/.tangram" "\$@"
+$TANGRAM --config "$LOCAL/config.json" --path "$HOME/.tangram" "\$@"
 EOF
 chmod +x "$LOCAL/tg_local"
 
@@ -107,7 +107,7 @@ push_to_cloud() {
     echo "pushing to cloud..."
     # Use tangram get to ensure all blobs are stored
     find "$REMOTE"/.tangram/blobs -type f -exec basename {} \; | while read -r blob_id; do
-        tg_remote get "$blob_id" > /dev/null 2>&1
+        "$REMOTE/tg_remote" get "$blob_id" > /dev/null 2>&1
     done
 
     pkill -P $REMOTE_PID 2>/dev/null || true
@@ -218,7 +218,7 @@ EOF
 pull_from_cloud
 
 # start remote server
-tg_remote serve &
+"$REMOTE/tg_remote" serve &
 REMOTE_PID=$!
 ps -o pid,pgid,command -p $REMOTE_PID || true
 
@@ -243,7 +243,7 @@ cat <<EOF > "$LOCAL"/config.json
 }
 EOF
 
-tg_local serve &
+"$LOCAL/tg_local" serve &
 LOCAL_PID=$!
 ps -o pid,pgid,command -p $LOCAL_PID || true
 

--- a/scripts/package_automation.ts
+++ b/scripts/package_automation.ts
@@ -301,7 +301,8 @@ class Options {
 		const actions = `Actions: ${Array.from(this.actions).join(", ")}`;
 		const packages = `Packages: ${Array.from(this.packages).join(", ")}`;
 		const config = `Parallel: ${this.parallel}`;
-		return `${actions}\n${packages}\n${config}`;
+		const tangram = `Tangram: ${this.tangram_exe}`;
+		return `${actions}\n${packages}\n${config}\n${tangram}`;
 	}
 }
 

--- a/scripts/package_automation.ts
+++ b/scripts/package_automation.ts
@@ -286,7 +286,7 @@ class Options {
 
 	async validateTangram() {
 		try {
-			const result = await $`${this.tangram_exe} --version`.text();
+			const result = await $`${this.tangram_exe} --mode client --version`.text();
 			const goodStdout = result.includes("tangram");
 			if (!goodStdout) {
 				throw new Error(`${this.tangram_exe} --help produced an unexpected result, provide a different executable.`);
@@ -353,14 +353,15 @@ const processPackage = async (
 ): Promise<Result> => {
 	const path = getPackagePath(name);
 	log(`processing ${name}: ${path}`);
+	const tg = `${options.tangram_exe}`
 
 	const actionMap: Record<Action, () => Promise<Result>> = {
-		format: () => formatAction(options.tangram_exe, path),
-		check: () => checkAction(options.tangram_exe, path),
-		build: () => buildDefaultTarget(options.tangram_exe, path, buildTracker),
-		test: () => buildTestTarget(options.tangram_exe, path, buildTracker),
-		upload: () => uploadAction(options.tangram_exe, path, buildTracker),
-		publish: () => publishAction(options.tangram_exe, name, path),
+		format: () => formatAction(tg, path),
+		check: () => checkAction(tg, path),
+		build: () => buildDefaultTarget(tg, path, buildTracker),
+		test: () => buildTestTarget(tg, path, buildTracker),
+		upload: () => uploadAction(tg, path, buildTracker),
+		publish: () => publishAction(tg, name, path),
 	};
 
 	for (const action of sortedActions(options.actions)) {
@@ -463,7 +464,7 @@ const checkinPackage = async (tangram: string, path: string): Promise<Result> =>
 		log(`finished checkin ${path}`);
 		return ok(id);
 	} catch (err) {
-		log(`error checking in ${path}`);
+		log(`error checking in ${path}: ${err}`);
 		return result("checkinError", err.stdout.toString());
 	}
 };

--- a/scripts/package_automation.ts
+++ b/scripts/package_automation.ts
@@ -8,6 +8,7 @@ const separator = "-".repeat(50);
 /** Toplevel entrypoint. */
 const entrypoint = async () => {
 	const options = Options.parseFromArgs();
+	await options.validateTangram();
 	log(`Starting! Options:\n${options.summarize()}\n${separator}`);
 	const results = await run(options);
 	log(`Done! Results:\n${results.summarize()}`);
@@ -89,9 +90,9 @@ const ok = (message?: string): Result => {
 /** Run the given options. */
 const run = async (options: Options): Promise<Results> => {
 	const results = new Results();
-	const buildTracker = new BuildTracker();
+	const buildTracker = new BuildTracker(options.tangram_exe);
 	const processAndLog = async (name: string) => {
-		const result = await processPackage(name, options.actions, buildTracker);
+		const result = await processPackage(name, options, buildTracker);
 		results.log(name, result);
 	};
 
@@ -159,11 +160,22 @@ class Options {
 	readonly actions: Set<Action>;
 	/** Whether to run each package concurrently. If false, will run in the order they are defined. */
 	readonly parallel: boolean;
+	/** The path to the tangram executable to use for each invocation. */
+	readonly tangram_exe: string;
 
 	constructor(...args: Array<string>) {
 		let packages: Set<string> = new Set();
 		let actions: Set<Action> = new Set();
 		let parallel = true;
+
+		// Set the tangram executable path.
+		// Read the TG_EXE env var
+		const envVar = Bun.env.TG_EXE;
+		if (envVar === undefined) {
+			this.tangram_exe = "tangram"
+		} else {
+			this.tangram_exe = envVar;
+		}
 
 		// Helper to process an individual flag.
 		const processFlag = (opt: string): void => {
@@ -272,6 +284,18 @@ class Options {
 		return new Options(...process.argv.slice(2));
 	}
 
+	async validateTangram() {
+		try {
+			const result = await $`${this.tangram_exe} --version`.text();
+			const goodStdout = result.includes("tangram");
+			if (!goodStdout) {
+				throw new Error(`${this.tangram_exe} --help produced an unexpected result, provide a different executable.`);
+			}
+		} catch (err) {
+			throw new Error(`Error running ${this.tangram_exe}, provide a different executable: ${err}`);
+		}
+	}
+
 	/** Produce a human-readable description of the parsed options. */
 	summarize(): string {
 		const actions = `Actions: ${Array.from(this.actions).join(", ")}`;
@@ -323,22 +347,22 @@ export const getPackagePath = (name: string) => path.join(packagesPath(), name);
 /** Ensuring the given package test succeeds, then ensure it is tagged and pushed along with the default target build. */
 const processPackage = async (
 	name: string,
-	actions: Set<Action>,
+	options: Options,
 	buildTracker: BuildTracker,
 ): Promise<Result> => {
 	const path = getPackagePath(name);
 	log(`processing ${name}: ${path}`);
 
 	const actionMap: Record<Action, () => Promise<Result>> = {
-		format: () => formatAction(path),
-		check: () => checkAction(path),
-		build: () => buildDefaultTarget(path, buildTracker),
-		test: () => buildTestTarget(path, buildTracker),
-		upload: () => uploadAction(path, buildTracker),
-		publish: () => publishAction(name, path),
+		format: () => formatAction(options.tangram_exe, path),
+		check: () => checkAction(options.tangram_exe, path),
+		build: () => buildDefaultTarget(options.tangram_exe, path, buildTracker),
+		test: () => buildTestTarget(options.tangram_exe, path, buildTracker),
+		upload: () => uploadAction(options.tangram_exe, path, buildTracker),
+		publish: () => publishAction(options.tangram_exe, name, path),
 	};
 
-	for (const action of sortedActions(actions)) {
+	for (const action of sortedActions(options.actions)) {
 		if (action in actionMap) {
 			const result = await actionMap[action]();
 			if (result.kind !== "ok") {
@@ -351,10 +375,10 @@ const processPackage = async (
 };
 
 /** Perform the `format` action for a package. */
-const formatAction = async (path: string): Promise<Result> => {
+const formatAction = async (tangram: string, path: string): Promise<Result> => {
 	log("format", path);
 	try {
-		await $`tg format ${path}`.quiet();
+		await $`${tangram} format ${path}`.quiet();
 		log(`finished formatting ${path}`);
 	} catch (err) {
 		log(`error formatting ${path}`);
@@ -364,10 +388,10 @@ const formatAction = async (path: string): Promise<Result> => {
 };
 
 /** Perform the `check` action for a package. */
-const checkAction = async (path: string): Promise<Result> => {
+const checkAction = async (tangram: string, path: string): Promise<Result> => {
 	log("checking", path);
 	try {
-		await $`tg check ${path}`.quiet();
+		await $`${tangram} check ${path}`.quiet();
 		log(`finished checking ${path}`);
 	} catch (err) {
 		log(`error checking ${path}`);
@@ -377,10 +401,10 @@ const checkAction = async (path: string): Promise<Result> => {
 };
 
 /** Perform the `publish` action for a package name. If the existing tag is out of date, tag and push the new package. */
-const publishAction = async (name: string, path: string): Promise<Result> => {
+const publishAction = async (tangram: string, name: string, path: string): Promise<Result> => {
 	log("publishing...");
 	// Check in the package, store the ID.
-	const packageIdResult = await checkinPackage(path);
+	const packageIdResult = await checkinPackage(tangram, path);
 	if (packageIdResult.kind !== "ok") {
 		return packageIdResult;
 	}
@@ -390,18 +414,18 @@ const publishAction = async (name: string, path: string): Promise<Result> => {
 	}
 
 	// Look up the existing tag for the given name.
-	const existingTag = await existingTaggedItem(name);
+	const existingTag = await existingTaggedItem(tangram, name);
 
 	// If there is no tag or the ID does not match, tag the package.
 	if (packageId !== existingTag) {
 		log(`tagging ${name}...`);
-		const tagResult = await tagPackage(name, path);
+		const tagResult = await tagPackage(tangram, name, path);
 		if (tagResult.kind !== "ok") {
 			return tagResult;
 		}
 
 		// Push the tag.
-		const pushTagResult = await push(name);
+		const pushTagResult = await push(tangram, name);
 		if (pushTagResult.kind !== "ok") {
 			return pushTagResult;
 		}
@@ -413,10 +437,11 @@ const publishAction = async (name: string, path: string): Promise<Result> => {
 
 /** Perform the upload action for a path. Will do the default build first. */
 const uploadAction = async (
+	tangram: string,
 	path: string,
 	buildTracker: BuildTracker,
 ): Promise<Result> => {
-	const buildIdResult = await buildDefaultTarget(path, buildTracker);
+	const buildIdResult = await buildDefaultTarget(tangram, path, buildTracker);
 	if (buildIdResult.kind !== "ok") {
 		return buildIdResult;
 	}
@@ -427,7 +452,7 @@ const uploadAction = async (
 
 	log(`uploading build ${buildId}`);
 	try {
-		await $`tg push ${buildId}`.quiet();
+		await $`${tangram} push ${buildId}`.quiet();
 		log(`finished pushing ${buildId}`);
 		return ok();
 	} catch (err) {
@@ -437,10 +462,10 @@ const uploadAction = async (
 };
 
 /** Check in a path, returning the resulting ID or "checkinError" on failure. */
-const checkinPackage = async (path: string): Promise<Result> => {
+const checkinPackage = async (tangram: string, path: string): Promise<Result> => {
 	log("checking in", path);
 	try {
-		const id = await $`tg checkin ${path}`.text().then((t) => t.trim());
+		const id = await $`${tangram} checkin ${path}`.text().then((t) => t.trim());
 		log(`finished checkin ${path}`);
 		return ok(id);
 	} catch (err) {
@@ -450,10 +475,10 @@ const checkinPackage = async (path: string): Promise<Result> => {
 };
 
 /** Get the existing tagged item for a given name, if present. */
-const existingTaggedItem = async (name: string): Promise<string> => {
+const existingTaggedItem = async (tangram: string, name: string): Promise<string> => {
 	log("checking for existing tag", name);
 	try {
-		const result = await $`tg tag get ${name}`.text().then((t) => t.trim());
+		const result = await $`${tangram} tag get ${name}`.text().then((t) => t.trim());
 		return result;
 	} catch (err) {
 		return "not found";
@@ -461,10 +486,10 @@ const existingTaggedItem = async (name: string): Promise<string> => {
 };
 
 /** Tag a package at the given path with the given name. */
-const tagPackage = async (name: string, path: string): Promise<Result> => {
+const tagPackage = async (tangram: string, name: string, path: string): Promise<Result> => {
 	log("tagging", name, path);
 	try {
-		await $`tg tag ${name} ${path}`.quiet();
+		await $`${tangram} tag ${name} ${path}`.quiet();
 		return ok();
 	} catch (err) {
 		return result("tagError");
@@ -472,10 +497,10 @@ const tagPackage = async (name: string, path: string): Promise<Result> => {
 };
 
 /** Push something. */
-const push = async (arg: string): Promise<Result> => {
+const push = async (tangram: string, arg: string): Promise<Result> => {
 	log("pushing", arg);
 	try {
-		await $`tg push ${arg}`.quiet();
+		await $`${tangram} push ${arg}`.quiet();
 		log(`finished pushing ${arg}`);
 	} catch (err) {
 		log(`error pushing ${arg}`);
@@ -486,15 +511,16 @@ const push = async (arg: string): Promise<Result> => {
 
 /** Build the default target given a path. Return the build ID. */
 const buildDefaultTarget = async (
+	tangram: string,
 	path: string,
 	buildTracker: BuildTracker,
 ): Promise<Result> => {
 	log(`building ${path}`);
 	try {
-		const buildId = await $`tg build ${path} -d`.text().then((t) => t.trim());
+		const buildId = await $`${tangram} build ${path} -d`.text().then((t) => t.trim());
 		buildTracker.add(buildId);
 		log(`${path}: ${buildId}`);
-		await $`tg build output ${buildId}`.quiet();
+		await $`${tangram} build output ${buildId}`.quiet();
 		buildTracker.remove(buildId);
 		log(`finished building ${path}`);
 		return ok(buildId);
@@ -506,17 +532,18 @@ const buildDefaultTarget = async (
 
 /** Build the default target given a path. Return the build ID. */
 const buildTestTarget = async (
+	tangram: string,
 	path: string,
 	buildTracker: BuildTracker,
 ): Promise<Result> => {
 	log(`building ${path}#test...`);
 	try {
-		const buildId = await $`tg build ${path}#test -d`
+		const buildId = await $`${tangram} build ${path}#test -d`
 			.text()
 			.then((t) => t.trim());
 		buildTracker.add(buildId);
 		log(`${path}#test: ${buildId}`);
-		await $`tg build output ${buildId}`.quiet();
+		await $`${tangram} build output ${buildId}`.quiet();
 		buildTracker.remove(buildId);
 		log(`finished building ${path}#test`);
 		return ok(buildId);
@@ -529,8 +556,10 @@ const buildTestTarget = async (
 /** Class for managing builds created by this script. */
 class BuildTracker {
 	private ids: Set<string>;
-	constructor() {
+	private readonly tangram_exe: string;
+	constructor(tangram_exe: string) {
 		this.ids = new Set();
+		this.tangram_exe = tangram_exe;
 		process.on("SIGINT", async () => {
 			await this.cancelAll();
 			process.exit(0);
@@ -547,7 +576,7 @@ class BuildTracker {
 		for (const id of this.ids) {
 			log(`cancelling ${id}`);
 			try {
-				await $`tg build cancel ${id}`.quiet();
+				await $`${this.tangram_exe} build cancel ${id}`.quiet();
 			} catch (err) {
 				log(`Failed to cancel build ${id}: ${err}`);
 			}

--- a/scripts/package_automation.ts
+++ b/scripts/package_automation.ts
@@ -414,25 +414,18 @@ const publishAction = async (tangram: string, name: string, path: string): Promi
 		return result("checkinError", `no ID for ${path}`);
 	}
 
-	// Look up the existing tag for the given name.
-	const existingTag = await existingTaggedItem(tangram, name);
-
-	// If there is no tag or the ID does not match, tag the package.
-	if (packageId !== existingTag) {
-		log(`tagging ${name}...`);
-		const tagResult = await tagPackage(tangram, name, path);
-		if (tagResult.kind !== "ok") {
-			return tagResult;
-		}
-
-		// Push the tag.
-		const pushTagResult = await push(tangram, name);
-		if (pushTagResult.kind !== "ok") {
-			return pushTagResult;
-		}
-	} else {
-		return ok(`matching tag found for ${name}: ${packageId}, not re-tagging.`);
+	log(`tagging ${name}...`);
+	const tagResult = await tagPackage(tangram, name, path);
+	if (tagResult.kind !== "ok") {
+		return tagResult;
 	}
+
+	// Push the tag.
+	const pushTagResult = await push(tangram, name);
+	if (pushTagResult.kind !== "ok") {
+		return pushTagResult;
+	}
+
 	return ok(`tagged ${name}: ${packageId}`);
 };
 


### PR DESCRIPTION
Adds a script that populates a "remote" database locally and syncs it all at once to the deployed cloud server.

Todo:

- [x] cleaner cloud server lifetime handling (start/stop)
- [x] diagnose why the tag is not available
- [x] replace test package with the automatic build/tag/push logic from the package_automation script, using the defined package whitelist
- [ ] change the push logic to use an alternate machine