### PR TITLE
fix(std): correct gconv module resolution in default SDK, correct cmake.build SDK path resolution

### DIFF
--- a/packages/cmake/tangram.ts
+++ b/packages/cmake/tangram.ts
@@ -88,7 +88,7 @@ export async function self(...args: tg.Args<Arg>) {
 		"--system-curl",
 		"--",
 		`-DCMAKE_LIBRARY_PATH="$(echo $LIBRARY_PATH | tr ':' ';')"`,
-		`-DCMAKE_INCLUDE_PATH="$(echo $CPATH | tr ':' ';')"`,
+		`-DCMAKE_INCLUDE_PATH="$(echo $CPATH | tr ':' ';');$(echo | cc -E -Wp,-v - 2>&1 >/dev/null | sed -n 's|^ /|/|p' | tr '\\n' ';')"`,
 	];
 	const prepare = {
 		command: tg.Mutation.prefix("mkdir work && cd work", "\n"),
@@ -370,6 +370,8 @@ export async function build(...args: tg.Args<BuildArg>) {
 	// Include any user-defined env with higher precedence than the SDK and cmake settings.
 	const env = await std.env.arg(...envs, userEnv ?? null);
 
+	const ccName = host !== target ? `${target}-cc` : `cc`;
+
 	// Define default phases.
 	const configureArgs = [
 		`-S`,
@@ -378,6 +380,8 @@ export async function build(...args: tg.Args<BuildArg>) {
 		`"${generator}"`,
 		tg`-DCMAKE_INSTALL_PREFIX=${prefixPath}`,
 		`-DCMAKE_INSTALL_LIBDIR=lib`,
+		`-DCMAKE_LIBRARY_PATH="$(printenv LIBRARY_PATH | tr ':' ';')"`,
+		`-DCMAKE_INCLUDE_PATH="$(printenv CPATH | tr ':' ';');$(echo | ${ccName} -E -Wp,-v - 2>&1 >/dev/null | sed -n 's|^ /|/|p' | tr '\\n' ';')"`,
 		`-B`,
 		buildDir,
 	];

--- a/packages/rust/tgrustc/Cargo.lock
+++ b/packages/rust/tgrustc/Cargo.lock
@@ -2067,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "async-channel",
  "aws-lc-rs",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "tangram_either"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "serde",
  "tangram_serialize",
@@ -2131,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "tangram_futures"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "dashmap",
  "futures",
@@ -2145,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "tangram_http"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2173,7 +2173,7 @@ dependencies = [
 [[package]]
 name = "tangram_pool"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "futures",
  "tangram_futures",
@@ -2183,7 +2183,7 @@ dependencies = [
 [[package]]
 name = "tangram_serialize"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "bytes",
  "num",
@@ -2194,7 +2194,7 @@ dependencies = [
 [[package]]
 name = "tangram_serialize_macro"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -2205,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "tangram_uri"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "derive_more",
  "http",
@@ -2220,7 +2220,7 @@ dependencies = [
 [[package]]
 name = "tangram_util"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "bytes",
  "data-encoding",

--- a/packages/rust/tgrustc/Cargo.lock
+++ b/packages/rust/tgrustc/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.5"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -2067,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "async-channel",
  "aws-lc-rs",
@@ -2122,7 +2122,7 @@ dependencies = [
 [[package]]
 name = "tangram_either"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "serde",
  "tangram_serialize",
@@ -2131,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "tangram_futures"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "dashmap",
  "futures",
@@ -2145,7 +2145,7 @@ dependencies = [
 [[package]]
 name = "tangram_http"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2173,7 +2173,7 @@ dependencies = [
 [[package]]
 name = "tangram_pool"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "futures",
  "tangram_futures",
@@ -2183,7 +2183,7 @@ dependencies = [
 [[package]]
 name = "tangram_serialize"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "bytes",
  "num",
@@ -2194,7 +2194,7 @@ dependencies = [
 [[package]]
 name = "tangram_serialize_macro"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -2205,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "tangram_uri"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "derive_more",
  "http",
@@ -2220,7 +2220,7 @@ dependencies = [
 [[package]]
 name = "tangram_util"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -2805,18 +2805,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/packages/rust/tgrustc/Cargo.toml
+++ b/packages/rust/tgrustc/Cargo.toml
@@ -19,7 +19,7 @@ result_large_err = "allow"
 
 [dependencies]
 rustix = { version = "1", features = ["stdio"] }
-tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "409fd1ccafb8c6c187cd07bd861d66be98ad8688" }
+tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f" }
 tokio = { version = "1", default-features = false, features = ["rt", "fs"] }
 
 [profile.release]

--- a/packages/rust/tgrustc/Cargo.toml
+++ b/packages/rust/tgrustc/Cargo.toml
@@ -19,7 +19,7 @@ result_large_err = "allow"
 
 [dependencies]
 rustix = { version = "1", features = ["stdio"] }
-tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "f383b9e04741fe1a7ec06800ed089b51bf48d1cb" }
+tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "409fd1ccafb8c6c187cd07bd861d66be98ad8688" }
 tokio = { version = "1", default-features = false, features = ["rt", "fs"] }
 
 [profile.release]

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -2343,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "async-channel",
  "aws-lc-rs",
@@ -2398,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "tangram_either"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "serde",
  "tangram_serialize",
@@ -2407,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "tangram_futures"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "dashmap",
  "futures",
@@ -2421,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "tangram_http"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2449,7 +2449,7 @@ dependencies = [
 [[package]]
 name = "tangram_pool"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "futures",
  "tangram_futures",
@@ -2459,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "tangram_serialize"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "bytes",
  "num",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "tangram_serialize_macro"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "itertools 0.15.0",
  "proc-macro2",
@@ -2481,7 +2481,7 @@ dependencies = [
 [[package]]
 name = "tangram_uri"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "derive_more",
  "http",
@@ -2496,7 +2496,7 @@ dependencies = [
 [[package]]
 name = "tangram_util"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
+source = "git+https://github.com/tangramdotdev/tangram?rev=10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f#10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f"
 dependencies = [
  "bytes",
  "data-encoding",

--- a/packages/std/Cargo.lock
+++ b/packages/std/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.5"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -424,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -2343,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "tangram_client"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "async-channel",
  "aws-lc-rs",
@@ -2398,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "tangram_either"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "serde",
  "tangram_serialize",
@@ -2407,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "tangram_futures"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "dashmap",
  "futures",
@@ -2421,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "tangram_http"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2449,7 +2449,7 @@ dependencies = [
 [[package]]
 name = "tangram_pool"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "futures",
  "tangram_futures",
@@ -2459,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "tangram_serialize"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "bytes",
  "num",
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "tangram_serialize_macro"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "itertools 0.15.0",
  "proc-macro2",
@@ -2481,7 +2481,7 @@ dependencies = [
 [[package]]
 name = "tangram_uri"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "derive_more",
  "http",
@@ -2496,7 +2496,7 @@ dependencies = [
 [[package]]
 name = "tangram_util"
 version = "0.0.0"
-source = "git+https://github.com/tangramdotdev/tangram?rev=f383b9e04741fe1a7ec06800ed089b51bf48d1cb#f383b9e04741fe1a7ec06800ed089b51bf48d1cb"
+source = "git+https://github.com/tangramdotdev/tangram?rev=409fd1ccafb8c6c187cd07bd861d66be98ad8688#409fd1ccafb8c6c187cd07bd861d66be98ad8688"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -3280,18 +3280,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -41,9 +41,9 @@ paste = "1"
 rustix = { version = "1", features = ["all-apis"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "409fd1ccafb8c6c187cd07bd861d66be98ad8688" }
-tangram_either = { git = "https://github.com/tangramdotdev/tangram", rev = "409fd1ccafb8c6c187cd07bd861d66be98ad8688" }
-tangram_serialize = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "409fd1ccafb8c6c187cd07bd861d66be98ad8688" }
+tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f" }
+tangram_either = { git = "https://github.com/tangramdotdev/tangram", rev = "10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f" }
+tangram_serialize = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "10cf988d2e9d5e3daed3f0c0a7e76c22e33b1c7f" }
 tempfile = "3"
 tokio = { version = "1", default-features = false, features = [
   "rt",

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -41,9 +41,9 @@ paste = "1"
 rustix = { version = "1", features = ["all-apis"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "f383b9e04741fe1a7ec06800ed089b51bf48d1cb" }
-tangram_either = { git = "https://github.com/tangramdotdev/tangram", rev = "f383b9e04741fe1a7ec06800ed089b51bf48d1cb" }
-tangram_serialize = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "f383b9e04741fe1a7ec06800ed089b51bf48d1cb" }
+tangram_client = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "409fd1ccafb8c6c187cd07bd861d66be98ad8688" }
+tangram_either = { git = "https://github.com/tangramdotdev/tangram", rev = "409fd1ccafb8c6c187cd07bd861d66be98ad8688" }
+tangram_serialize = { default-features = false, git = "https://github.com/tangramdotdev/tangram", rev = "409fd1ccafb8c6c187cd07bd861d66be98ad8688" }
 tempfile = "3"
 tokio = { version = "1", default-features = false, features = [
   "rt",

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -410,7 +410,13 @@ export namespace sdk {
 		const detectedHost = std.triple.host();
 		const host__ = host_ ?? detectedHost;
 		const standardizedHost = std.sdk.canonicalTriple(host__);
-		const isCross = isCrossCompilation(standardizedHost, target);
+		// Compare canonical forms on both sides. A two-part triple such as `aarch64-linux` carries no
+		// environment, so comparing it against a canonicalized host reads as a cross-compilation even
+		// when the caller passed the same string for both.
+		const isCross = isCrossCompilation(
+			standardizedHost,
+			std.sdk.canonicalTriple(target),
+		);
 
 		// Detect compilers and determine flavor and prefix
 		const compilerInfo = await detectCompilers(env, os, target, isCross);
@@ -1013,6 +1019,47 @@ export namespace sdk {
 		return true;
 	}
 
+	/** Assert that glibc's iconv can perform a real charset conversion with no `GCONV_PATH` set, proving the module path compiled into libc resolves. */
+	export async function assertIconv(sdkEnv: std.env.Arg, host: string) {
+		const testProgram = tg.file`
+			#include <stdio.h>
+			#include <string.h>
+			#include <iconv.h>
+
+			int main() {
+				iconv_t cd = iconv_open("ISO-8859-1", "UTF-8");
+				if (cd == (iconv_t)-1) {
+					printf("iconv_open failed\\n");
+					return 1;
+				}
+				char in[] = "caf\\xc3\\xa9";
+				char out[16];
+				char *ip = in, *op = out;
+				size_t il = strlen(in), ol = sizeof(out);
+				if (iconv(cd, &ip, &il, &op, &ol) == (size_t)-1) {
+					printf("iconv failed\\n");
+					return 1;
+				}
+				iconv_close(cd);
+				printf("%d %02x\\n", (int)(op - out), (unsigned char)out[3]);
+				return 0;
+			}`;
+		const output = await std
+			.build(std.shBootstrap`echo "testing iconv"
+				set -x
+				cc -xc ${testProgram} -o iconv-test
+				unset GCONV_PATH
+				./iconv-test > ${tg.output}`)
+			.env(sdkEnv)
+			.host(std.triple.archAndOs(host))
+			.then(tg.File.expect);
+		const text = (await output.text).trim();
+		tg.assert(
+			text === "4 e9",
+			`iconv produced "${text}" instead of a correct UTF-8 to ISO-8859-1 conversion, expected "4 e9"`,
+		);
+	}
+
 	/** Assert the given env provides everything it should for a particuar arg. */
 	export async function assertValid(
 		toolchainDir: tg.Directory,
@@ -1204,6 +1251,14 @@ export namespace sdk {
 				}
 			}),
 		);
+
+		// Only glibc resolves charsets through external gconv modules. musl and darwin's libiconv carry their conversions internally, so they have nothing to wire up.
+		const hostEnvironment = std.triple.environment(expected.host);
+		const isGlibc =
+			hostEnvironment === undefined || hostEnvironment.includes("gnu");
+		if (actualHostOs === "linux" && isGlibc) {
+			await assertIconv(env, expected.host);
+		}
 	}
 
 	export function canonicalTriple(triple: string): string {

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -410,9 +410,6 @@ export namespace sdk {
 		const detectedHost = std.triple.host();
 		const host__ = host_ ?? detectedHost;
 		const standardizedHost = std.sdk.canonicalTriple(host__);
-		// Compare canonical forms on both sides. A two-part triple such as `aarch64-linux` carries no
-		// environment, so comparing it against a canonicalized host reads as a cross-compilation even
-		// when the caller passed the same string for both.
 		const isCross = isCrossCompilation(
 			standardizedHost,
 			std.sdk.canonicalTriple(target),

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -1000,8 +1000,18 @@ export namespace sdk {
 			throw new Error(`Unexpected executable format ${metadata.format}.`);
 		}
 
-		// Assert the result contains a Tangram manifest, meaning it got automatically wrapped.
-		tg.assert((await std.wrap.Manifest.read(compiledProgram)) !== undefined);
+		const manifest = await std.wrap.Manifest.read(compiledProgram);
+		if (proxiedLinker) {
+			tg.assert(
+				manifest !== undefined,
+				`Expected the linker proxy to wrap the output of ${title}, but it contains no manifest.`,
+			);
+		} else {
+			tg.assert(
+				manifest === undefined,
+				`Expected a bypassed linker proxy to leave the output of ${title} unwrapped, but it contains a manifest.`,
+			);
+		}
 
 		// If we are not cross-compiling, assert we can execute the program and recieve the expected result, without providing the SDK env at runtime.
 		if (!isCross && proxiedLinker) {
@@ -1095,7 +1105,9 @@ export namespace sdk {
 		// Assert it can compile and wrap for all requested targets.
 		const allTargets = await sdk.supportedTargets(env);
 		// If there is an un-prefixed CC, add the host to the list.
-		if (await std.env.tryWhich({ env, name: "cc" })) {
+		const hasNativeCc =
+			(await std.env.tryWhich({ env, name: "cc" })) !== undefined;
+		if (hasNativeCc) {
 			allTargets.push(actualHost);
 		}
 		await Promise.all(
@@ -1249,11 +1261,15 @@ export namespace sdk {
 			}),
 		);
 
-		// Only glibc resolves charsets through external gconv modules. musl and darwin's libiconv carry their conversions internally, so they have nothing to wire up.
 		const hostEnvironment = std.triple.environment(expected.host);
 		const isGlibc =
 			hostEnvironment === undefined || hostEnvironment.includes("gnu");
-		if (actualHostOs === "linux" && isGlibc) {
+		if (
+			actualHostOs === "linux" &&
+			isGlibc &&
+			hasNativeCc &&
+			(arg?.proxyLinker ?? true)
+		) {
 			await assertIconv(env, expected.host);
 		}
 	}

--- a/packages/std/sdk/cmake.tg.ts
+++ b/packages/std/sdk/cmake.tg.ts
@@ -275,6 +275,12 @@ export async function build(...args: tg.Args<BuildArg>) {
 			? await std.env.compose(...envs, userEnv ?? null)
 			: await std.env.arg(...envs, userEnv ?? null);
 
+	const ccName = host !== target ? `${target}-cc` : `cc`;
+	const searchPathArgs = [
+		`-DCMAKE_LIBRARY_PATH="$(printenv LIBRARY_PATH | tr ':' ';')"`,
+		`-DCMAKE_INCLUDE_PATH="$(printenv CPATH | tr ':' ';');$(echo | ${ccName} -E -Wp,-v - 2>&1 >/dev/null | sed -n 's|^ /|/|p' | tr '\\n' ';')"`,
+	];
+
 	// Define default phases.
 	const configureArgs = [
 		`-S`,
@@ -282,6 +288,7 @@ export async function build(...args: tg.Args<BuildArg>) {
 		`-G`,
 		`"${generator}"`,
 		tg`-DCMAKE_INSTALL_PREFIX=${prefixPath}`,
+		...searchPathArgs,
 		`-B`,
 		buildDir,
 	];

--- a/packages/std/sdk/libc/glibc.tg.ts
+++ b/packages/std/sdk/libc/glibc.tg.ts
@@ -86,25 +86,6 @@ export async function build(arg: tg.Unresolved<Arg>) {
 	}
 
 	const configure = {
-		pre: `
-			echo "=== TG-DIAG begin ==="
-			echo "--- PATH ---"
-			echo "$PATH" | tr ':' '\\n'
-			echo "--- env ---"
-			env | sort
-			echo "--- which ${host}-gcc ---"
-			command -v ${host}-gcc || echo "TG-DIAG: not found"
-			echo "--- gcc -dumpmachine ---"
-			${host}-gcc -dumpmachine || echo "TG-DIAG: dumpmachine failed"
-			echo "--- gcc -print-search-dirs ---"
-			${host}-gcc -print-search-dirs || echo "TG-DIAG: print-search-dirs failed"
-			echo "--- compile test ---"
-			echo 'int main(void) { return 0; }' > tg-conftest.c
-			status=0
-			${host}-gcc -v -c tg-conftest.c -o tg-conftest.o || status=$?
-			echo "TG-DIAG: compile exited with $status"
-			echo "=== TG-DIAG end ==="
-		`,
 		body: {
 			args: [
 				"--disable-nls",
@@ -121,15 +102,6 @@ export async function build(arg: tg.Unresolved<Arg>) {
 		},
 	};
 
-	const install = {
-		args: [tg`DESTDIR="${tg.output}/${host}"`],
-	};
-
-	const phases = {
-		configure,
-		install,
-	};
-
 	const env: tg.Args<std.env.Arg> = [env_ ?? null];
 
 	env.push({
@@ -142,19 +114,55 @@ export async function build(arg: tg.Unresolved<Arg>) {
 		),
 	});
 
-	let result = await std.autotools.build({
-		build,
-		host,
-		defaultCrossArgs: false,
-		defaultCrossEnv: false,
-		env: std.env.compose(...env),
-		fortifySource: false,
-		hardeningCFlags: false,
-		opt: "3",
-		phases,
-		prefixPath: "/",
-		...std.args.optional("sdk", sdk),
-		source: source_ ?? source(version),
+	const buildOnce = async (gconvDir?: tg.Directory) => {
+		const gconvArgs = gconvDir !== undefined ? [tg`gconvdir=${gconvDir}`] : [];
+		const phases = {
+			configure,
+			...(gconvDir !== undefined ? { build: { args: gconvArgs } } : {}),
+			install: {
+				args: [tg`DESTDIR="${tg.output}/${host}"`, ...gconvArgs],
+			},
+		};
+		return await std.autotools.build({
+			build,
+			host,
+			defaultCrossArgs: false,
+			defaultCrossEnv: false,
+			env: std.env.compose(...env),
+			fortifySource: false,
+			hardeningCFlags: false,
+			opt: "3",
+			phases,
+			prefixPath: "/",
+			...std.args.optional("sdk", sdk),
+			source: source_ ?? source(version),
+		});
+	};
+
+	// glibc compiles its gconv module path in from `gconvdir`, defaulting to the
+	// absolute `/lib/gconv`, which never exists in a sandbox. The path can only
+	// name the modules once they are addressable, so pass 1 produces them and pass
+	// 2 compiles in where they landed.
+	const pass1 = await buildOnce();
+	const gconvModules = await pass1
+		.get(`${host}/lib/gconv`)
+		.then(tg.Directory.expect);
+
+	let result = await buildOnce(gconvModules);
+
+	result = await tg.directory(result, {
+		[`${host}/opt`]: null,
+		[`${host}/lib/gconv`]: gconvModules,
+	});
+
+	await gconvModules.store();
+	const libcPath = `${host}/lib/libc.so.6`;
+	const libc = await result.get(libcPath).then(tg.File.expect);
+	result = await tg.directory(result, {
+		[libcPath]: tg.file(libc, {
+			executable: true,
+			dependencies: { [gconvModules.id]: gconvModules },
+		}),
 	});
 
 	// Fix libc.so.


### PR DESCRIPTION
- The gconv module directory is attached to libc.so.6 as an ordinary file dependency, so it is locatable at runtime instead of failing on the hardcoded `/lib/gconv` path.
- The ${host}/opt tree that make install creates as DESTDIR's mirror of the absolute gconvdir is deleted from the output and replaced by a direct lib/gconv entry.
- A leftover TG-DIAG diagnostic block was removed from glibc's configure phase.
- `assertValid` now includes `sdk.assertIconv` which compiles and runs a real UTF-8 → ISO-8859-1 conversion with GCONV_PATH unset, so it passes only if the path compiled into libc resolves on its own.
- assertCompiler's manifest check now asserts both directions — a proxied linker must wrap its output, and a bypassed one must leave it unwrapped — replacing an assertion that had been vacuously passing on a Promise since the initial commit and failed the moment 627cb85a added the missing await.
- sdk/cmake.tg.ts and packages/cmake both now pass CMAKE_LIBRARY_PATH and CMAKE_INCLUDE_PATH built from LIBRARY_PATH and CPATH, because CMake's find_path/find_library search their own prefix lists and never ask the compiler where it looks.
- CMAKE_INCLUDE_PATH also appends the compiler's own default include directories, scraped from cc -E -Wp,-v, which autoconf discovers for free by compiling test programs.
- toolchainComponents canonicalizes the target before comparing it against the host, so a two-part triple like aarch64-linux no longer reads as a cross-compilation when the caller passed the same string for both.
- bump deps