### PR TITLE
fix(std): correct potential segfault

### DIFF
--- a/packages/std/packages/wrapper/include/arena.h
+++ b/packages/std/packages/wrapper/include/arena.h
@@ -226,8 +226,11 @@ TG_VISIBILITY char* cstr (Arena *arena, String s) {
 TG_VISIBILITY String executable_path (Arena* arena) {
 	String path;
 #ifdef __linux__
-	path.ptr = "/proc/self/exe";
-	path.len = tg_strlen(path.ptr);
+	path.ptr = ALLOC_N(arena, PATH_MAX + 32, uint8_t);
+	long n = readlink("/proc/self/exe", (char*)path.ptr, PATH_MAX);
+	ABORT_IF(n < 0, "failed to readlink /proc/self/exe");
+	path.ptr[n] = 0;
+	path.len = (uint64_t)n;
 #elif defined(__APPLE__)
 	path.ptr = ALLOC_N(arena, 256, uint8_t);
 	uint32_t size = 255;

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -2566,6 +2566,18 @@ export const argAndEnvDumpCross = () =>
 		host: "x86_64-unknown-linux-gnu",
 	});
 
+/**
+ * Reproduces the wrapper SEGV that occurs when a wrapped binary is invoked on
+ * a host that has neither /.tangram/artifacts nor /opt/tangram/artifacts.
+ */
+export const demoFindArtifactsDirHostRun = async () => {
+	const exe = await argAndEnvDump();
+	return tg.command({
+		executable: { path: "/bin/bash" },
+		args: ["-c", await tg`exec ${exe} hello`, "--"],
+	});
+};
+
 export const test = async () => {
 	await Promise.all([
 		tg.build(testSingleArgObjectNoMutations, {


### PR DESCRIPTION
On main, `executable_path()` in arena.h returned a pointer to `.rodata` containing the literal string `/proc/self/exe`. In sandboxes, the short-circuit path catching `/.tangram/artifacts` worked as intended. However, on my current machine, my artifacts live at `~/.tangram/artifacts`. This caused the bug where running outside the sandbox on a machine with neither `/.tangram artifacts` nor `/opt/tangram/artifacts` resulted in `find_artifacts_dir()` attempting to mutate the executable_path buffer in place, leading to a `SEGV_ACCERR`. This fix instead performs a readlink on `/proc/self/exe` to retrieve the actual path and stores that in a writable buffer instead, which can be mutated if needed.

The included reproduction in `wrap.tg.ts` will segfault on main when run as `tg run -b ./packages/std/wrap.tg.ts#demoFindArtifactsDirHostRun` on a machine with the artifacts directory not in `/opt/tangram/artifacts`, and correctly runs the program without issue with the fix applied.