### PR TITLE
fix(rust): force correct linker-flavor inference

### DIFF
--- a/packages/rust/cargo.tg.ts
+++ b/packages/rust/cargo.tg.ts
@@ -154,15 +154,15 @@ export const build = tg.target(async (...args: std.Args<Arg>) => {
 		buildCommand,
 	);
 
-	// When not cross-compiling, ensure the `cc` provided by the SDK is used, which enables Tangram linking.
+	// When not cross-compiling, ensure the `gcc` provided by the SDK is used, which enables Tangram linking.
 	let toolchainEnv = {
-		[`CARGO_TARGET_${tripleToEnvVar(target, true)}_LINKER`]: `cc`,
+		[`CARGO_TARGET_${tripleToEnvVar(target, true)}_LINKER`]: `gcc`,
 	};
 
 	// If cross-compiling, set additional environment variables.
 	if (crossCompiling) {
 		toolchainEnv = {
-			[`CARGO_TARGET_${tripleToEnvVar(target, true)}_LINKER`]: `${target}-cc`,
+			[`CARGO_TARGET_${tripleToEnvVar(target, true)}_LINKER`]: `${target}-gcc`,
 			[`AR_${tripleToEnvVar(target)}`]: `${target}-ar`,
 			[`CC_${tripleToEnvVar(target)}`]: `${target}-cc`,
 			[`CXX_${tripleToEnvVar(target)}`]: `${target}-c++`,
@@ -186,7 +186,7 @@ export const build = tg.target(async (...args: std.Args<Arg>) => {
 	let verbosityEnv = undefined;
 	if (verbose) {
 		verbosityEnv = {
-			RUSTFLAGS: "-v",
+			RUSTFLAGS: tg.Mutation.suffix("-v", " "),
 			CARGO_TERM_VERBOSE: "true",
 		};
 	}
@@ -421,7 +421,9 @@ export const testUnproxiedWorkspace = tg.target(async () => {
 		env: {
 			TANGRAM_LINKER_TRACING: "tangram=trace",
 		},
+		pre: "set -x",
 		proxy: false,
+		verbose: true
 	});
 
 	const helloOutput = await $`

--- a/packages/rust/tangram.ts
+++ b/packages/rust/tangram.ts
@@ -172,7 +172,6 @@ export const proxyRustObjcopy = tg.target(
 			host,
 			stripCommand: rustObjcopyExe,
 		});
-		console.log("proxied", await wrappedRustObjcopyExe.id());
 
 		// Replace the original path with the wrapper.
 		return tg.directory(rustInstall, {

--- a/packages/rust/tangram.ts
+++ b/packages/rust/tangram.ts
@@ -140,7 +140,6 @@ export const toolchain = tg.target(async (arg?: ToolchainArg) => {
 			[executable]: wrapped,
 		});
 	}
-	console.log("post-wrap rustInstall", await (await artifact).id());
 
 	return artifact;
 });


### PR DESCRIPTION
A change in `rustc` behavior caused the `-C linker=cc` flag to not correctly determine the appropriate `linker-flavor`, falling back to a broken linker on Linux. Using `gcc` instead of `cc` corrects this issue on both platforms.