### PR TITLE
refactor(std/wrap): rollup

### DIFF
--- a/packages/rust/proxy/Cargo.lock
+++ b/packages/rust/proxy/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitvec"
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -351,15 +351,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639"
+checksum = "5b16d9d0d88a5273d830dac8b78ceb217ffc9b1d5404e5597a3542515329405b"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -367,12 +367,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f"
+checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -975,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lsp-types"
@@ -1006,9 +1006,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -1299,7 +1299,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -2009,18 +2009,18 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b913a3b5fe84142e269d63cc62b64319ccaf89b748fc31fe025177f767a756c4"
+checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitvec"
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -351,15 +351,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639"
+checksum = "5b16d9d0d88a5273d830dac8b78ceb217ffc9b1d5404e5597a3542515329405b"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -367,12 +367,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f"
+checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1008,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lsp-types"
@@ -1039,9 +1039,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -1338,7 +1338,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -1436,7 +1436,7 @@ version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2163,18 +2163,18 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b913a3b5fe84142e269d63cc62b64319ccaf89b748fc31fe025177f767a756c4"
+checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/packages/std/packages/wrapper/src/main.rs
+++ b/packages/std/packages/wrapper/src/main.rs
@@ -17,6 +17,7 @@ fn main_inner() -> std::io::Result<()> {
 
 	// Get the wrapper path.
 	let wrapper_path = std::env::current_exe()?.canonicalize()?;
+	#[cfg(feature = "tracing")]
 	tracing::trace!(?wrapper_path);
 
 	// Read the manifest.

--- a/packages/std/tangram.ts
+++ b/packages/std/tangram.ts
@@ -76,6 +76,7 @@ const testActions = (): Record<string, () => Promise<any>> => {
 		wrapBasic: wrap.testSingleArgObjectNoMutations,
 		wrapContent: wrap.testContentExecutable,
 		wrapContentVariadic: wrap.testContentExecutableVariadic,
+		wrapDylib: wrap.testDylibPath,
 		wrap: wrap.test,
 		env: env.test,
 		proxyBasic: sdk.proxy.testBasic,

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -39,7 +39,6 @@ export async function wrap(
 		interpreter: arg.interpreter,
 		executable: arg.executable,
 		libraryPaths: arg.libraryPaths,
-		libraryPathStrategy: arg.libraryPathStrategy,
 	});
 
 	// Ensure we're not building an identity=executable wrapper for an unwrapped statically-linked executable.
@@ -124,11 +123,7 @@ export namespace wrap {
 		interpreter?: tg.File | tg.Symlink | tg.Template | Interpreter;
 
 		/** Library paths to include. If the executable is wrapped, they will be merged. */
-		// FIXME - normal interpreters should just add these to the env? Maybe? Maybe not? Right now they're discarded, which is certainly wrong. Maybe LD_LIBRARY_PATH.
 		libraryPaths?: Array<tg.Directory | tg.Symlink | tg.Template>;
-
-		/** Which library path strategy should we use? Default is "none" for normal/undefined interpreters, "isolate" for LdLinux/LdMusl/Dyld. */
-		libraryPathStrategy?: LibraryPathStrategy;
 
 		/** Specify how to handle executables that are already Tangram wrappers. When `merge` is true, retain the original executable in the resulting manifest. When `merge` is set to false, produce a manifest pointing to the original wrapper. This option is ignored if the executable being wrapped is not a Tangram wrapper. Default: true. */
 		merge?: boolean;
@@ -195,23 +190,6 @@ export namespace wrap {
 		preloads?: Array<tg.Template.Arg> | undefined;
 	};
 
-	/** Wrappers for dynamically linked executables can employ one of these strategies to optimize the set of library paths.
-	 * This strategy is only used to produce the manifest, and is not retained as a property once complete.
-	 * These mirror the strategies available in the Tangram `ld` proxy.
-	 *
-	 * - "none": Do not manipulate library paths. The paths provided by the user will be retained as-is. This is the strategy used for all wrappers for non-dynamically-linked executables (static binaries, scripts).
-	 * - "filter": Paths that do not contain libraries marked as needed by the executable are dropped.
-	 * - "resolve": After filtering, all library paths are resolved to their innermost directory. If you provided `${someArtifact}/lib`, it will be transformed to `${someArtifactLib}`, with no trailing subpath. This prevents, for example, the `"include" directory from being retained as a dependency of your wrapper.`
-	 * - "isolate": Each needed library will be placed in its own unique directory. This is the default strategy, which maximizes cache hits between wrappers.
-	 * - "combine": Each needed library will be placed together in a single directory. This is the most space-efficient, but likely to cause cache misses and duplication. If one wrapper needs `libc.so` and another needs `libc.so` and `libm.so`, you'll wind up with two copies of `libc.so` in your dependencies. If not checking out or bundling your artifact, this is not a concern, but external checkouts will incur the extra cost. To share a single copy of the common dependency, consider the "isolate" strategy.
-	 */
-	export type LibraryPathStrategy =
-		| "none"
-		| "filter"
-		| "resolve"
-		| "isolate"
-		| "combine";
-
 	export type Manifest = {
 		identity: Identity;
 		interpreter?: Manifest.Interpreter | undefined;
@@ -260,7 +238,6 @@ export namespace wrap {
 			interpreter,
 			merge: merge_ = true,
 			libraryPaths,
-			libraryPathStrategy,
 		} = await std.args.applyMutations(mutationArgs);
 
 		tg.assert(executable !== undefined);
@@ -325,7 +302,6 @@ export namespace wrap {
 			interpreter,
 			merge,
 			libraryPaths,
-			libraryPathStrategy,
 		};
 	};
 
@@ -570,6 +546,50 @@ export namespace wrap {
 			`Expected a map, but got ${value}.`,
 		);
 		return { kind: "set", value };
+	};
+
+	/** Attempt to obtain the needed libraries of the wrapped exectuable of a wrapper. */
+	export const tryNeededLibraries = async (
+		file: tg.File,
+	): Promise<Array<string> | undefined> => {
+		try {
+			return await neededLibraries(file);
+		} catch (_) {
+			return undefined;
+		}
+	};
+
+	/** Obtain the needed libraries of the wrapped executable of a wrapper. */
+	export const neededLibraries = async (
+		file: tg.File,
+	): Promise<Array<string>> => {
+		const manifest = await wrap.Manifest.read(file);
+		if (!manifest) {
+			throw new Error(
+				`Cannot determine needed libraries for ${await file.id()}: not a Tangram wrapper.`,
+			);
+		}
+		tg.assert(
+			manifest.interpreter !== undefined,
+			`cannot determine needed libraries for a wrapper without an interpreter`,
+		);
+		tg.assert(
+			manifest.interpreter.kind !== "normal",
+			`cannot determine needed libraries for a normal interpreter`,
+		);
+		const wrappedExecutable = manifest.executable;
+		tg.assert(
+			wrappedExecutable.kind !== "content",
+			"cannot determine needed libraries for a content executable",
+		);
+		const wrappedExecutableFile = await fileOrSymlinkFromManifestTemplate(
+			manifest.executable.value,
+		);
+		tg.assert(
+			wrappedExecutableFile instanceof tg.File,
+			`executable must be a file, received ${await wrappedExecutableFile.id()}`,
+		);
+		return await getNeededLibraries(wrappedExecutableFile);
 	};
 
 	/** Attempt to unwrap a wrapped executable. Returns undefined if the input was not a Tangram wrapper. */
@@ -869,7 +889,6 @@ type ManifestInterpreterArg = {
 		| undefined;
 	executable: string | tg.Template | tg.File | tg.Symlink;
 	libraryPaths?: Array<tg.Directory | tg.Symlink | tg.Template> | undefined;
-	libraryPathStrategy?: wrap.LibraryPathStrategy | undefined;
 };
 
 /** Produce the manifest interpreter object given a set of parameters. */
@@ -881,17 +900,6 @@ const manifestInterpreterFromWrapArgObject = async (
 		: await interpreterFromExecutableArg(arg.executable, arg.buildToolchain);
 	if (interpreter === undefined) {
 		return undefined;
-	}
-
-	// If this is not a "normal" interpreter run the library path optimization, including any additional paths from the user.
-	if (interpreter.kind !== "normal") {
-		const { executable, libraryPaths, libraryPathStrategy } = arg;
-		interpreter = await optimizeLibraryPaths({
-			executable,
-			interpreter,
-			libraryPaths,
-			libraryPathStrategy,
-		});
 	}
 
 	return manifestInterpreterFromWrapInterpreter(interpreter);
@@ -1225,135 +1233,6 @@ const interpreterFromElf = async (
 	}
 };
 
-type OptimizeLibraryPathsArg = {
-	executable: string | tg.Template | tg.File | tg.Symlink;
-	interpreter:
-		| wrap.DyLdInterpreter
-		| wrap.LdLinuxInterpreter
-		| wrap.LdMuslInterpreter;
-	libraryPaths?: Array<tg.Template.Arg> | undefined;
-	libraryPathStrategy?: wrap.LibraryPathStrategy | undefined;
-};
-
-const optimizeLibraryPaths = async (
-	arg: OptimizeLibraryPathsArg,
-): Promise<
-	wrap.DyLdInterpreter | wrap.LdLinuxInterpreter | wrap.LdMuslInterpreter
-> => {
-	const {
-		interpreter,
-		libraryPaths: additionalLibraryPaths = [],
-		libraryPathStrategy: strategy = "isolate",
-	} = arg;
-	if (strategy === "none") {
-		return interpreter;
-	}
-
-	let executable = arg.executable;
-
-	// Set up the initial set of paths.
-	const paths = interpreter.libraryPaths ?? [];
-
-	// If there are additional library paths, add them to the interpreter.
-	if (additionalLibraryPaths.length > 0) {
-		paths.push(...additionalLibraryPaths);
-	}
-
-	// Discover the containing directories of all transitively needed libraries.
-	// If the arg is a string or template, there is no interpreter.
-	if (typeof executable === "string" || executable instanceof tg.Template) {
-		throw new Error("cannot optimize paths for a non-file executable");
-	}
-
-	// Resolve the arg to a file if it is a symlink.
-	if (executable instanceof tg.Symlink) {
-		const resolvedArg = await executable.resolve();
-		tg.assert(resolvedArg instanceof tg.File);
-		executable = resolvedArg;
-	}
-
-	// Prepare to map needed libraries to their locations.
-	let neededLibraries = await getInitialNeededLibraries(executable);
-
-	// Produce a set of the available library paths as directories with optional subpaths.
-	const libraryPathSet = await createLibraryPathSet(paths);
-
-	// Find any transitively needed libraries in the set and record their location.
-	neededLibraries = await findTransitiveNeededLibraries(
-		executable,
-		libraryPathSet,
-		neededLibraries,
-	);
-
-	// All optimization strategies required filtering first.
-	const filtereredNeededLibraries: Map<string, DirWithSubpath> = new Map();
-	neededLibraries.forEach((val, key) => {
-		if (val !== undefined) {
-			filtereredNeededLibraries.set(key, val);
-		}
-	});
-	if (strategy === "filter") {
-		return interpreter;
-	}
-
-	switch (strategy) {
-		case "resolve": {
-			interpreter.libraryPaths = await resolvePaths(libraryPathSet);
-			break;
-		}
-		case "isolate": {
-			const isolatedPaths: Array<tg.Directory> = [];
-			for (let [name, referent] of filtereredNeededLibraries.entries()) {
-				let innerDir = await getInner(referent);
-				let libraryFile = await innerDir.tryGet(name);
-				if (libraryFile !== undefined) {
-					tg.File.assert(libraryFile);
-					let isolatedDir = await tg.directory({ name: libraryFile });
-					isolatedPaths.push(isolatedDir);
-				}
-				interpreter.libraryPaths = isolatedPaths;
-			}
-			break;
-		}
-		case "combine": {
-			const entries: Record<string, tg.Artifact> = {};
-			for (let [name, referent] of filtereredNeededLibraries.entries()) {
-				let innerDir = await getInner(referent);
-				let libraryFile = await innerDir.tryGet(name);
-				if (libraryFile !== undefined) {
-					tg.File.assert(libraryFile);
-					entries[name] = libraryFile;
-				}
-				interpreter.libraryPaths = [await tg.directory(entries)];
-			}
-			break;
-		}
-		default: {
-			throw new Error(`unexpected library path strategy: ${strategy}`);
-		}
-	}
-
-	return interpreter;
-};
-
-const getInitialNeededLibraries = async (
-	executable: tg.File,
-): Promise<Map<string, DirWithSubpath | undefined>> => {
-	const neededLibraries = new Map();
-	const neededLibNames = await getNeededLibraries(executable);
-	if (neededLibNames.length > 0) {
-		for (let libName of neededLibNames) {
-			// On macOS, libSystem is provided by the runtime.
-			if (libName.includes("libSystem")) {
-				continue;
-			}
-			neededLibraries.set(libName, undefined);
-		}
-	}
-
-	return neededLibraries;
-};
-
 const getNeededLibraries = async (
 	executable: tg.File,
 ): Promise<Array<string>> => {
@@ -1371,226 +1250,6 @@ const getNeededLibraries = async (
 		throw new Error(
 			"cannot determine needed libraries for non-ELF or Mach-O file",
 		);
-	}
-};
-
-type DirWithSubpath = {
-	dir: tg.Directory.Id;
-	subpath?: string | undefined;
-};
-
-const createLibraryPathSet = async (
-	libraryPaths: Array<tg.Template.Arg>,
-): Promise<Set<DirWithSubpath>> => {
-	const set: Set<DirWithSubpath> = new Set();
-
-	for (let path of libraryPaths) {
-		if (path instanceof tg.Directory) {
-			set.add({ dir: await path.id() });
-		}
-		if (path instanceof tg.Template) {
-			const maybeResult = await tryTemplateToDirWithSubpath(path);
-			if (maybeResult !== undefined) {
-				set.add(maybeResult);
-			}
-		}
-		if (path instanceof tg.Symlink) {
-			const artifact = await path.artifact();
-			if (artifact !== undefined) {
-				tg.Directory.assert(artifact);
-				let ret: DirWithSubpath = { dir: await artifact.id() };
-				const subpath = await path.subpath();
-				if (subpath !== undefined) {
-					ret = { ...ret, subpath };
-				}
-				set.add(ret);
-			}
-		}
-		if (path instanceof tg.File) {
-			throw new Error(`found a file in the library paths:  ${await path.id()}`);
-		}
-	}
-
-	return set;
-};
-
-/** If the template represetns a directory and optional subpath, return it. Otherwise, undefined. */
-const tryTemplateToDirWithSubpath = async (
-	t: tg.Template,
-): Promise<DirWithSubpath | undefined> => {
-	const components = await t.components;
-	const numComponents = components.length;
-	if (numComponents === 1) {
-		// Make sure the first component is a directory.
-		const component = components[0];
-		if (component instanceof tg.Directory) {
-			return {
-				dir: await component.id(),
-			};
-		} else {
-			return undefined;
-		}
-	}
-	if (numComponents === 2) {
-		const first = components[0];
-		const second = components[1];
-		// If the first is a string, assume the second is a directory.
-		if (typeof first === "string") {
-			if (second instanceof tg.Directory) {
-				return {
-					dir: await second.id(),
-				};
-			} else {
-				return undefined;
-			}
-		}
-		if (first instanceof tg.Directory) {
-			if (typeof second === "string") {
-				return {
-					dir: await first.id(),
-					subpath: second,
-				};
-			} else {
-				return undefined;
-			}
-		}
-		return undefined;
-	}
-	if (numComponents === 3) {
-		const first = components[0];
-		const second = components[1];
-		const third = components[2];
-		// With three, the first must be a string we discard, the second must be a directory, and the third must be a string subpath.
-		if (
-			typeof first === "string" &&
-			second instanceof tg.Directory &&
-			typeof third === "string"
-		) {
-			return {
-				dir: await second.id(),
-				subpath: third,
-			};
-		} else {
-			return undefined;
-		}
-	}
-	return undefined;
-};
-
-const findTransitiveNeededLibraries = async (
-	executable: tg.File,
-	libraryPaths: Set<DirWithSubpath>,
-	neededLibraries: Map<string, DirWithSubpath | undefined>,
-) => {
-	return findTransitiveNeededLibrariesInner(
-		executable,
-		libraryPaths,
-		neededLibraries,
-		0,
-	);
-};
-
-const findTransitiveNeededLibrariesInner = async (
-	executable: tg.File,
-	libraryPaths: Set<DirWithSubpath>,
-	neededLibraries: Map<string, DirWithSubpath | undefined>,
-	depth: number,
-) => {
-	const maxDepth = 16;
-
-	// Check if we're done.
-	if (foundAllLibraries(neededLibraries) || depth === maxDepth) {
-		return neededLibraries;
-	}
-
-	// Check for transitive dependencies if we've recurred beyond the initial file.
-	if (depth > 0) {
-		// get new needed libraries. add them to the neededLibraries set.
-		const neededLibNames = await getNeededLibraries(executable);
-		for (let lib of neededLibNames) {
-			if (!neededLibraries.has(lib)) {
-				neededLibraries.set(lib, undefined);
-			}
-		}
-	}
-
-	// Locate and record found libraries.
-	for (let referent of libraryPaths) {
-		const directory = await getInner(referent);
-		const copiedNeededLibraryNames = Array.from(neededLibraries.keys());
-		// Search dir for names.
-		for (let libName of copiedNeededLibraryNames) {
-			// If already found, skip it.
-			if (neededLibraries.get(libName) !== undefined) {
-				continue;
-			}
-			// Otherwise, check if it's here.
-			const maybeLibFile = await directory.tryGet(libName);
-			if (maybeLibFile !== undefined && maybeLibFile instanceof tg.File) {
-				// We found it! Record the location, and recurse.
-				neededLibraries.set(libName, referent);
-				neededLibraries = await findTransitiveNeededLibrariesInner(
-					maybeLibFile,
-					libraryPaths,
-					neededLibraries,
-					depth + 1,
-				);
-				// If we're done now, quit.
-				if (foundAllLibraries(neededLibraries)) {
-					return neededLibraries;
-				}
-			}
-		}
-	}
-
-	return neededLibraries;
-};
-
-/** Did we find an entry for every name in the needed libraries set? */
-const foundAllLibraries = (
-	neededLibraries: Map<string, DirWithSubpath | undefined>,
-) => {
-	return Array.from(neededLibraries.values()).every(
-		(value) => value !== undefined,
-	);
-};
-
-/** Resovle all subpaths to the inner directory. */
-const resolvePaths = async (
-	paths: Set<DirWithSubpath>,
-): Promise<Array<tg.Directory>> => {
-	return await Promise.all([...paths].map(getInner));
-};
-
-const getInner = async (
-	dirWithSubpath: DirWithSubpath,
-): Promise<tg.Directory> => {
-	const { dir, subpath } = dirWithSubpath;
-	const directory = tg.Directory.withId(dir);
-	if (subpath === undefined) {
-		return directory;
-	}
-	const inner = await directory.tryGet(subpath);
-	if (inner !== undefined) {
-		if (inner instanceof tg.Directory) {
-			return inner;
-		}
-		const id = await inner.id();
-		throw new Error(`expected a directory, got ${id}`);
-	} else {
-		throw new Error(`could not get ${inner} from ${dir}`);
-	}
-};
-
-const logMap = (map: Map<string, DirWithSubpath | undefined>) => {
-	for (let [k, v] of map.entries()) {
-		console.log(`${k}: ${v}`);
-	}
-};
-
-const logSet = (set: Set<DirWithSubpath>) => {
-	for (let el of set) {
-		console.log(`dir: ${el.dir}, subpath: ${el.subpath}`);
 	}
 };
 


### PR DESCRIPTION
- rename LibraryPathStrategy, remove integer option
- decouple interpreter construction from manifest serialization
- expose `neededLibraries` for wrappers of dynamically linked executables