### PR TITLE
fix(ld_proxy): correctly set wrapper identity

### DIFF
--- a/packages/std/packages/ld_proxy/src/main.rs
+++ b/packages/std/packages/ld_proxy/src/main.rs
@@ -587,6 +587,7 @@ fn extract_filename(path: &(impl AsRef<str> + ToString + ?Sized)) -> String {
 }
 
 /// Create a manifest.
+#[allow(clippy::too_many_lines)]
 async fn create_manifest<H: BuildHasher>(
 	tg: &impl tg::Handle,
 	ld_output_id: tg::artifact::Id,
@@ -696,9 +697,22 @@ async fn create_manifest<H: BuildHasher>(
 	let env = None;
 	let args = None;
 
+	// Set the identity. If the interpreter flavor is Dyld, LdLinux, or LdMusl, use `Executable`, and otherwise use `Wrapper`.
+	let identity = match interpreter {
+		Some(ref interpreter) => match interpreter {
+			tangram_std::manifest::Interpreter::LdLinux(_)
+			| tangram_std::manifest::Interpreter::LdMusl(_)
+			| tangram_std::manifest::Interpreter::DyLd(_) => tangram_std::manifest::Identity::Executable,
+			tangram_std::manifest::Interpreter::Normal(_) => {
+				tangram_std::manifest::Identity::Wrapper
+			},
+		},
+		None => tangram_std::manifest::Identity::Wrapper,
+	};
+
 	// Create the manifest.
 	let manifest = tangram_std::Manifest {
-		identity: tangram_std::manifest::Identity::Wrapper,
+		identity,
 		interpreter,
 		executable,
 		env,

--- a/packages/std/tangram.ts
+++ b/packages/std/tangram.ts
@@ -163,12 +163,7 @@ const testActions = (): Record<string, () => Promise<any>> => {
 };
 
 /** A subset of all defined tests to run in the correct order. */
-const defaultTests = [
-	"hostSystem",
-	"triple",
-	"certificates",
-	"sdkDefault",
-];
+const defaultTests = ["hostSystem", "triple", "certificates", "sdkDefault"];
 
 /** With no arguments, runs a set of default tests. Pass test names to run individual component tests. */
 export const test = tg.target(async (...testNames: Array<string>) => {

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -1629,7 +1629,19 @@ export const test = tg.target(async () => {
 export const testSingleArgObjectNoMutations = tg.target(async () => {
 	const executable = await argAndEnvDump();
 	const executableID = await executable.id();
-	console.log("argAndEnvDump ID", executableID);
+	// The program is a wrapper produced by the LD proxy.
+	console.log("argAndEnvDump wrapper ID", executableID);
+
+	// Get the value of the original executable.
+	const origManifest = await wrap.Manifest.read(executable);
+	tg.assert(origManifest);
+	const origManifestExecutable = origManifest.executable;
+	tg.assert(origManifestExecutable.kind === "path");
+	const origExecutable = await wrap.executableFromManifestExecutable(
+		origManifestExecutable,
+	);
+	const origExecutableId = await origExecutable.id();
+	console.log("origExecutable", origExecutableId);
 
 	const buildToolchain = await bootstrap.sdk.env();
 
@@ -1659,7 +1671,7 @@ export const testSingleArgObjectNoMutations = tg.target(async () => {
 	console.log("text", text);
 
 	tg.assert(
-		text.includes(`/proc/self/exe: /.tangram/artifacts/${executableID}`),
+		text.includes(`/proc/self/exe: /.tangram/artifacts/${origExecutableId}`),
 		"Expected /proc/self/exe to be set to the artifact ID of the wrapped executable",
 	);
 	tg.assert(

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -1647,14 +1647,17 @@ export const testSingleArgObjectNoMutations = tg.target(async () => {
 	const manifest = await wrap.Manifest.read(wrapper);
 	console.log("wrapper manifest", manifest);
 	tg.assert(manifest);
-	tg.assert(manifest.identity === "executable"); // FIXME - this is coming out as "wrapper", why not executable?
+	tg.assert(manifest.identity === "executable");
 	tg.assert(manifest.interpreter);
 
 	// Check the output matches the expected output.
-	const output = tg.File.expect(
-		(await tg.target(tg`${wrapper} > $OUTPUT`)).output(),
-	);
+	const output = await tg
+		.target(tg`${wrapper} > $OUTPUT`)
+		.then((target) => target.output())
+		.then(tg.File.expect);
 	const text = await output.text();
+	console.log("text", text);
+
 	tg.assert(
 		text.includes(`/proc/self/exe: /.tangram/artifacts/${executableID}`),
 		"Expected /proc/self/exe to be set to the artifact ID of the wrapped executable",


### PR DESCRIPTION
Previously, the ld proxy was always creating wrappers with the `wrapper` identity. This change now defaults to `executable` when the executable is dynamically linked, matching the behavior of `std.wrap()`.

Closes #131.