### PR TITLE
fix(std): read the wrapper manifest from the mapped image

### DIFF
--- a/packages/std/packages/common/src/manifest.rs
+++ b/packages/std/packages/common/src/manifest.rs
@@ -230,9 +230,6 @@ impl Manifest {
 		tracing::debug!(?self, "Embedding manifest");
 
 		// Get the paths of the required files.
-		let wrapper_bin = TANGRAM_WRAPPER_BIN_PATH
-			.as_ref()
-			.ok_or_else(|| tg::error!("missing wrapper bin"))?;
 		let wrapper_exe = TANGRAM_WRAPPER_EXE_PATH
 			.as_ref()
 			.ok_or_else(|| tg::error!("missing wrapper exe"))?;
@@ -245,7 +242,6 @@ impl Manifest {
 			.map_err(|error| tg::error!(!error, "failed to check out the input file"))?;
 
 		// Provide the context to wrap.
-		wrap::set_wrapper_bin_path(wrapper_bin.clone());
 		wrap::set_wrapper_exe_path(wrapper_exe.clone());
 		if let Some(objcopy) = objcopy {
 			wrap::set_objcopy_path(objcopy.clone());
@@ -607,12 +603,6 @@ fn dependency_from_object_id(id: &tg::object::Id) -> Option<tg::file::Dependency
 
 // These are rendered from artifacts in the manifest, so each is a dependency already present in an
 // artifact root.
-static TANGRAM_WRAPPER_BIN_PATH: LazyLock<Option<PathBuf>> = LazyLock::new(|| {
-	std::env::var("TANGRAM_WRAPPER_BIN_PATH")
-		.ok()
-		.map(PathBuf::from)
-});
-
 static TANGRAM_WRAPPER_EXE_PATH: LazyLock<Option<PathBuf>> = LazyLock::new(|| {
 	std::env::var("TANGRAM_WRAPPER_EXE_PATH")
 		.ok()

--- a/packages/std/packages/wrap/src/elf.rs
+++ b/packages/std/packages/wrap/src/elf.rs
@@ -96,8 +96,6 @@ macro_rules! impl_elf {
 				}
 			}
 
-			/// Get the offset of the program header of the loadable segment whose file contents end
-			/// last. The manifest goes at the end of it, where the wrapper looks for the footer.
 			fn last_loadable_segment(&self, file: &File) -> Option<usize> {
 				let phdr_size = size_of::<paste! {[<$elf _Phdr>]}>();
 				let (phdr_offset, phdr_count) = {
@@ -123,8 +121,6 @@ macro_rules! impl_elf {
 				last.map(|(offset, _)| offset)
 			}
 
-			/// Get the end of the last address the loadable segments occupy, the largest alignment
-			/// they require, and the distance between their addresses and their offsets.
 			fn image_extent(&self, file: &File) -> (usize, usize, usize) {
 				let phdr_size = size_of::<paste! {[<$elf _Phdr>]}>();
 				let (phdr_offset, phdr_count) = {
@@ -155,19 +151,10 @@ macro_rules! impl_elf {
 				(max_vaddr, max_align, vaddr - offset)
 			}
 
-			/// Choose the offset, address, and alignment of a new loadable segment at the end of the
-			/// file. It goes after every address the image already occupies, and the same distance from
-			/// its offset as the rest of the image, because a kernel before 5.19 reports the program
-			/// header table at the load address plus `e_phoff` rather than at the address of the
-			/// segment holding it. Both computations agree only when every segment keeps the same
-			/// distance.
 			fn appended_segment(&self, file: &File, file_size: usize) -> (usize, usize, usize) {
 				let (max_vaddr, max_align, bias) = self.image_extent(file);
 				let offset = align(file_size.max(align(max_vaddr, max_align) - bias), max_align);
 
-				// The segment is placed at the largest alignment in the image, but it can only claim
-				// an alignment its own address and offset agree on, which an image loaded at an
-				// unusual address may not.
 				let mut segment_align = max_align;
 				while bias % segment_align != 0 {
 					segment_align /= 2;
@@ -175,11 +162,6 @@ macro_rules! impl_elf {
 				(offset, offset + bias, segment_align)
 			}
 
-			/// Add the manifest in a new read-only segment at the end of the file. This is for images
-			/// whose last loadable segment has a bss, which cannot be extended over file data without
-			/// initializing memory that must stay zero-filled. The segment also holds a copy of the elf
-			/// header and a program header table with room for itself, because the wrapper reads both
-			/// from the addresses the kernel maps them at.
 			fn append_manifest_segment(
 				&self,
 				file: &mut File,
@@ -199,8 +181,6 @@ macro_rules! impl_elf {
 				};
 				let new_phdr_count = phdr_count + 1;
 
-				// The section table goes first, so that the manifest and its footer are the last bytes
-				// of the file, and so of the segment.
 				let file_size = file
 					.file_size()
 					.expect("failed to get the file size")
@@ -214,7 +194,6 @@ macro_rules! impl_elf {
 				let new_section_offset = headers_offset + new_phdr_count * phdr_size;
 				let segment_size = new_section_offset + data.len() - segment_offset;
 
-				// Add the manifest section.
 				let new_section_header = paste! {[<$elf _Shdr>] {
 					sh_type: sys::SHT_NOTE,
 					sh_offset: new_section_offset.try_into().unwrap(),
@@ -231,7 +210,6 @@ macro_rules! impl_elf {
 				}};
 				section_table.extend_from_slice(new_section_header.as_bytes());
 
-				// Build the new program header table, moving PT_PHDR along with it.
 				let new_segment = paste! {[<$elf _Phdr>] {
 					p_type: sys::PT_LOAD,
 					p_flags: sys::PF_R,
@@ -263,11 +241,9 @@ macro_rules! impl_elf {
 					phdr_bytes.extend_from_slice(phdr.as_bytes());
 				}
 
-				// The new segment goes last, which keeps the loadable segments in address order
-				// because it is above every address the image already occupies.
+				// The new segment is above the existing image, preserving PT_LOAD order.
 				phdr_bytes.extend_from_slice(new_segment.as_bytes());
 
-				// Write the section table, then the segment.
 				let padding = section_table_offset - file_size;
 				if padding > 0 {
 					file.append(&vec![0; padding])
@@ -365,12 +341,7 @@ macro_rules! impl_elf {
 					}
 				}
 
-				// The blob that gets appended is the wrapper's memory image, not its file. The stub
-				// segment below maps the blob contiguously at a single address, while the wrapper's
-				// own segments sit at different distances from their offsets, and its code reaches
-				// its data by the distances the linker resolved. Copying the file would move that
-				// data out from under the code, with nothing to notice: a static PIE reaching a
-				// hidden global emits a plain pc-relative address and no relocation at all.
+				// Reconstruct the wrapper's memory image from its loadable segments.
 				let wrapper_exe = std::fs::read(&wrapper_exe_path)?;
 				let wrapper_ehdr = paste! {[<$elf _Ehdr>]::read_from_bytes(
 					&wrapper_exe[0..size_of::<[<$elf _Ehdr>]>()],
@@ -412,8 +383,6 @@ macro_rules! impl_elf {
 						)
 					})?;
 
-				// Lay each segment down at its address. The gaps between them, and any memory a
-				// segment claims past its file contents, stay zero.
 				let image_size = wrapper_segments
 					.iter()
 					.map(|&(_, vaddr, _, memsz)| vaddr + memsz - min_vaddr)
@@ -448,7 +417,6 @@ macro_rules! impl_elf {
 					)
 				};
 
-				// Find the PT_INTERP header and where a new segment can go.
 				let mut pt_interp_index: Option<usize> = None;
 				for i in 0..phdr_count {
 					let off = phdr_offset + i * phdr_size;
@@ -496,19 +464,15 @@ macro_rules! impl_elf {
 				let manifest_shdr_offset = manifest_shdr_offset
 					.ok_or_else(|| std::io::Error::other("missing manifest section"))?;
 
-				// Compute the data layout. The footer is included so that the segment covers the same
-				// bytes as the manifest section header, which counts it in its size.
 				let wrapper_data_size =
 					wrapper_image.len() + manifest.len() + size_of::<crate::Footer>();
 
-				// Determine the wrapper offset and address, and build a new phdr table if needed.
 				let new_phdr_table: Option<(Vec<u8>, usize)>;
 				let wrapper_offset: usize;
 				let wrapper_vaddr: usize;
 
 				if let Some(interpreter_index) = pt_interp_index {
-					// Reuse PT_INTERP header for the stub segment. The existing program header table
-					// stays where it is, so the kernel keeps mapping it and reporting it in AT_PHDR.
+					// Reuse PT_INTERP for the stub segment.
 					assert_eq!(
 						phdr_offset,
 						size_of::<paste! {[<$elf _Ehdr>]}>(),
@@ -531,9 +495,7 @@ macro_rules! impl_elf {
 					let offset = phdr_offset + interpreter_index * phdr_size;
 					file[offset..offset + phdr_size].copy_from_slice(stub_segment.as_bytes());
 				} else {
-					// Create a new program header table if there's no PT_INTERP we can abuse. It goes
-					// inside the stub segment, preceded by a copy of the elf header, because the
-					// wrapper reads both from the addresses the kernel maps them at.
+					// Put a copied ELF header and new program header table in the stub.
 					let new_count = phdr_count + 1;
 					let headers_size = size_of::<paste! {[<$elf _Ehdr>]}>() + new_count * phdr_size;
 					let stub_size = align(headers_size, segment_align) + wrapper_data_size;
@@ -555,7 +517,6 @@ macro_rules! impl_elf {
 					let mut bytes = Vec::with_capacity(new_count * phdr_size);
 					let mut load_entries = Vec::new();
 
-					// Collect all loadable segments, including the stub, and order them by address.
 					for i in 0..phdr_count {
 						let off = phdr_offset + i * phdr_size;
 						let phdr = paste! {[<$elf _Phdr>]::read_from_bytes(&file[off..off + phdr_size])}.unwrap();
@@ -657,8 +618,6 @@ macro_rules! impl_elf {
 					}
 				}
 
-				// Write new program header table if necessary, preceded by a copy of the patched elf
-				// header, which is where the wrapper looks for it.
 				if let Some((phdr_bytes, headers_offset)) = new_phdr_table {
 					let ehdr_bytes = self.elf_header(&file).as_bytes().to_vec();
 					let padding = headers_offset - ehdr_bytes.len() - file_size;
@@ -679,7 +638,6 @@ macro_rules! impl_elf {
 					}
 				}
 
-				// Append the wrapper executable.
 				file.append(&wrapper_image)?;
 
 				// Append manifest.
@@ -745,14 +703,11 @@ macro_rules! impl_elf {
 				let string_table_location = self.section_string_table(file);
 				let mut section_table_location = self.section_header_table(file);
 
-				// Get the section table, before the insert below moves it.
 				let mut section_table = file[section_table_location].to_vec();
 
-				// The name goes at the end of the string table, so its index is the old length.
 				let name_index = string_table_location.length;
 
-				// Update existing sections. Growing the string table in place shifts everything after
-				// it along by the length of the name.
+				// Account for growing the section string table.
 				let shift = <paste! {[<$elf _Off>]}>::try_from(name_len).unwrap();
 				for (index, chunk) in section_table
 					.chunks_exact_mut(size_of::<paste! {[<$elf _Shdr>]}>())
@@ -769,19 +724,15 @@ macro_rules! impl_elf {
 					}
 				}
 
-				// Append the name to the string table.
 				file.insert(name, string_table_location.end().to_u64().unwrap())
 					.expect("failed to insert string table");
 
-				// Delete the old section table, which the insert may have moved.
 				if section_table_location.offset >= string_table_location.end() {
 					section_table_location.offset += name_len;
 				}
 				file.delete(section_table_location)
 					.expect("failed to delete section table");
 
-				// Get the segment the manifest will be added to, and the distance between its
-				// addresses and its offsets.
 				let phdr_size = size_of::<paste! {[<$elf _Phdr>]}>();
 				let segment_offset = self
 					.last_loadable_segment(file)
@@ -794,8 +745,7 @@ macro_rules! impl_elf {
 					"segment file size exceeds its memory size",
 				);
 
-				// Extending a segment with a BSS would make the bytes after p_filesz initialize
-				// memory which must remain zero-filled, so give the manifest a segment of its own.
+				// Do not turn BSS into file-backed data.
 				if segment.p_filesz < segment.p_memsz {
 					self.append_manifest_segment(file, data, section_table, name_index);
 					return;
@@ -803,16 +753,12 @@ macro_rules! impl_elf {
 				let vaddr_delta =
 					segment.p_vaddr.to_usize().unwrap() - segment.p_offset.to_usize().unwrap();
 
-				// The section table is written before the manifest, so that the manifest and its
-				// footer are the last bytes of the file, and so of the segment extended below.
 				let section_table_offset = file.file_size().expect("failed to get the file size");
 				let new_section_offset = section_table_offset.to_usize().unwrap()
 					+ section_table.len()
 					+ size_of::<paste! {[<$elf _Shdr>]}>();
 
-				// Create the new section. It is allocated, so that a tool which repacks the file keeps
-				// it inside the segment extended below rather than moving it out with the other
-				// sections that are not part of the image.
+				// SHF_ALLOC keeps the manifest mapped after strip.
 				let new_section_header = paste! {[<$elf _Shdr>]{
 					sh_type: sys::SHT_NOTE,
 					sh_offset: new_section_offset .try_into().unwrap(),
@@ -833,11 +779,9 @@ macro_rules! impl_elf {
 				file.append(&section_table)
 					.expect("failed to write the new section table to the file");
 
-				// Write the new section.
 				file.append(data)
 					.expect("failed to write new section to end of file");
 
-				// Extend the segment so that the kernel maps the manifest.
 				let file_size = file.file_size().expect("failed to get the file size");
 				let segment =
 					paste! {[<$elf _Phdr>]::mut_from_bytes(&mut file[segment_offset..segment_offset + phdr_size])}
@@ -890,8 +834,7 @@ macro_rules! impl_elf {
 					}
 				}
 
-				// Update the segment containing the manifest, so that its file size continues to
-				// cover the whole manifest and footer.
+				// Keep the manifest covered by its segment.
 				let phdr_size = size_of::<paste! {[<$elf _Phdr>]}>();
 				let (phdr_offset, phdr_count) = {
 					let ehdr = self.elf_header(file);

--- a/packages/std/packages/wrap/src/elf.rs
+++ b/packages/std/packages/wrap/src/elf.rs
@@ -96,6 +96,33 @@ macro_rules! impl_elf {
 				}
 			}
 
+			/// Get the offset of the program header of the loadable segment whose file contents end
+			/// last. The manifest goes at the end of it, where the wrapper looks for the footer.
+			fn last_loadable_segment(&self, file: &File) -> Option<usize> {
+				let phdr_size = size_of::<paste! {[<$elf _Phdr>]}>();
+				let (phdr_offset, phdr_count) = {
+					let ehdr = self.elf_header(file);
+					(
+						ehdr.e_phoff.to_usize().unwrap(),
+						ehdr.e_phnum.to_usize().unwrap(),
+					)
+				};
+				let mut last: Option<(usize, usize)> = None;
+				for i in 0..phdr_count {
+					let offset = phdr_offset + i * phdr_size;
+					let phdr = paste! {[<$elf _Phdr>]::read_from_bytes(&file[offset..offset + phdr_size])}
+						.expect("expected a program header");
+					if phdr.p_type != sys::PT_LOAD {
+						continue;
+					}
+					let end = phdr.p_offset.to_usize().unwrap() + phdr.p_filesz.to_usize().unwrap();
+					if last.is_none_or(|(_, last_end)| end > last_end) {
+						last = Some((offset, end));
+					}
+				}
+				last.map(|(offset, _)| offset)
+			}
+
 			fn section_header_table(&self, file: &File) -> FileLocation {
 				let ehdr = self.elf_header(file);
 				FileLocation {
@@ -191,8 +218,9 @@ macro_rules! impl_elf {
 					)
 				};
 
-				// Find PT_INTERP header and compute max virtual address / alignment.
+				// Find PT_INTERP header and compute the virtual address range / alignment.
 				let mut pt_interp_index: Option<usize> = None;
+				let mut min_vaddr = <paste! {[<$elf _Off>]}>::MAX;
 				let mut max_vaddr = 0;
 				let mut max_align = 0;
 				for i in 0..phdr_count {
@@ -200,6 +228,7 @@ macro_rules! impl_elf {
 					let phdr = paste! {[<$elf _Phdr>]::read_from_bytes(&file[off..off + phdr_size])}
 						.expect("invalid program header");
 					if phdr.p_type == sys::PT_LOAD {
+						min_vaddr = min_vaddr.min(phdr.p_vaddr);
 						max_vaddr = max_vaddr.max(phdr.p_vaddr + phdr.p_memsz);
 						max_align = max_align.max(phdr.p_align);
 					}
@@ -208,6 +237,8 @@ macro_rules! impl_elf {
 						pt_interp_index = Some(i);
 					}
 				}
+				let min_vaddr = min_vaddr.to_usize().unwrap();
+				let max_align = max_align.to_usize().unwrap();
 
 				// Find wrapper and manifest section headers in a single pass.
 				let mut wrapper_shdr_offset: Option<usize> = None;
@@ -247,53 +278,67 @@ macro_rules! impl_elf {
 				// bytes as the manifest section header, which counts it in its size.
 				let wrapper_data_size =
 					wrapper_exe.len() + manifest.len() + size_of::<crate::Footer>();
-				let wrapper_vaddr = align(max_vaddr.to_usize().unwrap(), max_align.to_usize().unwrap())
-					.try_into()
-					.unwrap();
-				let wrapper_memsz = align(wrapper_data_size, max_align.to_usize().unwrap())
-					.try_into()
-					.unwrap();
 
-				// Determine wrapper offset and build new phdr table if needed.
+				// Determine the wrapper offset and address, and build a new phdr table if needed.
 				let new_phdr_table: Option<(Vec<u8>, usize)>;
 				let wrapper_offset: usize;
+				let wrapper_vaddr: usize;
 
 				if let Some(interpreter_index) = pt_interp_index {
-					// Reuse PT_INTERP header for the stub segment.
-					wrapper_offset = align(file_size, max_align.to_usize().unwrap());
+					// Reuse PT_INTERP header for the stub segment. The existing program header table
+					// stays where it is, so the kernel keeps mapping it and reporting it in AT_PHDR.
+					assert_eq!(
+						phdr_offset,
+						size_of::<paste! {[<$elf _Ehdr>]}>(),
+						"the program header table must follow the elf header",
+					);
+					wrapper_offset = align(file_size, max_align);
+					wrapper_vaddr = align(max_vaddr.to_usize().unwrap(), max_align);
 					new_phdr_table = None;
 
 					let stub_segment = paste! {[<$elf _Phdr>] {
 						p_type: sys::PT_LOAD,
 						p_flags: sys::PF_R | sys::PF_X,
 						p_offset: wrapper_offset.try_into().unwrap(),
-						p_vaddr: wrapper_vaddr,
-						p_paddr: wrapper_vaddr,
+						p_vaddr: wrapper_vaddr.try_into().unwrap(),
+						p_paddr: wrapper_vaddr.try_into().unwrap(),
 						p_filesz: wrapper_data_size.try_into().unwrap(),
-						p_memsz: wrapper_memsz,
-						p_align: max_align,
+						p_memsz: align(wrapper_data_size, max_align).try_into().unwrap(),
+						p_align: max_align.try_into().unwrap(),
 					}};
 					let offset = phdr_offset + interpreter_index * phdr_size;
 					file[offset..offset + phdr_size].copy_from_slice(stub_segment.as_bytes());
 				} else {
-					// Create a new section header if there's no PT_INTERP we can abuse.
-					let headers_offset = align(file_size, 64);
+					// Create a new program header table if there's no PT_INTERP we can abuse. It goes
+					// inside the stub segment, preceded by a copy of the elf header, because the
+					// wrapper reads both from the addresses the kernel maps them at. The segment's
+					// address matches its offset so that AT_PHDR is correct on kernels that compute
+					// it as the load address plus e_phoff.
 					let new_count = phdr_count + 1;
-					let headers_size = new_count * phdr_size;
-					wrapper_offset = align(headers_offset + headers_size, max_align.to_usize().unwrap());
+					let headers_size = size_of::<paste! {[<$elf _Ehdr>]}>() + new_count * phdr_size;
+					let stub_size = align(headers_size, max_align) + wrapper_data_size;
+					let mut segment_offset = align(file_size, max_align);
+					if segment_offset < max_vaddr.to_usize().unwrap()
+						&& segment_offset + stub_size > min_vaddr
+					{
+						segment_offset = align(max_vaddr.to_usize().unwrap(), max_align);
+					}
+					let headers_offset = segment_offset + size_of::<paste! {[<$elf _Ehdr>]}>();
+					wrapper_offset = segment_offset + align(headers_size, max_align);
+					wrapper_vaddr = wrapper_offset;
 
 					let stub_segment = paste! {[<$elf _Phdr>]{
 						p_type: sys::PT_LOAD,
 						p_flags: sys::PF_R | sys::PF_X,
-						p_offset: wrapper_offset.try_into().unwrap(),
-						p_vaddr: wrapper_vaddr,
-						p_paddr: wrapper_vaddr,
-						p_filesz: wrapper_data_size.try_into().unwrap(),
-						p_memsz: wrapper_memsz,
-						p_align: max_align,
+						p_offset: segment_offset.try_into().unwrap(),
+						p_vaddr: segment_offset.try_into().unwrap(),
+						p_paddr: segment_offset.try_into().unwrap(),
+						p_filesz: stub_size.try_into().unwrap(),
+						p_memsz: align(stub_size, max_align).try_into().unwrap(),
+						p_align: max_align.try_into().unwrap(),
 					}};
 
-					let mut bytes = Vec::with_capacity(headers_size);
+					let mut bytes = Vec::with_capacity(new_count * phdr_size);
 
 					// Copy existing loadable segments first.
 					for i in 0..phdr_count {
@@ -317,7 +362,7 @@ macro_rules! impl_elf {
 						}
 					}
 
-					assert_eq!(bytes.len(), headers_size);
+					assert_eq!(bytes.len(), new_count * phdr_size);
 					new_phdr_table = Some((bytes, headers_offset));
 				}
 
@@ -328,11 +373,11 @@ macro_rules! impl_elf {
 				.unwrap();
 				wrapper_shdr.sh_type = sys::SHT_PROGBITS;
 				wrapper_shdr.sh_flags = (sys::SHF_ALLOC | sys::SHF_EXECINSTR).try_into().unwrap();
-				wrapper_shdr.sh_addr = wrapper_vaddr;
+				wrapper_shdr.sh_addr = wrapper_vaddr.try_into().unwrap();
 				wrapper_shdr.sh_offset = wrapper_offset.try_into().unwrap();
 				wrapper_shdr.sh_size = wrapper_data_size.try_into().unwrap();
 				wrapper_shdr.sh_link = 0;
-				wrapper_shdr.sh_addralign = max_align;
+				wrapper_shdr.sh_addralign = max_align.try_into().unwrap();
 				wrapper_shdr.sh_entsize = 0;
 				file[wrapper_shdr_offset..wrapper_shdr_offset + shdr_size]
 					.copy_from_slice(wrapper_shdr.as_bytes());
@@ -343,9 +388,8 @@ macro_rules! impl_elf {
 				.unwrap();
 				manifest_shdr.sh_type = sys::SHT_NOTE;
 				manifest_shdr.sh_flags = 0;
-				manifest_shdr.sh_addr = (wrapper_vaddr.to_usize().unwrap() + wrapper_exe.len()).try_into().unwrap();
-				manifest_shdr.sh_offset =
-					(wrapper_offset.to_usize().unwrap() + wrapper_exe.len()).try_into().unwrap();
+				manifest_shdr.sh_addr = (wrapper_vaddr + wrapper_exe.len()).try_into().unwrap();
+				manifest_shdr.sh_offset = (wrapper_offset + wrapper_exe.len()).try_into().unwrap();
 				manifest_shdr.sh_size =
 					(manifest.len() + size_of::<crate::Footer>()).try_into().unwrap();
 				manifest_shdr.sh_link = 0;
@@ -363,7 +407,9 @@ macro_rules! impl_elf {
 
 				// Patch the entrypoint.
 				let ehdr = self.elf_header_mut(&mut file);
-				ehdr.e_entry = wrapper_vaddr + wrapper_entry;
+				ehdr.e_entry = (wrapper_vaddr + wrapper_entry.to_usize().unwrap())
+					.try_into()
+					.unwrap();
 
 				// Patch program header table or sort existing headers.
 				if let Some((_, headers_offset)) = &new_phdr_table {
@@ -394,12 +440,15 @@ macro_rules! impl_elf {
 					}
 				}
 
-				// Write new program header table if necessary.
+				// Write new program header table if necessary, preceded by a copy of the patched elf
+				// header, which is where the wrapper looks for it.
 				if let Some((phdr_bytes, headers_offset)) = new_phdr_table {
-					let padding = headers_offset - file_size;
+					let ehdr_bytes = self.elf_header(&file).as_bytes().to_vec();
+					let padding = headers_offset - ehdr_bytes.len() - file_size;
 					if padding > 0 {
 						file.append(&vec![0u8; padding])?;
 					}
+					file.append(&ehdr_bytes)?;
 					file.append(&phdr_bytes)?;
 					let padding = wrapper_offset - headers_offset - phdr_bytes.len();
 					if padding > 0 {
@@ -515,12 +564,28 @@ macro_rules! impl_elf {
 				file.delete(section_table_location)
 					.expect("failed to delete section table");
 
-				// Get the offset of the end of the file.
-				let new_section_offset = file.file_size().expect("failed to get the file size");
+				// Get the segment the manifest will be added to, and the distance between its
+				// addresses and its offsets.
+				let phdr_size = size_of::<paste! {[<$elf _Phdr>]}>();
+				let segment_offset = self
+					.last_loadable_segment(file)
+					.expect("expected a loadable segment");
+				let segment =
+					paste! {[<$elf _Phdr>]::read_from_bytes(&file[segment_offset..segment_offset + phdr_size])}
+						.expect("expected a program header");
+				assert_eq!(
+					segment.p_filesz, segment.p_memsz,
+					"cannot extend a segment with a bss",
+				);
+				let vaddr_delta =
+					segment.p_vaddr.to_usize().unwrap() - segment.p_offset.to_usize().unwrap();
 
-				// Write the new section.
-				file.append(data)
-					.expect("failed to write new section to end of file");
+				// The section table is written before the manifest, so that the manifest and its
+				// footer are the last bytes of the file, and so of the segment extended below.
+				let section_table_offset = file.file_size().expect("failed to get the file size");
+				let new_section_offset = section_table_offset.to_usize().unwrap()
+					+ section_table.len()
+					+ size_of::<paste! {[<$elf _Shdr>]}>();
 
 				// Create the new section.
 				let sh_type = sys::SHT_NOTE;
@@ -529,7 +594,7 @@ macro_rules! impl_elf {
 					sh_type: sh_type .try_into().unwrap(),
 					sh_offset: new_section_offset .try_into().unwrap(),
 					sh_size: data.len() .try_into().unwrap(),
-					sh_addr: 0,
+					sh_addr: (new_section_offset + vaddr_delta) .try_into().unwrap(),
 					sh_name: name_index .try_into().unwrap(),
 					sh_flags: sh_flags .try_into().unwrap(),
 					sh_link: 0,
@@ -541,12 +606,22 @@ macro_rules! impl_elf {
 				// Write the new section to the section table.
 				section_table.extend_from_slice(new_section_header.as_bytes());
 
-				// Get the offset of the new section table.
-				let section_table_offset = file.file_size().expect("failed to get the file size");
-
 				// Append the new section table.
 				file.append(&section_table)
 					.expect("failed to write the new section table to the file");
+
+				// Write the new section.
+				file.append(data)
+					.expect("failed to write new section to end of file");
+
+				// Extend the segment so that the kernel maps the manifest.
+				let file_size = file.file_size().expect("failed to get the file size");
+				let segment =
+					paste! {[<$elf _Phdr>]::mut_from_bytes(&mut file[segment_offset..segment_offset + phdr_size])}
+						.expect("expected a program header");
+				let filesz = file_size.to_usize().unwrap() - segment.p_offset.to_usize().unwrap();
+				segment.p_filesz = filesz.try_into().unwrap();
+				segment.p_memsz = filesz.try_into().unwrap();
 
 				// Update the elf header.
 				let ehdr = self.elf_header_mut(file);
@@ -615,8 +690,7 @@ macro_rules! impl_elf {
 						let new_filesz = isize::try_from(phdr.p_filesz).unwrap() + diff;
 						let new_filesz = usize::try_from(new_filesz).unwrap();
 						phdr.p_filesz = new_filesz.try_into().unwrap();
-						let p_align = phdr.p_align.to_usize().unwrap().max(1);
-						phdr.p_memsz = align(new_filesz, p_align).try_into().unwrap();
+						phdr.p_memsz = phdr.p_memsz.max(new_filesz.try_into().unwrap());
 						break;
 					}
 				}

--- a/packages/std/packages/wrap/src/elf.rs
+++ b/packages/std/packages/wrap/src/elf.rs
@@ -519,6 +519,7 @@ macro_rules! impl_elf {
 					})
 			}
 
+			#[allow(clippy::too_many_lines)]
 			fn write_manifest(&self, file: &mut File, data: &[u8]) {
 				let name = TANGRAM_MANIFEST_SECTION_NAME.to_bytes_with_nul();
 				let name_len = name.len();
@@ -573,10 +574,131 @@ macro_rules! impl_elf {
 				let segment =
 					paste! {[<$elf _Phdr>]::read_from_bytes(&file[segment_offset..segment_offset + phdr_size])}
 						.expect("expected a program header");
-				assert_eq!(
-					segment.p_filesz, segment.p_memsz,
-					"cannot extend a segment with a bss",
+				assert!(
+					segment.p_filesz <= segment.p_memsz,
+					"segment file size exceeds its memory size",
 				);
+
+				// Extending a segment with a BSS would make the bytes after p_filesz initialize
+				// memory which must remain zero-filled. Instead, append a read-only segment containing
+				// a relocated program header table followed by the manifest.
+				if segment.p_filesz < segment.p_memsz {
+					let (phdr_offset, phdr_count) = {
+						let ehdr = self.elf_header(file);
+						(
+							ehdr.e_phoff.to_usize().unwrap(),
+							ehdr.e_phnum.to_usize().unwrap(),
+						)
+					};
+					let new_phdr_count = phdr_count + 1;
+					let mut max_vaddr = 0;
+					let mut max_align = 1;
+					for index in 0..phdr_count {
+						let offset = phdr_offset + index * phdr_size;
+						let phdr = paste! {[<$elf _Phdr>]::read_from_bytes(
+							&file[offset..offset + phdr_size],
+						)}
+						.expect("expected a program header");
+						if phdr.p_type == sys::PT_LOAD {
+							max_vaddr = max_vaddr.max(
+								phdr.p_vaddr.to_usize().unwrap()
+									+ phdr.p_memsz.to_usize().unwrap(),
+							);
+							max_align = max_align.max(phdr.p_align.to_usize().unwrap());
+						}
+					}
+
+					let section_table_offset =
+						file.file_size().expect("failed to get the file size");
+					let section_table_size =
+						section_table.len() + size_of::<paste! {[<$elf _Shdr>]}>();
+					let segment_file_offset = align(
+						section_table_offset.to_usize().unwrap() + section_table_size,
+						max_align,
+					);
+					let segment_vaddr = align(max_vaddr, max_align);
+					let headers_offset =
+						segment_file_offset + size_of::<paste! {[<$elf _Ehdr>]}>();
+					let new_section_offset = headers_offset + new_phdr_count * phdr_size;
+					let segment_size = new_section_offset + data.len() - segment_file_offset;
+
+					let new_section_header = paste! {[<$elf _Shdr>] {
+						sh_type: sys::SHT_NOTE,
+						sh_offset: new_section_offset.try_into().unwrap(),
+						sh_size: data.len().try_into().unwrap(),
+						sh_addr: (segment_vaddr + new_section_offset - segment_file_offset)
+							.try_into()
+							.unwrap(),
+						sh_name: name_index.try_into().unwrap(),
+						sh_flags: 0,
+						sh_link: 0,
+						sh_info: 0,
+						sh_addralign: 0,
+						sh_entsize: 0,
+					}};
+					section_table.extend_from_slice(new_section_header.as_bytes());
+					file.append(&section_table)
+						.expect("failed to write the new section table to the file");
+
+					let padding = segment_file_offset
+						- file
+							.file_size()
+							.expect("failed to get the file size")
+							.to_usize()
+							.unwrap();
+					if padding > 0 {
+						file.append(&vec![0; padding])
+							.expect("failed to write segment padding");
+					}
+
+					let new_segment = paste! {[<$elf _Phdr>] {
+						p_type: sys::PT_LOAD,
+						p_flags: sys::PF_R,
+						p_offset: segment_file_offset.try_into().unwrap(),
+						p_vaddr: segment_vaddr.try_into().unwrap(),
+						p_paddr: segment_vaddr.try_into().unwrap(),
+						p_filesz: segment_size.try_into().unwrap(),
+						p_memsz: segment_size.try_into().unwrap(),
+						p_align: max_align.try_into().unwrap(),
+					}};
+					let mut phdr_bytes = Vec::with_capacity(new_phdr_count * phdr_size);
+					let mut found_phdr = false;
+					for index in 0..phdr_count {
+						let offset = phdr_offset + index * phdr_size;
+						let mut phdr = paste! {[<$elf _Phdr>]::read_from_bytes(
+							&file[offset..offset + phdr_size],
+						)}
+						.expect("expected a program header");
+						if phdr.p_type == sys::PT_PHDR {
+							assert!(!found_phdr, "multiple program header segments found");
+							found_phdr = true;
+							let size = new_phdr_count * phdr_size;
+							phdr.p_offset = headers_offset.try_into().unwrap();
+							phdr.p_vaddr = (segment_vaddr + size_of::<paste! {[<$elf _Ehdr>]}>())
+								.try_into()
+								.unwrap();
+							phdr.p_paddr = phdr.p_vaddr;
+							phdr.p_filesz = size.try_into().unwrap();
+							phdr.p_memsz = size.try_into().unwrap();
+						}
+						phdr_bytes.extend_from_slice(phdr.as_bytes());
+					}
+					phdr_bytes.extend_from_slice(new_segment.as_bytes());
+
+					let ehdr = self.elf_header_mut(file);
+					ehdr.e_phoff = headers_offset.try_into().unwrap();
+					ehdr.e_phnum = new_phdr_count.try_into().unwrap();
+					ehdr.e_shnum += 1;
+					ehdr.e_shoff = section_table_offset.try_into().unwrap();
+					let ehdr_bytes = ehdr.as_bytes().to_vec();
+					file.append(&ehdr_bytes)
+						.expect("failed to write the copied elf header");
+					file.append(&phdr_bytes)
+						.expect("failed to write the relocated program header table");
+					file.append(data)
+						.expect("failed to write new section to end of file");
+					return;
+				}
 				let vaddr_delta =
 					segment.p_vaddr.to_usize().unwrap() - segment.p_offset.to_usize().unwrap();
 
@@ -718,4 +840,102 @@ impl_elf!(Elf64);
 
 fn align(m: usize, n: usize) -> usize {
 	(m + n - 1) & !(n - 1)
+}
+
+#[cfg(all(
+	test,
+	target_os = "linux",
+	target_endian = "little",
+	target_pointer_width = "64"
+))]
+mod tests {
+	use super::*;
+	use std::sync::atomic::{AtomicU8, Ordering};
+
+	const CHILD_ENV: &str = "TANGRAM_WRAP_BSS_TEST_CHILD";
+
+	#[used]
+	static RETAINED_BSS: [AtomicU8; 65_536] = [const { AtomicU8::new(0) }; 65_536];
+
+	fn retained_bss_is_zero() -> bool {
+		RETAINED_BSS[0].load(Ordering::Relaxed) == 0
+			&& RETAINED_BSS[RETAINED_BSS.len() - 1].load(Ordering::Relaxed) == 0
+	}
+
+	fn last_loadable_segment(file: &File) -> Elf64_Phdr {
+		let offset = Elf64
+			.last_loadable_segment(file)
+			.expect("expected a loadable segment");
+		Elf64_Phdr::read_from_bytes(&file[offset..offset + size_of::<Elf64_Phdr>()])
+			.expect("expected a program header")
+	}
+
+	#[test]
+	fn writes_manifest_to_elf_with_bss() {
+		if std::env::var_os(CHILD_ENV).is_some() {
+			assert!(retained_bss_is_zero());
+			return;
+		}
+
+		assert!(retained_bss_is_zero());
+		let executable = std::env::current_exe().expect("failed to get the test executable");
+		let original = File::open(&executable, true).expect("failed to open the test executable");
+		let original_phnum = Elf64.elf_header(&original).e_phnum;
+		let bss_segment = last_loadable_segment(&original);
+		assert!(bss_segment.p_memsz > bss_segment.p_filesz);
+		drop(original);
+
+		let temp = tempfile::tempdir().expect("failed to create a temporary directory");
+		let rewritten_path = temp.path().join("wrap-bss-test");
+		std::fs::copy(&executable, &rewritten_path).expect("failed to copy the test executable");
+		let manifest = serde_json::json!({ "bss": true });
+		crate::write_manifest(&rewritten_path, &manifest, None);
+
+		let output = crate::read_manifest::<serde_json::Value>(&rewritten_path, None);
+		assert_eq!(output.manifest, Some(manifest));
+		let rewritten =
+			File::open(&rewritten_path, true).expect("failed to open the rewritten file");
+		let ehdr = Elf64.elf_header(&rewritten);
+		assert_eq!(ehdr.e_phnum, original_phnum + 1);
+		let manifest_location = output.location.expect("expected a manifest location");
+		let phdr_size = size_of::<Elf64_Phdr>();
+		let mut found_original_bss = false;
+		let mut found_manifest_segment = false;
+		for index in 0..ehdr.e_phnum.to_usize().unwrap() {
+			let offset = ehdr.e_phoff.to_usize().unwrap() + index * phdr_size;
+			let phdr = Elf64_Phdr::read_from_bytes(&rewritten[offset..offset + phdr_size])
+				.expect("expected a program header");
+			if phdr.p_type != sys::PT_LOAD {
+				continue;
+			}
+			if phdr.p_vaddr == bss_segment.p_vaddr {
+				assert_eq!(phdr.p_offset, bss_segment.p_offset);
+				assert_eq!(phdr.p_filesz, bss_segment.p_filesz);
+				assert_eq!(phdr.p_memsz, bss_segment.p_memsz);
+				found_original_bss = true;
+			}
+			let start = phdr.p_offset.to_usize().unwrap();
+			let end = start + phdr.p_filesz.to_usize().unwrap();
+			if manifest_location.offset >= start && manifest_location.end() == end {
+				assert_eq!(phdr.p_filesz, phdr.p_memsz);
+				found_manifest_segment = true;
+			}
+		}
+		assert!(found_original_bss);
+		assert!(found_manifest_segment);
+		drop(rewritten);
+
+		let child = std::process::Command::new(&rewritten_path)
+			.args(["--exact", "elf::tests::writes_manifest_to_elf_with_bss"])
+			.env(CHILD_ENV, "1")
+			.output()
+			.expect("failed to execute the rewritten test executable");
+		assert!(
+			child.status.success(),
+			"rewritten executable failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+			child.status.code(),
+			String::from_utf8_lossy(&child.stdout),
+			String::from_utf8_lossy(&child.stderr),
+		);
+	}
 }

--- a/packages/std/packages/wrap/src/elf.rs
+++ b/packages/std/packages/wrap/src/elf.rs
@@ -106,8 +106,6 @@ macro_rules! impl_elf {
 
 			#[allow(clippy::too_many_lines)]
 			fn embed(&self, executable: &Path, manifest: &[u8]) -> std::io::Result<()> {
-				let wrapper_bin_path = crate::wrapper_bin_path()
-					.ok_or_else(|| std::io::Error::other("missing wrapper bin"))?;
 				let wrapper_exe_path = crate::wrapper_exe_path()
 					.ok_or_else(|| std::io::Error::other("missing wrapper exe"))?;
 
@@ -169,12 +167,16 @@ macro_rules! impl_elf {
 					}
 				}
 
-				// Read wrapper binary and get entrypoint from wrapper ELF.
-				let wrapper_bin = std::fs::read(&wrapper_bin_path)?;
-				let wrapper_entry = {
-					let wrapper_exe = File::open(&wrapper_exe_path, true)?;
-					self.elf_header(&wrapper_exe).e_entry
-				};
+				// The whole ELF file is the blob that gets appended. The stub segment below maps it
+				// at p_offset = wrapper_offset, p_vaddr = wrapper_vaddr, so the blob must be indexed
+				// by file offset: an `objcopy -O binary` image is indexed by load address and faults
+				// once execution leaves the first segment.
+				let wrapper_exe = std::fs::read(&wrapper_exe_path)?;
+				let wrapper_entry = paste! {[<$elf _Ehdr>]::read_from_bytes(
+					&wrapper_exe[0..size_of::<[<$elf _Ehdr>]>()],
+				)}
+				.expect("expected an elf header")
+				.e_entry;
 
 				// Open the executable for modification.
 				let mut file = File::open(executable, false)?;
@@ -241,8 +243,10 @@ macro_rules! impl_elf {
 				let manifest_shdr_offset = manifest_shdr_offset
 					.ok_or_else(|| std::io::Error::other("missing manifest section"))?;
 
-				// Compute the data layout.
-				let wrapper_data_size = wrapper_bin.len() + manifest.len();
+				// Compute the data layout. The footer is included so that the segment covers the same
+				// bytes as the manifest section header, which counts it in its size.
+				let wrapper_data_size =
+					wrapper_exe.len() + manifest.len() + size_of::<crate::Footer>();
 				let wrapper_vaddr = align(max_vaddr.to_usize().unwrap(), max_align.to_usize().unwrap())
 					.try_into()
 					.unwrap();
@@ -339,9 +343,9 @@ macro_rules! impl_elf {
 				.unwrap();
 				manifest_shdr.sh_type = sys::SHT_NOTE;
 				manifest_shdr.sh_flags = 0;
-				manifest_shdr.sh_addr = (wrapper_vaddr.to_usize().unwrap() + wrapper_bin.len()).try_into().unwrap();
+				manifest_shdr.sh_addr = (wrapper_vaddr.to_usize().unwrap() + wrapper_exe.len()).try_into().unwrap();
 				manifest_shdr.sh_offset =
-					(wrapper_offset.to_usize().unwrap() + wrapper_bin.len()).try_into().unwrap();
+					(wrapper_offset.to_usize().unwrap() + wrapper_exe.len()).try_into().unwrap();
 				manifest_shdr.sh_size =
 					(manifest.len() + size_of::<crate::Footer>()).try_into().unwrap();
 				manifest_shdr.sh_link = 0;
@@ -409,8 +413,8 @@ macro_rules! impl_elf {
 					}
 				}
 
-				// Append wrapper binary.
-				file.append(&wrapper_bin)?;
+				// Append the wrapper executable.
+				file.append(&wrapper_exe)?;
 
 				// Append manifest.
 				file.append(manifest)?;
@@ -584,6 +588,35 @@ macro_rules! impl_elf {
 						let old_size = isize::try_from(header.sh_size).unwrap();
 						let new_size = old_size + diff;
 						header.sh_size = new_size.try_into().unwrap();
+						break;
+					}
+				}
+
+				// Update the segment containing the manifest, so that its file size continues to
+				// cover the whole manifest and footer.
+				let phdr_size = size_of::<paste! {[<$elf _Phdr>]}>();
+				let (phdr_offset, phdr_count) = {
+					let ehdr = self.elf_header(file);
+					(
+						ehdr.e_phoff.to_usize().unwrap(),
+						ehdr.e_phnum.to_usize().unwrap(),
+					)
+				};
+				for i in 0..phdr_count {
+					let off = phdr_offset + i * phdr_size;
+					let phdr = paste! {[<$elf _Phdr>]::mut_from_bytes(&mut file[off..off + phdr_size])}
+						.expect("expected a program header");
+					if phdr.p_type != sys::PT_LOAD {
+						continue;
+					}
+					let start = phdr.p_offset.to_usize().unwrap();
+					let end = start + phdr.p_filesz.to_usize().unwrap();
+					if old.offset >= start && old.offset < end {
+						let new_filesz = isize::try_from(phdr.p_filesz).unwrap() + diff;
+						let new_filesz = usize::try_from(new_filesz).unwrap();
+						phdr.p_filesz = new_filesz.try_into().unwrap();
+						let p_align = phdr.p_align.to_usize().unwrap().max(1);
+						phdr.p_memsz = align(new_filesz, p_align).try_into().unwrap();
 						break;
 					}
 				}

--- a/packages/std/packages/wrap/src/elf.rs
+++ b/packages/std/packages/wrap/src/elf.rs
@@ -199,11 +199,40 @@ macro_rules! impl_elf {
 				// by file offset: an `objcopy -O binary` image is indexed by load address and faults
 				// once execution leaves the first segment.
 				let wrapper_exe = std::fs::read(&wrapper_exe_path)?;
-				let wrapper_entry = paste! {[<$elf _Ehdr>]::read_from_bytes(
+				let wrapper_ehdr = paste! {[<$elf _Ehdr>]::read_from_bytes(
 					&wrapper_exe[0..size_of::<[<$elf _Ehdr>]>()],
 				)}
-				.expect("expected an elf header")
-				.e_entry;
+				.expect("expected an elf header");
+				if wrapper_ehdr.e_type.to_u32() != Some(sys::ET_DYN) {
+					return Err(std::io::Error::new(
+						std::io::ErrorKind::InvalidInput,
+						"the wrapper executable must be position-independent (ET_DYN)",
+					));
+				}
+				let wrapper_entry_vaddr = wrapper_ehdr.e_entry.to_usize().unwrap();
+				let wrapper_phdr_offset = wrapper_ehdr.e_phoff.to_usize().unwrap();
+				let wrapper_phdr_count = wrapper_ehdr.e_phnum.to_usize().unwrap();
+				let wrapper_entry_offset = (0..wrapper_phdr_count)
+					.find_map(|index| {
+						let offset = wrapper_phdr_offset + index * phdr_size;
+						let bytes = wrapper_exe.get(offset..offset + phdr_size)?;
+						let phdr = paste! {[<$elf _Phdr>]::read_from_bytes(bytes)}.ok()?;
+						if phdr.p_type != sys::PT_LOAD {
+							return None;
+						}
+						let vaddr = phdr.p_vaddr.to_usize().unwrap();
+						let filesz = phdr.p_filesz.to_usize().unwrap();
+						if wrapper_entry_vaddr < vaddr || wrapper_entry_vaddr >= vaddr + filesz {
+							return None;
+						}
+						Some(phdr.p_offset.to_usize().unwrap() + wrapper_entry_vaddr - vaddr)
+					})
+					.ok_or_else(|| {
+						std::io::Error::new(
+							std::io::ErrorKind::InvalidInput,
+							"the wrapper entry point is not in a file-backed PT_LOAD",
+						)
+					})?;
 
 				// Open the executable for modification.
 				let mut file = File::open(executable, false)?;
@@ -339,19 +368,22 @@ macro_rules! impl_elf {
 					}};
 
 					let mut bytes = Vec::with_capacity(new_count * phdr_size);
+					let mut load_entries = Vec::new();
 
-					// Copy existing loadable segments first.
+					// Collect all loadable segments, including the stub, and order them by address.
 					for i in 0..phdr_count {
 						let off = phdr_offset + i * phdr_size;
 						let phdr = paste! {[<$elf _Phdr>]::read_from_bytes(&file[off..off + phdr_size])}.unwrap();
 						assert!(phdr.p_type != sys::PT_PHDR, "unexpected PT_PHDR");
 						if phdr.p_type == sys::PT_LOAD {
-							bytes.extend_from_slice(phdr.as_bytes());
+							load_entries.push(phdr);
 						}
 					}
-
-					// Add the new stub segment.
-					bytes.extend_from_slice(stub_segment.as_bytes());
+					load_entries.push(stub_segment);
+					load_entries.sort_unstable_by_key(|phdr| phdr.p_vaddr);
+					for phdr in load_entries {
+						bytes.extend_from_slice(phdr.as_bytes());
+					}
 
 					// Copy non-loadable segments.
 					for i in 0..phdr_count {
@@ -407,7 +439,7 @@ macro_rules! impl_elf {
 
 				// Patch the entrypoint.
 				let ehdr = self.elf_header_mut(&mut file);
-				ehdr.e_entry = (wrapper_vaddr + wrapper_entry.to_usize().unwrap())
+				ehdr.e_entry = (wrapper_vaddr + wrapper_entry_offset)
 					.try_into()
 					.unwrap();
 
@@ -608,8 +640,15 @@ macro_rules! impl_elf {
 						}
 					}
 
-					let section_table_offset =
-						file.file_size().expect("failed to get the file size");
+					let file_size = file
+						.file_size()
+						.expect("failed to get the file size")
+						.to_usize()
+						.unwrap();
+					let section_table_offset = align(
+						file_size,
+						align_of::<paste! {[<$elf _Shdr>]}>(),
+					);
 					let section_table_size =
 						section_table.len() + size_of::<paste! {[<$elf _Shdr>]}>();
 					let segment_file_offset = align(
@@ -637,6 +676,11 @@ macro_rules! impl_elf {
 						sh_entsize: 0,
 					}};
 					section_table.extend_from_slice(new_section_header.as_bytes());
+					let section_table_padding = section_table_offset - file_size;
+					if section_table_padding > 0 {
+						file.append(&vec![0; section_table_padding])
+							.expect("failed to align the section table");
+					}
 					file.append(&section_table)
 						.expect("failed to write the new section table to the file");
 
@@ -888,9 +932,13 @@ mod tests {
 		let temp = tempfile::tempdir().expect("failed to create a temporary directory");
 		let rewritten_path = temp.path().join("wrap-bss-test");
 		std::fs::copy(&executable, &rewritten_path).expect("failed to copy the test executable");
-		let manifest = serde_json::json!({ "bss": true });
-		crate::write_manifest(&rewritten_path, &manifest, None);
+		let first_manifest = serde_json::json!({ "bss": true });
+		crate::write_manifest(&rewritten_path, &first_manifest, None);
+		let output = crate::read_manifest::<serde_json::Value>(&rewritten_path, None);
+		assert_eq!(output.manifest, Some(first_manifest));
 
+		let manifest = serde_json::json!({ "bss": true, "padding": "x".repeat(8_192) });
+		crate::write_manifest(&rewritten_path, &manifest, None);
 		let output = crate::read_manifest::<serde_json::Value>(&rewritten_path, None);
 		assert_eq!(output.manifest, Some(manifest));
 		let rewritten =

--- a/packages/std/packages/wrap/src/elf.rs
+++ b/packages/std/packages/wrap/src/elf.rs
@@ -365,10 +365,12 @@ macro_rules! impl_elf {
 					}
 				}
 
-				// The whole ELF file is the blob that gets appended. The stub segment below maps it
-				// at p_offset = wrapper_offset, p_vaddr = wrapper_vaddr, so the blob must be indexed
-				// by file offset: an `objcopy -O binary` image is indexed by load address and faults
-				// once execution leaves the first segment.
+				// The blob that gets appended is the wrapper's memory image, not its file. The stub
+				// segment below maps the blob contiguously at a single address, while the wrapper's
+				// own segments sit at different distances from their offsets, and its code reaches
+				// its data by the distances the linker resolved. Copying the file would move that
+				// data out from under the code, with nothing to notice: a static PIE reaching a
+				// hidden global emits a plain pc-relative address and no relocation at all.
 				let wrapper_exe = std::fs::read(&wrapper_exe_path)?;
 				let wrapper_ehdr = paste! {[<$elf _Ehdr>]::read_from_bytes(
 					&wrapper_exe[0..size_of::<[<$elf _Ehdr>]>()],
@@ -383,27 +385,55 @@ macro_rules! impl_elf {
 				let wrapper_entry_vaddr = wrapper_ehdr.e_entry.to_usize().unwrap();
 				let wrapper_phdr_offset = wrapper_ehdr.e_phoff.to_usize().unwrap();
 				let wrapper_phdr_count = wrapper_ehdr.e_phnum.to_usize().unwrap();
-				let wrapper_entry_offset = (0..wrapper_phdr_count)
-					.find_map(|index| {
+				let wrapper_segments = (0..wrapper_phdr_count)
+					.filter_map(|index| {
 						let offset = wrapper_phdr_offset + index * phdr_size;
 						let bytes = wrapper_exe.get(offset..offset + phdr_size)?;
 						let phdr = paste! {[<$elf _Phdr>]::read_from_bytes(bytes)}.ok()?;
 						if phdr.p_type != sys::PT_LOAD {
 							return None;
 						}
-						let vaddr = phdr.p_vaddr.to_usize().unwrap();
-						let filesz = phdr.p_filesz.to_usize().unwrap();
-						if wrapper_entry_vaddr < vaddr || wrapper_entry_vaddr >= vaddr + filesz {
-							return None;
-						}
-						Some(phdr.p_offset.to_usize().unwrap() + wrapper_entry_vaddr - vaddr)
+						Some((
+							phdr.p_offset.to_usize().unwrap(),
+							phdr.p_vaddr.to_usize().unwrap(),
+							phdr.p_filesz.to_usize().unwrap(),
+							phdr.p_memsz.to_usize().unwrap(),
+						))
 					})
+					.collect::<Vec<_>>();
+				let min_vaddr = wrapper_segments
+					.iter()
+					.map(|&(_, vaddr, _, _)| vaddr)
+					.min()
 					.ok_or_else(|| {
 						std::io::Error::new(
 							std::io::ErrorKind::InvalidInput,
-							"the wrapper entry point is not in a file-backed PT_LOAD",
+							"the wrapper executable has no loadable segments",
 						)
 					})?;
+
+				// Lay each segment down at its address. The gaps between them, and any memory a
+				// segment claims past its file contents, stay zero.
+				let image_size = wrapper_segments
+					.iter()
+					.map(|&(_, vaddr, _, memsz)| vaddr + memsz - min_vaddr)
+					.max()
+					.unwrap();
+				let mut wrapper_image = vec![0u8; image_size];
+				for &(offset, vaddr, filesz, _) in &wrapper_segments {
+					let start = vaddr - min_vaddr;
+					wrapper_image[start..start + filesz]
+						.copy_from_slice(&wrapper_exe[offset..offset + filesz]);
+				}
+				if !wrapper_segments.iter().any(|&(_, vaddr, filesz, _)| {
+					wrapper_entry_vaddr >= vaddr && wrapper_entry_vaddr < vaddr + filesz
+				}) {
+					return Err(std::io::Error::new(
+						std::io::ErrorKind::InvalidInput,
+						"the wrapper entry point is not in a file-backed PT_LOAD",
+					));
+				}
+				let wrapper_entry_offset = wrapper_entry_vaddr - min_vaddr;
 
 				// Open the executable for modification.
 				let mut file = File::open(executable, false)?;
@@ -469,7 +499,7 @@ macro_rules! impl_elf {
 				// Compute the data layout. The footer is included so that the segment covers the same
 				// bytes as the manifest section header, which counts it in its size.
 				let wrapper_data_size =
-					wrapper_exe.len() + manifest.len() + size_of::<crate::Footer>();
+					wrapper_image.len() + manifest.len() + size_of::<crate::Footer>();
 
 				// Determine the wrapper offset and address, and build a new phdr table if needed.
 				let new_phdr_table: Option<(Vec<u8>, usize)>;
@@ -575,8 +605,8 @@ macro_rules! impl_elf {
 				.unwrap();
 				manifest_shdr.sh_type = sys::SHT_NOTE;
 				manifest_shdr.sh_flags = sys::SHF_ALLOC.try_into().unwrap();
-				manifest_shdr.sh_addr = (wrapper_vaddr + wrapper_exe.len()).try_into().unwrap();
-				manifest_shdr.sh_offset = (wrapper_offset + wrapper_exe.len()).try_into().unwrap();
+				manifest_shdr.sh_addr = (wrapper_vaddr + wrapper_image.len()).try_into().unwrap();
+				manifest_shdr.sh_offset = (wrapper_offset + wrapper_image.len()).try_into().unwrap();
 				manifest_shdr.sh_size =
 					(manifest.len() + size_of::<crate::Footer>()).try_into().unwrap();
 				manifest_shdr.sh_link = 0;
@@ -650,7 +680,7 @@ macro_rules! impl_elf {
 				}
 
 				// Append the wrapper executable.
-				file.append(&wrapper_exe)?;
+				file.append(&wrapper_image)?;
 
 				// Append manifest.
 				file.append(manifest)?;

--- a/packages/std/packages/wrap/src/elf.rs
+++ b/packages/std/packages/wrap/src/elf.rs
@@ -123,6 +123,177 @@ macro_rules! impl_elf {
 				last.map(|(offset, _)| offset)
 			}
 
+			/// Get the end of the last address the loadable segments occupy, the largest alignment
+			/// they require, and the distance between their addresses and their offsets.
+			fn image_extent(&self, file: &File) -> (usize, usize, usize) {
+				let phdr_size = size_of::<paste! {[<$elf _Phdr>]}>();
+				let (phdr_offset, phdr_count) = {
+					let ehdr = self.elf_header(file);
+					(
+						ehdr.e_phoff.to_usize().unwrap(),
+						ehdr.e_phnum.to_usize().unwrap(),
+					)
+				};
+				let mut max_vaddr = 0;
+				let mut max_align = 1;
+				let mut first: Option<(usize, usize)> = None;
+				for i in 0..phdr_count {
+					let offset = phdr_offset + i * phdr_size;
+					let phdr = paste! {[<$elf _Phdr>]::read_from_bytes(&file[offset..offset + phdr_size])}
+						.expect("expected a program header");
+					if phdr.p_type != sys::PT_LOAD {
+						continue;
+					}
+					let vaddr = phdr.p_vaddr.to_usize().unwrap();
+					max_vaddr = max_vaddr.max(vaddr + phdr.p_memsz.to_usize().unwrap());
+					max_align = max_align.max(phdr.p_align.to_usize().unwrap());
+					if first.is_none_or(|(current, _)| vaddr < current) {
+						first = Some((vaddr, phdr.p_offset.to_usize().unwrap()));
+					}
+				}
+				let (vaddr, offset) = first.expect("expected a loadable segment");
+				(max_vaddr, max_align, vaddr - offset)
+			}
+
+			/// Choose the offset, address, and alignment of a new loadable segment at the end of the
+			/// file. It goes after every address the image already occupies, and the same distance from
+			/// its offset as the rest of the image, because a kernel before 5.19 reports the program
+			/// header table at the load address plus `e_phoff` rather than at the address of the
+			/// segment holding it. Both computations agree only when every segment keeps the same
+			/// distance.
+			fn appended_segment(&self, file: &File, file_size: usize) -> (usize, usize, usize) {
+				let (max_vaddr, max_align, bias) = self.image_extent(file);
+				let offset = align(file_size.max(align(max_vaddr, max_align) - bias), max_align);
+
+				// The segment is placed at the largest alignment in the image, but it can only claim
+				// an alignment its own address and offset agree on, which an image loaded at an
+				// unusual address may not.
+				let mut segment_align = max_align;
+				while bias % segment_align != 0 {
+					segment_align /= 2;
+				}
+				(offset, offset + bias, segment_align)
+			}
+
+			/// Add the manifest in a new read-only segment at the end of the file. This is for images
+			/// whose last loadable segment has a bss, which cannot be extended over file data without
+			/// initializing memory that must stay zero-filled. The segment also holds a copy of the elf
+			/// header and a program header table with room for itself, because the wrapper reads both
+			/// from the addresses the kernel maps them at.
+			fn append_manifest_segment(
+				&self,
+				file: &mut File,
+				data: &[u8],
+				mut section_table: Vec<u8>,
+				name_index: usize,
+			) {
+				let ehdr_size = size_of::<paste! {[<$elf _Ehdr>]}>();
+				let phdr_size = size_of::<paste! {[<$elf _Phdr>]}>();
+				let shdr_size = size_of::<paste! {[<$elf _Shdr>]}>();
+				let (phdr_offset, phdr_count) = {
+					let ehdr = self.elf_header(file);
+					(
+						ehdr.e_phoff.to_usize().unwrap(),
+						ehdr.e_phnum.to_usize().unwrap(),
+					)
+				};
+				let new_phdr_count = phdr_count + 1;
+
+				// The section table goes first, so that the manifest and its footer are the last bytes
+				// of the file, and so of the segment.
+				let file_size = file
+					.file_size()
+					.expect("failed to get the file size")
+					.to_usize()
+					.unwrap();
+				let section_table_offset = align(file_size, align_of::<paste! {[<$elf _Shdr>]}>());
+				let section_table_size = section_table.len() + shdr_size;
+				let (segment_offset, segment_vaddr, segment_align) =
+					self.appended_segment(file, section_table_offset + section_table_size);
+				let headers_offset = segment_offset + ehdr_size;
+				let new_section_offset = headers_offset + new_phdr_count * phdr_size;
+				let segment_size = new_section_offset + data.len() - segment_offset;
+
+				// Add the manifest section.
+				let new_section_header = paste! {[<$elf _Shdr>] {
+					sh_type: sys::SHT_NOTE,
+					sh_offset: new_section_offset.try_into().unwrap(),
+					sh_size: data.len().try_into().unwrap(),
+					sh_addr: (segment_vaddr + new_section_offset - segment_offset)
+						.try_into()
+						.unwrap(),
+					sh_name: name_index.try_into().unwrap(),
+					sh_flags: sys::SHF_ALLOC.try_into().unwrap(),
+					sh_link: 0,
+					sh_info: 0,
+					sh_addralign: 1,
+					sh_entsize: 0,
+				}};
+				section_table.extend_from_slice(new_section_header.as_bytes());
+
+				// Build the new program header table, moving PT_PHDR along with it.
+				let new_segment = paste! {[<$elf _Phdr>] {
+					p_type: sys::PT_LOAD,
+					p_flags: sys::PF_R,
+					p_offset: segment_offset.try_into().unwrap(),
+					p_vaddr: segment_vaddr.try_into().unwrap(),
+					p_paddr: segment_vaddr.try_into().unwrap(),
+					p_filesz: segment_size.try_into().unwrap(),
+					p_memsz: segment_size.try_into().unwrap(),
+					p_align: segment_align.try_into().unwrap(),
+				}};
+				let mut phdr_bytes = Vec::with_capacity(new_phdr_count * phdr_size);
+				let mut found_phdr = false;
+				for index in 0..phdr_count {
+					let offset = phdr_offset + index * phdr_size;
+					let mut phdr = paste! {[<$elf _Phdr>]::read_from_bytes(
+						&file[offset..offset + phdr_size],
+					)}
+					.expect("expected a program header");
+					if phdr.p_type == sys::PT_PHDR {
+						assert!(!found_phdr, "multiple program header segments found");
+						found_phdr = true;
+						let size = new_phdr_count * phdr_size;
+						phdr.p_offset = headers_offset.try_into().unwrap();
+						phdr.p_vaddr = (segment_vaddr + ehdr_size).try_into().unwrap();
+						phdr.p_paddr = phdr.p_vaddr;
+						phdr.p_filesz = size.try_into().unwrap();
+						phdr.p_memsz = size.try_into().unwrap();
+					}
+					phdr_bytes.extend_from_slice(phdr.as_bytes());
+				}
+
+				// The new segment goes last, which keeps the loadable segments in address order
+				// because it is above every address the image already occupies.
+				phdr_bytes.extend_from_slice(new_segment.as_bytes());
+
+				// Write the section table, then the segment.
+				let padding = section_table_offset - file_size;
+				if padding > 0 {
+					file.append(&vec![0; padding])
+						.expect("failed to align the section table");
+				}
+				file.append(&section_table)
+					.expect("failed to write the new section table to the file");
+				let padding = segment_offset - section_table_offset - section_table_size;
+				if padding > 0 {
+					file.append(&vec![0; padding])
+						.expect("failed to write segment padding");
+				}
+				let ehdr = self.elf_header_mut(file);
+				ehdr.e_phoff = headers_offset.try_into().unwrap();
+				ehdr.e_phnum = new_phdr_count.try_into().unwrap();
+				ehdr.e_shnum += 1;
+				ehdr.e_shoff = section_table_offset.try_into().unwrap();
+				let ehdr_bytes = ehdr.as_bytes().to_vec();
+				file.append(&ehdr_bytes)
+					.expect("failed to write the copied elf header");
+				file.append(&phdr_bytes)
+					.expect("failed to write the relocated program header table");
+				file.append(data)
+					.expect("failed to write the manifest to the end of the file");
+			}
+
 			fn section_header_table(&self, file: &File) -> FileLocation {
 				let ehdr = self.elf_header(file);
 				FileLocation {
@@ -247,27 +418,19 @@ macro_rules! impl_elf {
 					)
 				};
 
-				// Find PT_INTERP header and compute the virtual address range / alignment.
+				// Find the PT_INTERP header and where a new segment can go.
 				let mut pt_interp_index: Option<usize> = None;
-				let mut min_vaddr = <paste! {[<$elf _Off>]}>::MAX;
-				let mut max_vaddr = 0;
-				let mut max_align = 0;
 				for i in 0..phdr_count {
 					let off = phdr_offset + i * phdr_size;
 					let phdr = paste! {[<$elf _Phdr>]::read_from_bytes(&file[off..off + phdr_size])}
 						.expect("invalid program header");
-					if phdr.p_type == sys::PT_LOAD {
-						min_vaddr = min_vaddr.min(phdr.p_vaddr);
-						max_vaddr = max_vaddr.max(phdr.p_vaddr + phdr.p_memsz);
-						max_align = max_align.max(phdr.p_align);
-					}
 					if phdr.p_type == sys::PT_INTERP {
 						assert!(pt_interp_index.is_none(), "multiple interpreters found");
 						pt_interp_index = Some(i);
 					}
 				}
-				let min_vaddr = min_vaddr.to_usize().unwrap();
-				let max_align = max_align.to_usize().unwrap();
+				let (segment_offset, segment_vaddr, segment_align) =
+					self.appended_segment(&file, file_size);
 
 				// Find wrapper and manifest section headers in a single pass.
 				let mut wrapper_shdr_offset: Option<usize> = None;
@@ -321,8 +484,8 @@ macro_rules! impl_elf {
 						size_of::<paste! {[<$elf _Ehdr>]}>(),
 						"the program header table must follow the elf header",
 					);
-					wrapper_offset = align(file_size, max_align);
-					wrapper_vaddr = align(max_vaddr.to_usize().unwrap(), max_align);
+					wrapper_offset = segment_offset;
+					wrapper_vaddr = segment_vaddr;
 					new_phdr_table = None;
 
 					let stub_segment = paste! {[<$elf _Phdr>] {
@@ -332,39 +495,31 @@ macro_rules! impl_elf {
 						p_vaddr: wrapper_vaddr.try_into().unwrap(),
 						p_paddr: wrapper_vaddr.try_into().unwrap(),
 						p_filesz: wrapper_data_size.try_into().unwrap(),
-						p_memsz: align(wrapper_data_size, max_align).try_into().unwrap(),
-						p_align: max_align.try_into().unwrap(),
+						p_memsz: align(wrapper_data_size, segment_align).try_into().unwrap(),
+						p_align: segment_align.try_into().unwrap(),
 					}};
 					let offset = phdr_offset + interpreter_index * phdr_size;
 					file[offset..offset + phdr_size].copy_from_slice(stub_segment.as_bytes());
 				} else {
 					// Create a new program header table if there's no PT_INTERP we can abuse. It goes
 					// inside the stub segment, preceded by a copy of the elf header, because the
-					// wrapper reads both from the addresses the kernel maps them at. The segment's
-					// address matches its offset so that AT_PHDR is correct on kernels that compute
-					// it as the load address plus e_phoff.
+					// wrapper reads both from the addresses the kernel maps them at.
 					let new_count = phdr_count + 1;
 					let headers_size = size_of::<paste! {[<$elf _Ehdr>]}>() + new_count * phdr_size;
-					let stub_size = align(headers_size, max_align) + wrapper_data_size;
-					let mut segment_offset = align(file_size, max_align);
-					if segment_offset < max_vaddr.to_usize().unwrap()
-						&& segment_offset + stub_size > min_vaddr
-					{
-						segment_offset = align(max_vaddr.to_usize().unwrap(), max_align);
-					}
+					let stub_size = align(headers_size, segment_align) + wrapper_data_size;
 					let headers_offset = segment_offset + size_of::<paste! {[<$elf _Ehdr>]}>();
-					wrapper_offset = segment_offset + align(headers_size, max_align);
-					wrapper_vaddr = wrapper_offset;
+					wrapper_offset = segment_offset + align(headers_size, segment_align);
+					wrapper_vaddr = segment_vaddr + align(headers_size, segment_align);
 
 					let stub_segment = paste! {[<$elf _Phdr>]{
 						p_type: sys::PT_LOAD,
 						p_flags: sys::PF_R | sys::PF_X,
 						p_offset: segment_offset.try_into().unwrap(),
-						p_vaddr: segment_offset.try_into().unwrap(),
-						p_paddr: segment_offset.try_into().unwrap(),
+						p_vaddr: segment_vaddr.try_into().unwrap(),
+						p_paddr: segment_vaddr.try_into().unwrap(),
 						p_filesz: stub_size.try_into().unwrap(),
-						p_memsz: align(stub_size, max_align).try_into().unwrap(),
-						p_align: max_align.try_into().unwrap(),
+						p_memsz: align(stub_size, segment_align).try_into().unwrap(),
+						p_align: segment_align.try_into().unwrap(),
 					}};
 
 					let mut bytes = Vec::with_capacity(new_count * phdr_size);
@@ -409,7 +564,7 @@ macro_rules! impl_elf {
 				wrapper_shdr.sh_offset = wrapper_offset.try_into().unwrap();
 				wrapper_shdr.sh_size = wrapper_data_size.try_into().unwrap();
 				wrapper_shdr.sh_link = 0;
-				wrapper_shdr.sh_addralign = max_align.try_into().unwrap();
+				wrapper_shdr.sh_addralign = segment_align.try_into().unwrap();
 				wrapper_shdr.sh_entsize = 0;
 				file[wrapper_shdr_offset..wrapper_shdr_offset + shdr_size]
 					.copy_from_slice(wrapper_shdr.as_bytes());
@@ -419,13 +574,13 @@ macro_rules! impl_elf {
 				)}
 				.unwrap();
 				manifest_shdr.sh_type = sys::SHT_NOTE;
-				manifest_shdr.sh_flags = 0;
+				manifest_shdr.sh_flags = sys::SHF_ALLOC.try_into().unwrap();
 				manifest_shdr.sh_addr = (wrapper_vaddr + wrapper_exe.len()).try_into().unwrap();
 				manifest_shdr.sh_offset = (wrapper_offset + wrapper_exe.len()).try_into().unwrap();
 				manifest_shdr.sh_size =
 					(manifest.len() + size_of::<crate::Footer>()).try_into().unwrap();
 				manifest_shdr.sh_link = 0;
-				manifest_shdr.sh_addralign = 0;
+				manifest_shdr.sh_addralign = 1;
 				manifest_shdr.sh_entsize = 0;
 				file[manifest_shdr_offset..manifest_shdr_offset + shdr_size]
 					.copy_from_slice(manifest_shdr.as_bytes());
@@ -551,7 +706,6 @@ macro_rules! impl_elf {
 					})
 			}
 
-			#[allow(clippy::too_many_lines)]
 			fn write_manifest(&self, file: &mut File, data: &[u8]) {
 				let name = TANGRAM_MANIFEST_SECTION_NAME.to_bytes_with_nul();
 				let name_len = name.len();
@@ -561,16 +715,15 @@ macro_rules! impl_elf {
 				let string_table_location = self.section_string_table(file);
 				let mut section_table_location = self.section_header_table(file);
 
-				// Get the actual data.
-				let mut string_table = file[string_table_location].to_vec();
+				// Get the section table, before the insert below moves it.
 				let mut section_table = file[section_table_location].to_vec();
 
-				// Add to the string table.
-				let name_index = string_table.len();
-				string_table.extend_from_slice(name);
-				string_table.push(0);
+				// The name goes at the end of the string table, so its index is the old length.
+				let name_index = string_table_location.length;
 
-				// Update existing sections.
+				// Update existing sections. Growing the string table in place shifts everything after
+				// it along by the length of the name.
+				let shift = <paste! {[<$elf _Off>]}>::try_from(name_len).unwrap();
 				for (index, chunk) in section_table
 					.chunks_exact_mut(size_of::<paste! {[<$elf _Shdr>]}>())
 					.enumerate()
@@ -578,22 +731,22 @@ macro_rules! impl_elf {
 					let header = paste! {[<$elf _Shdr>]::mut_from_bytes(chunk)}
 						.expect("expected a section header");
 					if index == string_table_index {
-						header.sh_size += <paste! {[<$elf _Off>]}>::try_from(name_len).unwrap();
+						header.sh_size += shift;
 						continue;
 					}
-					// If this section occurs after the original string_table location, update its offset.
-					if header.sh_offset > string_table_location.end().try_into().unwrap() {
-						header.sh_offset = <paste! {[<$elf _Off>]}>::try_from(name_len).unwrap();
+					if header.sh_offset >= string_table_location.end().try_into().unwrap() {
+						header.sh_offset += shift;
 					}
 				}
 
-				// Now the hard part:
-				// Insert the new string table at the offset of the original.
-				file.insert(&string_table, string_table_location.offset as u64)
+				// Append the name to the string table.
+				file.insert(name, string_table_location.end().to_u64().unwrap())
 					.expect("failed to insert string table");
 
-				// Delete the old section table.
-				section_table_location.offset += name_len;
+				// Delete the old section table, which the insert may have moved.
+				if section_table_location.offset >= string_table_location.end() {
+					section_table_location.offset += name_len;
+				}
 				file.delete(section_table_location)
 					.expect("failed to delete section table");
 
@@ -612,135 +765,9 @@ macro_rules! impl_elf {
 				);
 
 				// Extending a segment with a BSS would make the bytes after p_filesz initialize
-				// memory which must remain zero-filled. Instead, append a read-only segment containing
-				// a relocated program header table followed by the manifest.
+				// memory which must remain zero-filled, so give the manifest a segment of its own.
 				if segment.p_filesz < segment.p_memsz {
-					let (phdr_offset, phdr_count) = {
-						let ehdr = self.elf_header(file);
-						(
-							ehdr.e_phoff.to_usize().unwrap(),
-							ehdr.e_phnum.to_usize().unwrap(),
-						)
-					};
-					let new_phdr_count = phdr_count + 1;
-					let mut max_vaddr = 0;
-					let mut max_align = 1;
-					for index in 0..phdr_count {
-						let offset = phdr_offset + index * phdr_size;
-						let phdr = paste! {[<$elf _Phdr>]::read_from_bytes(
-							&file[offset..offset + phdr_size],
-						)}
-						.expect("expected a program header");
-						if phdr.p_type == sys::PT_LOAD {
-							max_vaddr = max_vaddr.max(
-								phdr.p_vaddr.to_usize().unwrap()
-									+ phdr.p_memsz.to_usize().unwrap(),
-							);
-							max_align = max_align.max(phdr.p_align.to_usize().unwrap());
-						}
-					}
-
-					let file_size = file
-						.file_size()
-						.expect("failed to get the file size")
-						.to_usize()
-						.unwrap();
-					let section_table_offset = align(
-						file_size,
-						align_of::<paste! {[<$elf _Shdr>]}>(),
-					);
-					let section_table_size =
-						section_table.len() + size_of::<paste! {[<$elf _Shdr>]}>();
-					let segment_file_offset = align(
-						section_table_offset.to_usize().unwrap() + section_table_size,
-						max_align,
-					);
-					let segment_vaddr = align(max_vaddr, max_align);
-					let headers_offset =
-						segment_file_offset + size_of::<paste! {[<$elf _Ehdr>]}>();
-					let new_section_offset = headers_offset + new_phdr_count * phdr_size;
-					let segment_size = new_section_offset + data.len() - segment_file_offset;
-
-					let new_section_header = paste! {[<$elf _Shdr>] {
-						sh_type: sys::SHT_NOTE,
-						sh_offset: new_section_offset.try_into().unwrap(),
-						sh_size: data.len().try_into().unwrap(),
-						sh_addr: (segment_vaddr + new_section_offset - segment_file_offset)
-							.try_into()
-							.unwrap(),
-						sh_name: name_index.try_into().unwrap(),
-						sh_flags: 0,
-						sh_link: 0,
-						sh_info: 0,
-						sh_addralign: 0,
-						sh_entsize: 0,
-					}};
-					section_table.extend_from_slice(new_section_header.as_bytes());
-					let section_table_padding = section_table_offset - file_size;
-					if section_table_padding > 0 {
-						file.append(&vec![0; section_table_padding])
-							.expect("failed to align the section table");
-					}
-					file.append(&section_table)
-						.expect("failed to write the new section table to the file");
-
-					let padding = segment_file_offset
-						- file
-							.file_size()
-							.expect("failed to get the file size")
-							.to_usize()
-							.unwrap();
-					if padding > 0 {
-						file.append(&vec![0; padding])
-							.expect("failed to write segment padding");
-					}
-
-					let new_segment = paste! {[<$elf _Phdr>] {
-						p_type: sys::PT_LOAD,
-						p_flags: sys::PF_R,
-						p_offset: segment_file_offset.try_into().unwrap(),
-						p_vaddr: segment_vaddr.try_into().unwrap(),
-						p_paddr: segment_vaddr.try_into().unwrap(),
-						p_filesz: segment_size.try_into().unwrap(),
-						p_memsz: segment_size.try_into().unwrap(),
-						p_align: max_align.try_into().unwrap(),
-					}};
-					let mut phdr_bytes = Vec::with_capacity(new_phdr_count * phdr_size);
-					let mut found_phdr = false;
-					for index in 0..phdr_count {
-						let offset = phdr_offset + index * phdr_size;
-						let mut phdr = paste! {[<$elf _Phdr>]::read_from_bytes(
-							&file[offset..offset + phdr_size],
-						)}
-						.expect("expected a program header");
-						if phdr.p_type == sys::PT_PHDR {
-							assert!(!found_phdr, "multiple program header segments found");
-							found_phdr = true;
-							let size = new_phdr_count * phdr_size;
-							phdr.p_offset = headers_offset.try_into().unwrap();
-							phdr.p_vaddr = (segment_vaddr + size_of::<paste! {[<$elf _Ehdr>]}>())
-								.try_into()
-								.unwrap();
-							phdr.p_paddr = phdr.p_vaddr;
-							phdr.p_filesz = size.try_into().unwrap();
-							phdr.p_memsz = size.try_into().unwrap();
-						}
-						phdr_bytes.extend_from_slice(phdr.as_bytes());
-					}
-					phdr_bytes.extend_from_slice(new_segment.as_bytes());
-
-					let ehdr = self.elf_header_mut(file);
-					ehdr.e_phoff = headers_offset.try_into().unwrap();
-					ehdr.e_phnum = new_phdr_count.try_into().unwrap();
-					ehdr.e_shnum += 1;
-					ehdr.e_shoff = section_table_offset.try_into().unwrap();
-					let ehdr_bytes = ehdr.as_bytes().to_vec();
-					file.append(&ehdr_bytes)
-						.expect("failed to write the copied elf header");
-					file.append(&phdr_bytes)
-						.expect("failed to write the relocated program header table");
-					file.append(data)
-						.expect("failed to write new section to end of file");
+					self.append_manifest_segment(file, data, section_table, name_index);
 					return;
 				}
 				let vaddr_delta =
@@ -753,19 +780,19 @@ macro_rules! impl_elf {
 					+ section_table.len()
 					+ size_of::<paste! {[<$elf _Shdr>]}>();
 
-				// Create the new section.
-				let sh_type = sys::SHT_NOTE;
-				let sh_flags = 0;
+				// Create the new section. It is allocated, so that a tool which repacks the file keeps
+				// it inside the segment extended below rather than moving it out with the other
+				// sections that are not part of the image.
 				let new_section_header = paste! {[<$elf _Shdr>]{
-					sh_type: sh_type .try_into().unwrap(),
+					sh_type: sys::SHT_NOTE,
 					sh_offset: new_section_offset .try_into().unwrap(),
 					sh_size: data.len() .try_into().unwrap(),
 					sh_addr: (new_section_offset + vaddr_delta) .try_into().unwrap(),
 					sh_name: name_index .try_into().unwrap(),
-					sh_flags: sh_flags .try_into().unwrap(),
+					sh_flags: sys::SHF_ALLOC .try_into().unwrap(),
 					sh_link: 0,
 					sh_info: 0,
-					sh_addralign: 0,
+					sh_addralign: 1,
 					sh_entsize: 0,
 				}};
 

--- a/packages/std/packages/wrap/src/lib.rs
+++ b/packages/std/packages/wrap/src/lib.rs
@@ -220,18 +220,10 @@ pub fn detect_format(path: impl AsRef<Path>) -> std::io::Result<Option<Format>> 
 }
 
 static OBJCOPY_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
-static WRAPPER_BIN_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
 static WRAPPER_EXE_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
 
 pub fn set_objcopy_path(p: impl AsRef<Path>) {
 	OBJCOPY_PATH.lock().unwrap().replace(p.as_ref().to_owned());
-}
-
-pub fn set_wrapper_bin_path(p: impl AsRef<Path>) {
-	WRAPPER_BIN_PATH
-		.lock()
-		.unwrap()
-		.replace(p.as_ref().to_owned());
 }
 
 pub fn set_wrapper_exe_path(p: impl AsRef<Path>) {
@@ -248,10 +240,6 @@ pub(crate) fn objcopy_path() -> PathBuf {
 		.as_ref()
 		.cloned()
 		.unwrap_or_else(|| PathBuf::from("objcopy"))
-}
-
-pub(crate) fn wrapper_bin_path() -> Option<PathBuf> {
-	WRAPPER_EXE_PATH.lock().unwrap().as_ref().cloned()
 }
 
 pub(crate) fn wrapper_exe_path() -> Option<PathBuf> {

--- a/packages/std/packages/wrap/src/mach.rs
+++ b/packages/std/packages/wrap/src/mach.rs
@@ -31,10 +31,6 @@ fn page_size(cputype: sys::cpu_type_t) -> u64 {
 	}
 }
 
-/// Pad the manifest at the front, so that whatever follows it stays aligned and the footer stays the
-/// last thing before it. `read_manifest` reports the manifest without the padding, so replacing one
-/// leaves the padding of the previous write in the file. That is at most `ALIGNMENT` bytes each
-/// time, and always inside `__LINKEDIT` ahead of the manifest, where nothing reads it.
 fn pad_manifest(data: &[u8], position: usize) -> Vec<u8> {
 	let padding = (ALIGNMENT - (position + data.len()) % ALIGNMENT) % ALIGNMENT;
 	let mut output = vec![0; padding];
@@ -151,7 +147,6 @@ impl BinaryFormat for Mach64 {
 		// Compute the new offset of the code signature.
 		let new_offset = old.offset.to_usize().unwrap() + data.len();
 
-		// Find the code signature and LINKEDIT segment.
 		let header = *file.read_at::<mach_header_64>(0);
 		let mut offset = size_of_val(&header);
 		let mut code_signature_command = None;
@@ -172,7 +167,6 @@ impl BinaryFormat for Mach64 {
 			offset += load_command.cmdsize.to_usize().unwrap();
 		}
 
-		// Patch the code signature and LINKEDIT segment.
 		if let Some(offset) = code_signature_command {
 			let command = file.read_at_mut::<linkedit_data_command>(offset);
 			command.dataoff = new_offset.try_into().unwrap();

--- a/packages/std/packages/wrap/src/mach.rs
+++ b/packages/std/packages/wrap/src/mach.rs
@@ -19,6 +19,40 @@ const LINKEDIT: [u8; 16] = [
 const MAGIC_64: u32 = 0xfeed_facf;
 const MAGIC_UNIVERSAL: u32 = 0xcafe_babe;
 const ALIGNMENT: usize = 16;
+const CPU_TYPE_ARM64: sys::cpu_type_t = 0x0100_000c;
+const ARM64_PAGE_SIZE: u64 = 16 * 1024;
+const DEFAULT_PAGE_SIZE: u64 = 4 * 1024;
+
+fn page_size(cputype: sys::cpu_type_t) -> u64 {
+	if cputype == CPU_TYPE_ARM64 {
+		ARM64_PAGE_SIZE
+	} else {
+		DEFAULT_PAGE_SIZE
+	}
+}
+
+fn pad_manifest(data: &[u8], position: usize) -> Vec<u8> {
+	let padding = (ALIGNMENT - (position + data.len()) % ALIGNMENT) % ALIGNMENT;
+	let mut output = vec![0; padding];
+	output.extend_from_slice(data);
+	output
+}
+
+fn resize_linkedit(
+	command: &mut segment_command_64,
+	old_size: usize,
+	new_size: usize,
+	page_size: u64,
+) {
+	command.filesize = command
+		.filesize
+		.checked_sub(old_size.to_u64().unwrap())
+		.and_then(|size| size.checked_add(new_size.to_u64().unwrap()))
+		.expect("invalid LINKEDIT file size");
+	command.vmsize = command
+		.vmsize
+		.max(command.filesize.next_multiple_of(page_size));
+}
 
 impl BinaryFormat for Mach64 {
 	fn matches(&self, file: &crate::file::File) -> bool {
@@ -32,22 +66,11 @@ impl BinaryFormat for Mach64 {
 	}
 
 	fn write_manifest(&self, file: &mut File, data: &[u8]) {
-		// Get the data and pad to 4 byte boundaries.
-		let mut data = data.to_vec();
-
-		// Pad to 4 byte boundaries.
-		if !data.len().is_multiple_of(ALIGNMENT) {
-			let padding = ALIGNMENT - data.len() % ALIGNMENT;
-			for _ in 0..padding {
-				data.insert(0, 0);
-			}
-		}
-
 		// Find the code signature and LINKEDIT sections.
 		let mut code_signature_command = None;
 		let mut linkedit_command = None;
-		let header = file.read_at::<mach_header_64>(0);
-		let mut offset = size_of_val(header);
+		let header = *file.read_at::<mach_header_64>(0);
+		let mut offset = size_of_val(&header);
 		for _ in 0..header.ncmds {
 			let load_command = file.read_at::<load_command>(offset);
 			if load_command.cmd == LC_CODE_SIGNATURE {
@@ -70,11 +93,12 @@ impl BinaryFormat for Mach64 {
 			|| file.file_size().unwrap(),
 			|(_, command)| command.dataoff.into(),
 		);
+		let data = pad_manifest(data, position.to_usize().unwrap());
 
 		// Patch LINKEDIT
 		if let Some(offset) = linkedit_command {
 			let command = file.read_at_mut::<segment_command_64>(offset);
-			command.filesize += data.len().to_u64().unwrap();
+			resize_linkedit(command, 0, data.len(), page_size(header.cputype));
 		}
 
 		// Patch the code signature.
@@ -118,25 +142,41 @@ impl BinaryFormat for Mach64 {
 			self.write_manifest(file, data);
 			return;
 		};
+		let data = pad_manifest(data, old.offset);
 
 		// Compute the new offset of the code signature.
 		let new_offset = old.offset.to_usize().unwrap() + data.len();
 
-		// Find the code signature.
+		// Find the code signature and LINKEDIT segment.
 		let header = *file.read_at::<mach_header_64>(0);
 		let mut offset = size_of_val(&header);
+		let mut code_signature_command = None;
+		let mut linkedit_command = None;
 		for _ in 0..header.ncmds {
 			let load_command = *file.read_at::<load_command>(offset);
 			if load_command.cmd == LC_CODE_SIGNATURE {
-				let code_signature = file.read_at_mut::<linkedit_data_command>(offset);
-				code_signature.dataoff = new_offset.try_into().unwrap();
-				break;
+				assert!(code_signature_command.replace(offset).is_none());
+			} else if load_command.cmd == LC_SEGMENT_64 {
+				let command = file.read_at::<segment_command_64>(offset);
+				if command.segname == LINKEDIT {
+					assert!(linkedit_command.replace(offset).is_none());
+				}
 			}
 			offset += load_command.cmdsize.to_usize().unwrap();
 		}
 
+		// Patch the code signature and LINKEDIT segment.
+		if let Some(offset) = code_signature_command {
+			let command = file.read_at_mut::<linkedit_data_command>(offset);
+			command.dataoff = new_offset.try_into().unwrap();
+		}
+		if let Some(offset) = linkedit_command {
+			let command = file.read_at_mut::<segment_command_64>(offset);
+			resize_linkedit(command, old.length, data.len(), page_size(header.cputype));
+		}
+
 		// Replace the manifest.
-		file.replace(old, data)
+		file.replace(old, &data)
 			.expect("failed to overwrite manifest");
 	}
 

--- a/packages/std/packages/wrap/src/mach.rs
+++ b/packages/std/packages/wrap/src/mach.rs
@@ -31,6 +31,10 @@ fn page_size(cputype: sys::cpu_type_t) -> u64 {
 	}
 }
 
+/// Pad the manifest at the front, so that whatever follows it stays aligned and the footer stays the
+/// last thing before it. `read_manifest` reports the manifest without the padding, so replacing one
+/// leaves the padding of the previous write in the file. That is at most `ALIGNMENT` bytes each
+/// time, and always inside `__LINKEDIT` ahead of the manifest, where nothing reads it.
 fn pad_manifest(data: &[u8], position: usize) -> Vec<u8> {
 	let padding = (ALIGNMENT - (position + data.len()) % ALIGNMENT) % ALIGNMENT;
 	let mut output = vec![0; padding];
@@ -155,11 +159,14 @@ impl BinaryFormat for Mach64 {
 		for _ in 0..header.ncmds {
 			let load_command = *file.read_at::<load_command>(offset);
 			if load_command.cmd == LC_CODE_SIGNATURE {
-				assert!(code_signature_command.replace(offset).is_none());
-			} else if load_command.cmd == LC_SEGMENT_64 {
+				assert!(code_signature_command.is_none());
+				code_signature_command.replace(offset);
+			}
+			if load_command.cmd == LC_SEGMENT_64 {
 				let command = file.read_at::<segment_command_64>(offset);
 				if command.segname == LINKEDIT {
-					assert!(linkedit_command.replace(offset).is_none());
+					assert!(linkedit_command.is_none());
+					linkedit_command.replace(offset);
 				}
 			}
 			offset += load_command.cmdsize.to_usize().unwrap();

--- a/packages/std/packages/wrap/src/main.rs
+++ b/packages/std/packages/wrap/src/main.rs
@@ -69,10 +69,6 @@ struct Embed {
 	#[arg(long)]
 	wrapper_exe: PathBuf,
 
-	/// The wrapper binary.
-	#[arg(long)]
-	wrapper_bin: Option<PathBuf>,
-
 	/// The path of the objcopy binary to use.
 	#[arg(long)]
 	objcopy_path: Option<PathBuf>,
@@ -112,9 +108,6 @@ fn main() {
 			.expect("failed to deserialize manifest");
 			if let Some(path) = args.objcopy_path {
 				wrap::set_objcopy_path(path);
-			}
-			if let Some(path) = args.wrapper_bin {
-				wrap::set_wrapper_bin_path(path);
 			}
 			wrap::set_wrapper_exe_path(args.wrapper_exe);
 			std::fs::copy(args.input, &args.output).expect("failed to copy input file");

--- a/packages/std/packages/wrapper/include/footer.h
+++ b/packages/std/packages/wrapper/include/footer.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdint.h>
+#define TANGRAM_MAGIC "tangram"
 typedef struct {
 	uint64_t size;
 	uint64_t version;

--- a/packages/std/packages/wrapper/include/mach.h
+++ b/packages/std/packages/wrapper/include/mach.h
@@ -1,8 +1,10 @@
 #pragma once
 #include <stdint.h>
+#define LC_SEGMENT_64 0x19
 #define LC_CODE_SIGNATURE 29
 typedef int cpu_type_t;
 typedef int cpu_subtype_t;
+typedef int vm_prot_t;
 
 typedef struct {
 	uint32_t	magic;
@@ -19,6 +21,20 @@ typedef struct {
 	uint32_t 	cmd;
 	uint32_t 	cmdsize;
 } load_command;
+
+typedef struct {
+	uint32_t 	cmd;
+	uint32_t 	cmdsize;
+	char		segname[16];
+	uint64_t	vmaddr;
+	uint64_t	vmsize;
+	uint64_t	fileoff;
+	uint64_t	filesize;
+	vm_prot_t	maxprot;
+	vm_prot_t	initprot;
+	uint32_t	nsects;
+	uint32_t	flags;
+} segment_command_64;
 
 typedef struct {
 	uint32_t 	cmd;

--- a/packages/std/packages/wrapper/include/wrapper.h
+++ b/packages/std/packages/wrapper/include/wrapper.h
@@ -421,18 +421,17 @@ TG_VISIBILITY Executable create_executable (Arena* arena, Stack* stack, Options*
 	// Look for the manifest in the executable sections.
 	char* data = NULL;
 
-	// Read the manifest. TODO: use loadable segment?
-	int fd = open((char*)path.ptr, O_RDONLY, 0);
-	ABORT_IF(fd < 0, "failed to open the file %s", path.ptr);
+#ifdef __linux__
+	// On ELF targets, the manifest is embedded in an ELF section. The header and program header
+	// table come from the same descriptor and are needed by the userland exec below regardless.
+	// Open /proc/self/exe rather than the path, so the descriptor refers to the executing inode:
+	// the path can be replaced concurrently, which libtool does when it relinks under make -j.
+	int fd = open("/proc/self/exe", O_RDONLY, 0);
+	ABORT_IF(fd < 0, "failed to open /proc/self/exe");
 	off_t offset = 0;
 	if (options->enable_tracing) {
-		trace("opened %s (%d)\n", path.ptr, fd);
+		trace("opened /proc/self/exe (%d)\n", fd);
 	}
-#ifdef __linux__
-	// On ELF targets, the manifest is embedded in an ELF section. To read it we read the ELF
-	// file, walk the file contents, and read the manifest directly from the section. In the
-	// future we may choose to make the section loadable and read only to avoid needing to open
-	// the file at all.
 	executable.elf_header = ALLOC(arena, Elf64_Ehdr);
 
 	// Read the elf header. We don't need to do any validation here, we assume the kernel didn't lie.
@@ -494,45 +493,68 @@ TG_VISIBILITY Executable create_executable (Arena* arena, Stack* stack, Options*
 	}
 	ABORT_IF(!data, "failed to find manifest section");
 
+	// Close the file.
+	close(fd);
 #elif defined(__APPLE__)
-	// On Mach platforms, the manifest is embedded into the binary just before the code signature
-	// which must occur at the end of the file. We read the header and all the load commands to
-	// find where the code signature is in the file, then walk back from there to read the
-	// manifest.
-	mach_header_64 mach_header = {0};
-	load_command load_command = {0};
-	linkedit_data_command code_signature_command = {0};
-	read_all(options->enable_tracing, fd, (char*)&mach_header, sizeof(mach_header_64), 0);
-	if(options->enable_tracing) {
-		trace("mach_header: %08x, ncmds: %d, izeofcmds: %d\n",
-			mach_header.magic, mach_header.ncmds, mach_header.sizeofcmds);
+	// On Mach platforms, the manifest is embedded just before the code signature, which must occur
+	// at the end of the file. Both sit in __LINKEDIT, which the kernel maps, so read them from our
+	// own image: there is no /proc/self/exe here, and resolving our path would race with any
+	// concurrent job that replaces the file.
+	extern const mach_header_64 _mh_execute_header;
+	const mach_header_64* mach_header = &_mh_execute_header;
+	if (options->enable_tracing) {
+		trace("mach_header: %08x, ncmds: %d, sizeofcmds: %d\n",
+			mach_header->magic, mach_header->ncmds, mach_header->sizeofcmds);
 	}
 
-	// Find the code signature.
-	offset = (off_t)sizeof(mach_header_64);
-	for (int i = 0; i < mach_header.ncmds; i++) {
-		read_all(options->enable_tracing, fd, (char*)&load_command, sizeof(load_command), offset);
-		if (load_command.cmd == LC_CODE_SIGNATURE) {
-			read_all(options->enable_tracing, fd, (char*)&code_signature_command, sizeof(linkedit_data_command), offset);
-			break;
+	// Find the __TEXT and __LINKEDIT segments and the code signature.
+	const segment_command_64* text_segment = NULL;
+	const segment_command_64* linkedit_segment = NULL;
+	const linkedit_data_command* code_signature_command = NULL;
+	const char* command_itr = (const char*)mach_header + sizeof(mach_header_64);
+	for (uint32_t i = 0; i < mach_header->ncmds; i++) {
+		const load_command* command = (const load_command*)command_itr;
+		if (command->cmd == LC_SEGMENT_64) {
+			const segment_command_64* segment = (const segment_command_64*)command_itr;
+			if (memcmp(segment->segname, "__TEXT", sizeof("__TEXT")) == 0) {
+				text_segment = segment;
+			} else if (memcmp(segment->segname, "__LINKEDIT", sizeof("__LINKEDIT")) == 0) {
+				linkedit_segment = segment;
+			}
+		} else if (command->cmd == LC_CODE_SIGNATURE) {
+			code_signature_command = (const linkedit_data_command*)command_itr;
 		}
-		offset += load_command.cmdsize;
+		command_itr += command->cmdsize;
 	}
-	ABORT_IF(code_signature_command.dataoff== 0, "failed to find the code signature");
+	ABORT_IF(text_segment == NULL || linkedit_segment == NULL, "failed to find the segments");
+	ABORT_IF(
+		code_signature_command == NULL || code_signature_command->dataoff == 0,
+		"failed to find the code signature"
+	);
 
-	// The footer will be stored just before the code signature.
-	offset = code_signature_command.dataoff - (off_t)sizeof(Footer);
-	read_all(options->enable_tracing, fd, (char*)&executable.footer, sizeof(Footer), offset);
+	// The image is position independent, so apply the slide to the recorded addresses.
+	uintptr_t slide = (uintptr_t)mach_header - (uintptr_t)text_segment->vmaddr;
+	const char* linkedit = (const char*)((uintptr_t)linkedit_segment->vmaddr + slide);
+	uint64_t linkedit_start = linkedit_segment->fileoff;
+
+	// The footer is stored just before the code signature.
+	ABORT_IF(
+		code_signature_command->dataoff < linkedit_start + sizeof(Footer)
+			|| code_signature_command->dataoff
+				> linkedit_start + linkedit_segment->filesize,
+		"the code signature is outside the __LINKEDIT segment"
+	);
+	uint64_t footer_offset = code_signature_command->dataoff - sizeof(Footer);
+	memcpy(&executable.footer, linkedit + (footer_offset - linkedit_start), sizeof(Footer));
 
 	// The manifest is just before the footer.
-	offset -= (off_t)executable.footer.size;
+	ABORT_IF(executable.footer.size > footer_offset - linkedit_start, "invalid footer");
+	uint64_t manifest_offset = footer_offset - executable.footer.size;
 	data = ALLOC_N(arena, executable.footer.size, char);
-	read_all(options->enable_tracing, fd, data, executable.footer.size, offset);
+	memcpy(data, linkedit + (manifest_offset - linkedit_start), executable.footer.size);
 #else
 #error "unsupported target"
 #endif
-	// Close the file.
-	close(fd);
 
 	// Parse the manifest.
 	if (options->enable_tracing) {

--- a/packages/std/packages/wrapper/include/wrapper.h
+++ b/packages/std/packages/wrapper/include/wrapper.h
@@ -40,10 +40,9 @@ typedef struct
 // The executable image.
 typedef struct {
 #ifdef __linux__
-	Elf64_Ehdr* 	elf_header;		// Header of the ELF file.
+	Elf64_Ehdr* 	elf_header;		// Header of the ELF file, mapped by the kernel.
 	Elf64_Phdr* 	program_headers;	// Program headers passed by the kernel.
-	Elf64_Shdr* 	section_headers;	// Section headers read from the binary.
-	char*		section_string_table;	// String table, for finding sections by name
+	uintptr_t	load_address;		// Address the image was loaded at.
 #endif
 	Manifest* 	manifest;		// The parsed manifest.
 	Footer		footer;			// The parsed footer.
@@ -207,9 +206,7 @@ int main (int argc, char** argv) {
 		trace("read aux vector\n");
 	}
 
-	// Compute the base address. Normally this is computed using the program header table
-	// supplied in the aux vector, but this could be garbage if using a patched program header table.
-	uintptr_t load_address = stack.auxv_glob[AT_ENTRY] - executable.elf_header->e_entry;
+	uintptr_t load_address = executable.load_address;
 
 	// Check that we have space to write the new program header table and number of entries later.
 	ABORT_IF(!nphdr || nentry < 0, "missing AT_PHDR or AT_ENTRY");
@@ -422,79 +419,60 @@ TG_VISIBILITY Executable create_executable (Arena* arena, Stack* stack, Options*
 	char* data = NULL;
 
 #ifdef __linux__
-	// On ELF targets, the manifest is embedded in an ELF section. The header and program header
-	// table come from the same descriptor and are needed by the userland exec below regardless.
-	// Open /proc/self/exe rather than the path, so the descriptor refers to the executing inode:
-	// the path can be replaced concurrently, which libtool does when it relinks under make -j.
-	int fd = open("/proc/self/exe", O_RDONLY, 0);
-	ABORT_IF(fd < 0, "failed to open /proc/self/exe");
-	off_t offset = 0;
+	// On ELF targets, the manifest is written at the end of a loadable segment, which the kernel
+	// maps, so read it from our own image: opening the path would race with any concurrent job
+	// that replaces the file, which libtool does when it relinks under a parallel make.
+	//
+	// The kernel passes the address of the mapped program header table in the aux vector, and the
+	// ELF header always sits immediately before it. `wrap` preserves that when it appends a
+	// program header table of its own. Both are needed by the userland exec below regardless.
+	uintptr_t program_header_address = stack->auxv_glob[AT_PHDR];
+	ABORT_IF(!program_header_address, "missing AT_PHDR");
+	executable.elf_header = (Elf64_Ehdr*)(program_header_address - sizeof(Elf64_Ehdr));
+	executable.program_headers = (Elf64_Phdr*)program_header_address;
+	bool is_elf = (executable.elf_header->e_ident[EI_MAG0] == ELFMAG0)
+		&& (executable.elf_header->e_ident[EI_MAG1] == ELFMAG1)
+		&& (executable.elf_header->e_ident[EI_MAG2] == ELFMAG2)
+		&& (executable.elf_header->e_ident[EI_MAG3] == ELFMAG3);
+	ABORT_IF(!is_elf, "the program header table is not preceded by an elf header");
+	ABORT_IF(
+		executable.elf_header->e_phnum != stack->auxv_glob[AT_PHNUM],
+		"AT_PHNUM does not match the elf header"
+	);
+
+	// The image is position independent, so apply the load address to the recorded addresses. This
+	// is computed from the entrypoint rather than the program header table, whose address is
+	// replaced by a userland exec.
+	executable.load_address = stack->auxv_glob[AT_ENTRY] - executable.elf_header->e_entry;
 	if (options->enable_tracing) {
-		trace("opened /proc/self/exe (%d)\n", fd);
-	}
-	executable.elf_header = ALLOC(arena, Elf64_Ehdr);
-
-	// Read the elf header. We don't need to do any validation here, we assume the kernel didn't lie.
-	read_all(options->enable_tracing, fd, (char*)executable.elf_header, sizeof(Elf64_Ehdr), 0);
-
-	// Read the program header table.
-	offset = executable.elf_header->e_phoff;
-	size_t size = executable.elf_header->e_phnum * sizeof(Elf64_Phdr);
-	executable.program_headers = ALLOC_N(arena, executable.elf_header->e_phnum, Elf64_Phdr);
-	read_all(options->enable_tracing, fd, (char*)executable.program_headers, size, offset);
-
-	// Read the section header table.
-	offset = executable.elf_header->e_shoff;
-	size = executable.elf_header->e_shnum * sizeof(Elf64_Shdr);
-	executable.section_headers = ALLOC_N(arena, executable.elf_header->e_shnum, Elf64_Shdr);
-	read_all(options->enable_tracing, fd, (char*)executable.section_headers, size, offset);
-
-	// Read the section header string table.
-	Elf64_Shdr* section = executable.section_headers + executable.elf_header->e_shstrndx;
-	offset = section->sh_offset;
-	size = section->sh_size;
-	executable.section_string_table = ALLOC_N(arena, size, char);
-	read_all(options->enable_tracing, fd, (char*)executable.section_string_table, size, offset);
-
-	// Get the file size.
-	offset = lseek(fd, 0, SEEK_END);
-	if (offset < 0) {
-		ABORT("failed to seek");
-	}
-	if (options->enable_tracing) {
-		trace("file size: %d\n", offset);
+		trace("load address: %p, program headers: %p (%d)\n",
+			executable.load_address, executable.program_headers, executable.elf_header->e_phnum);
 	}
 
-	Elf64_Shdr* section_itr = executable.section_headers;
-	Elf64_Shdr* section_end = section_itr + executable.elf_header->e_shnum;
-	String TANGRAM_MANIFEST_SECTION_NAME = STRING_LITERAL(".note.tg-manifest");
-	for (; section_itr != section_end; section_itr++) {
-		String name = {0};
-		name.ptr = (uint8_t*)&executable.section_string_table[section_itr->sh_name];
-		name.len = tg_strlen((char*)name.ptr);
+	// Find the segment whose file contents end with the footer.
+	String magic = { .ptr = (uint8_t*)TANGRAM_MAGIC, .len = sizeof(executable.footer.magic) };
+	Elf64_Phdr* segment_itr = executable.program_headers;
+	Elf64_Phdr* segment_end = segment_itr + executable.elf_header->e_phnum;
+	for (; segment_itr != segment_end; segment_itr++) {
+		if (segment_itr->p_type != PT_LOAD || segment_itr->p_filesz < sizeof(Footer)) {
+			continue;
+		}
+		char* end = (char*)(executable.load_address + segment_itr->p_vaddr + segment_itr->p_filesz);
+		Footer footer = {0};
+		memcpy((void*)&footer, (void*)(end - sizeof(Footer)), sizeof(Footer));
+		String found = { .ptr = (uint8_t*)footer.magic, .len = sizeof(footer.magic) };
+		if (!streq(found, magic)) {
+			continue;
+		}
+		ABORT_IF(footer.size > segment_itr->p_filesz - sizeof(Footer), "invalid footer");
+		executable.footer = footer;
+		data = end - sizeof(Footer) - footer.size;
 		if (options->enable_tracing) {
-			trace("found section ");
-			print_json_string(&name);
-			trace("\n");
+			trace("read manifest at %p, size: %ld\n", data, footer.size);
 		}
-		if (streq(name, TANGRAM_MANIFEST_SECTION_NAME)) {
-			data	= alloc(arena, section_itr->sh_size, 1);
-			size	= section_itr->sh_size;
-			offset	= section_itr->sh_offset;
-			ABORT_IF(size < sizeof(Footer), "manifest section too small");
-			if (options->enable_tracing) {
-				trace("reading manifest at offset: %ld, size: %ld\n", offset, size);
-			}
-			read_all(options->enable_tracing, fd, data, size, offset);
-			memcpy((void*)&executable.footer, (void*)(data + (size - sizeof(Footer))), sizeof(Footer));
-			ABORT_IF(executable.footer.size > size - sizeof(Footer), "invalid footer");
-			break;
-		}
+		break;
 	}
-	ABORT_IF(!data, "failed to find manifest section");
-
-	// Close the file.
-	close(fd);
+	ABORT_IF(!data, "failed to find the manifest");
 #elif defined(__APPLE__)
 	// On Mach platforms, the manifest is embedded just before the code signature, which must occur
 	// at the end of the file. Both sit in __LINKEDIT, which the kernel maps, so read them from our
@@ -546,6 +524,10 @@ TG_VISIBILITY Executable create_executable (Arena* arena, Stack* stack, Options*
 	);
 	uint64_t footer_offset = code_signature_command->dataoff - sizeof(Footer);
 	memcpy(&executable.footer, linkedit + (footer_offset - linkedit_start), sizeof(Footer));
+	ABORT_IF(
+		memcmp(executable.footer.magic, TANGRAM_MAGIC, sizeof(executable.footer.magic)) != 0,
+		"failed to find the manifest"
+	);
 
 	// The manifest is just before the footer.
 	ABORT_IF(executable.footer.size > footer_offset - linkedit_start, "invalid footer");

--- a/packages/std/packages/wrapper/include/wrapper.h
+++ b/packages/std/packages/wrapper/include/wrapper.h
@@ -417,13 +417,7 @@ TG_VISIBILITY Executable create_executable (Arena* arena, Stack* stack, Options*
 	char* data = NULL;
 
 #ifdef __linux__
-	// On ELF targets, the manifest is written at the end of a loadable segment, which the kernel
-	// maps, so read it from our own image: opening the path would race with any concurrent job
-	// that replaces the file, which libtool does when it relinks under a parallel make.
-	//
-	// The kernel passes the address of the mapped program header table in the aux vector, and the
-	// ELF header always sits immediately before it. `wrap` preserves that when it appends a
-	// program header table of its own. Both are needed by the userland exec below regardless.
+	// Read the manifest from the mapped image to avoid racing replacements of the executable.
 	uintptr_t program_header_address = stack->auxv_glob[AT_PHDR];
 	ABORT_IF(!program_header_address, "missing AT_PHDR");
 	executable.elf_header = (Elf64_Ehdr*)(program_header_address - sizeof(Elf64_Ehdr));
@@ -438,18 +432,13 @@ TG_VISIBILITY Executable create_executable (Arena* arena, Stack* stack, Options*
 		"AT_PHNUM does not match the elf header"
 	);
 
-	// The image is position independent, so apply the load address to the recorded addresses. This
-	// is computed from the entrypoint rather than the program header table, whose address is
-	// replaced by a userland exec.
 	executable.load_address = stack->auxv_glob[AT_ENTRY] - executable.elf_header->e_entry;
 	if (options->enable_tracing) {
 		trace("load address: %p, program headers: %p (%d)\n",
 			executable.load_address, executable.program_headers, executable.elf_header->e_phnum);
 	}
 
-	// Find the footer at the end of the file contents of a loadable segment. `wrap` writes it to the
-	// segment whose file contents end last, so take that one: a binary wrapped more than once keeps
-	// the earlier footers, and only the last one describes the manifest in force.
+	// Use the footer in the loadable segment whose file contents end last.
 	String magic = { .ptr = (uint8_t*)TANGRAM_MAGIC, .len = sizeof(executable.footer.magic) };
 	Elf64_Phdr* segment_itr = executable.program_headers;
 	Elf64_Phdr* segment_end = segment_itr + executable.elf_header->e_phnum;
@@ -478,10 +467,7 @@ TG_VISIBILITY Executable create_executable (Arena* arena, Stack* stack, Options*
 	}
 	ABORT_IF(!data, "failed to find the manifest");
 #elif defined(__APPLE__)
-	// On Mach platforms, the manifest is embedded just before the code signature, which must occur
-	// at the end of the file. Both sit in __LINKEDIT, which the kernel maps, so read them from our
-	// own image: there is no /proc/self/exe here, and resolving our path would race with any
-	// concurrent job that replaces the file.
+	// Read the manifest from the mapped __LINKEDIT segment.
 	extern const mach_header_64 _mh_execute_header;
 	const mach_header_64* mach_header = &_mh_execute_header;
 	if (options->enable_tracing) {
@@ -489,7 +475,6 @@ TG_VISIBILITY Executable create_executable (Arena* arena, Stack* stack, Options*
 			mach_header->magic, mach_header->ncmds, mach_header->sizeofcmds);
 	}
 
-	// Find the __TEXT and __LINKEDIT segments and the code signature.
 	const segment_command_64* text_segment = NULL;
 	const segment_command_64* linkedit_segment = NULL;
 	const linkedit_data_command* code_signature_command = NULL;
@@ -514,12 +499,10 @@ TG_VISIBILITY Executable create_executable (Arena* arena, Stack* stack, Options*
 		"failed to find the code signature"
 	);
 
-	// The image is position independent, so apply the slide to the recorded addresses.
 	uintptr_t slide = (uintptr_t)mach_header - (uintptr_t)text_segment->vmaddr;
 	const char* linkedit = (const char*)((uintptr_t)linkedit_segment->vmaddr + slide);
 	uint64_t linkedit_start = linkedit_segment->fileoff;
 
-	// The footer is stored just before the code signature.
 	ABORT_IF(
 		code_signature_command->dataoff < linkedit_start + sizeof(Footer)
 			|| code_signature_command->dataoff
@@ -533,8 +516,6 @@ TG_VISIBILITY Executable create_executable (Arena* arena, Stack* stack, Options*
 		"failed to find the manifest"
 	);
 
-	// The manifest is just before the footer. Point straight at the mapping: parsing it does not
-	// write to it, so there is nothing to copy.
 	ABORT_IF(executable.footer.size > footer_offset - linkedit_start, "invalid footer");
 	uint64_t manifest_offset = footer_offset - executable.footer.size;
 	data = (char*)(linkedit + (manifest_offset - linkedit_start));

--- a/packages/std/packages/wrapper/include/wrapper.h
+++ b/packages/std/packages/wrapper/include/wrapper.h
@@ -206,8 +206,6 @@ int main (int argc, char** argv) {
 		trace("read aux vector\n");
 	}
 
-	uintptr_t load_address = executable.load_address;
-
 	// Check that we have space to write the new program header table and number of entries later.
 	ABORT_IF(!nphdr || nentry < 0, "missing AT_PHDR or AT_ENTRY");
 
@@ -215,7 +213,7 @@ int main (int argc, char** argv) {
 	void* entrypoint = NULL;
 	if (executable.manifest->interpreter.ptr) {
 		// If there's an interpreter arg,
-		stack.auxv[nentry].a_un.a_val = load_address + executable.manifest->entrypoint;
+		stack.auxv[nentry].a_un.a_val = executable.load_address + executable.manifest->entrypoint;
 
 		// Load the interpreter.
 		Interpreter interpreter = create_interpreter(
@@ -236,7 +234,7 @@ int main (int argc, char** argv) {
 		// Set the entrypoint as the interpreter.
 		entrypoint = (void*)(interpreter.base_address + interpreter.entry);
 	} else {
-		entrypoint = (void*)((uintptr_t)load_address + executable.manifest->entrypoint);
+		entrypoint = (void*)(executable.load_address + executable.manifest->entrypoint);
 	}
 
 	// Fix program headers. We use a second arena to avoid freeing the memory before userland exec.
@@ -245,7 +243,7 @@ int main (int argc, char** argv) {
 	ProgramHeaders new_phdrs = create_program_headers(
 		&preserved_memory,
 		executable.manifest,
-		(void*)load_address,
+		(void*)executable.load_address,
 		stack.auxv[nentry].a_un.a_val,
 		executable.program_headers,
 		executable.elf_header->e_phnum
@@ -449,12 +447,18 @@ TG_VISIBILITY Executable create_executable (Arena* arena, Stack* stack, Options*
 			executable.load_address, executable.program_headers, executable.elf_header->e_phnum);
 	}
 
-	// Find the segment whose file contents end with the footer.
+	// Find the footer at the end of the file contents of a loadable segment. `wrap` writes it to the
+	// segment whose file contents end last, so take that one: a binary wrapped more than once keeps
+	// the earlier footers, and only the last one describes the manifest in force.
 	String magic = { .ptr = (uint8_t*)TANGRAM_MAGIC, .len = sizeof(executable.footer.magic) };
 	Elf64_Phdr* segment_itr = executable.program_headers;
 	Elf64_Phdr* segment_end = segment_itr + executable.elf_header->e_phnum;
+	uint64_t file_end = 0;
 	for (; segment_itr != segment_end; segment_itr++) {
 		if (segment_itr->p_type != PT_LOAD || segment_itr->p_filesz < sizeof(Footer)) {
+			continue;
+		}
+		if (data && segment_itr->p_offset + segment_itr->p_filesz <= file_end) {
 			continue;
 		}
 		char* end = (char*)(executable.load_address + segment_itr->p_vaddr + segment_itr->p_filesz);
@@ -467,10 +471,10 @@ TG_VISIBILITY Executable create_executable (Arena* arena, Stack* stack, Options*
 		ABORT_IF(footer.size > segment_itr->p_filesz - sizeof(Footer), "invalid footer");
 		executable.footer = footer;
 		data = end - sizeof(Footer) - footer.size;
+		file_end = segment_itr->p_offset + segment_itr->p_filesz;
 		if (options->enable_tracing) {
 			trace("read manifest at %p, size: %ld\n", data, footer.size);
 		}
-		break;
 	}
 	ABORT_IF(!data, "failed to find the manifest");
 #elif defined(__APPLE__)
@@ -529,11 +533,14 @@ TG_VISIBILITY Executable create_executable (Arena* arena, Stack* stack, Options*
 		"failed to find the manifest"
 	);
 
-	// The manifest is just before the footer.
+	// The manifest is just before the footer. Point straight at the mapping: parsing it does not
+	// write to it, so there is nothing to copy.
 	ABORT_IF(executable.footer.size > footer_offset - linkedit_start, "invalid footer");
 	uint64_t manifest_offset = footer_offset - executable.footer.size;
-	data = ALLOC_N(arena, executable.footer.size, char);
-	memcpy(data, linkedit + (manifest_offset - linkedit_start), executable.footer.size);
+	data = (char*)(linkedit + (manifest_offset - linkedit_start));
+	if (options->enable_tracing) {
+		trace("read manifest at %p, size: %ld\n", data, executable.footer.size);
+	}
 #else
 #error "unsupported target"
 #endif

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -764,7 +764,7 @@ export namespace sdk {
 			const ldsoPath = libc.interpreterName(target);
 
 			// Try the toplevel lib directory first
-			let libDir = await directory.tryGet("lib");
+			const libDir = await directory.tryGet("lib");
 			if (libDir && libDir instanceof tg.Directory) {
 				const ldso = await libDir.tryGet(ldsoPath);
 				if (ldso && ldso instanceof tg.File) {
@@ -772,16 +772,20 @@ export namespace sdk {
 				}
 			}
 
-			// If not found in toplevel lib, try the target-prefixed directory.
-			libDir = await directory
-				.tryGet(`${target}/lib`)
-				.then(tg.Directory.expect);
+			// If not found in toplevel lib, try the target-prefixed directory. Both lookups are
+			// `tryGet`, so that a toolchain that has neither reports which one was missing rather
+			// than an unlabelled assertion.
+			const sysrootLibDir = await directory.tryGet(`${target}/lib`);
 			tg.assert(
-				libDir && libDir instanceof tg.Directory,
-				"failed to locate toolchain sysroot libdir",
+				sysrootLibDir instanceof tg.Directory,
+				`failed to locate the toolchain sysroot libdir for ${target}`,
 			);
-			const ldso = await libDir.tryGet(ldsoPath).then(tg.File.expect);
-			return { ldso, libDir };
+			const ldso = await sysrootLibDir.tryGet(ldsoPath);
+			tg.assert(
+				ldso instanceof tg.File,
+				`failed to locate ${ldsoPath} in the toolchain sysroot libdir for ${target}`,
+			);
+			return { ldso, libDir: sysrootLibDir };
 		}
 	}
 

--- a/packages/std/sdk.tg.ts
+++ b/packages/std/sdk.tg.ts
@@ -772,9 +772,6 @@ export namespace sdk {
 				}
 			}
 
-			// If not found in toplevel lib, try the target-prefixed directory. Both lookups are
-			// `tryGet`, so that a toolchain that has neither reports which one was missing rather
-			// than an unlabelled assertion.
 			const sysrootLibDir = await directory.tryGet(`${target}/lib`);
 			tg.assert(
 				sysrootLibDir instanceof tg.Directory,

--- a/packages/std/sdk/proxy.tg.ts
+++ b/packages/std/sdk/proxy.tg.ts
@@ -299,7 +299,6 @@ async function ldProxy(arg: LdProxyArg) {
 		std.triple.os(build) === "linux" ? (arg.embedWrapper ?? true) : false;
 
 	// Get the embedded wrapper artifacts.
-	const wrapperBin = await workspace.wrapperBinary({ host, build });
 	const wrapperExe = await workspace.wrapper({ host, build });
 	let objcopy = undefined;
 
@@ -363,7 +362,6 @@ async function ldProxy(arg: LdProxyArg) {
 		TANGRAM_CODESIGN_PATH: codesign
 			? tg.Mutation.set(codesign)
 			: (tg.Mutation.unset() as tg.Mutation<tg.File>),
-		TANGRAM_WRAPPER_BIN_PATH: tg.Mutation.set(wrapperBin),
 		TANGRAM_WRAPPER_EXE_PATH: tg.Mutation.set(wrapperExe),
 		TANGRAM_OBJCOPY_PATH: objcopy
 			? tg.Mutation.set(objcopy)
@@ -467,10 +465,9 @@ export async function test() {
 	return true;
 }
 
-/** The names of the linker proxy env vars that each locate an artifact the proxy checks out at run time. */
-const ldProxyArtifactEnvVars = [
-	"TANGRAM_CODESIGN_PATH",
-	"TANGRAM_WRAPPER_BIN_PATH",
+/** The names of the linker proxy env vars that each locate an artifact the proxy checks out at run time. Only Mach-O outputs get codesigned, so the proxy leaves `TANGRAM_CODESIGN_PATH` unset elsewhere. */
+const ldProxyArtifactEnvVars = (host: string) => [
+	...(std.triple.os(host) === "darwin" ? ["TANGRAM_CODESIGN_PATH"] : []),
 	"TANGRAM_WRAPPER_EXE_PATH",
 	"TGLD_INJECTION_PATH",
 ];
@@ -501,8 +498,8 @@ const manifestEnvValue = (
 
 /** Every artifact the linker proxy needs at run time must be reachable from its object graph.
  *
- * The proxy receives the wrapper executable, the wrapper binary, `codesign`, and the injection
- * library through its env. Passing any of them as a bare id string smuggles the reference past the
+ * The proxy receives the wrapper executable, `codesign`, and the injection library through its
+ * env. Passing any of them as a bare id string smuggles the reference past the
  * object graph: a string component is not an artifact component, so no dependency edge is recorded,
  * so the sandboxed process holds no grant and its runtime checkout is denied ("failed to ensure the
  * artifacts are stored and authorized ... failed to find the artifact").
@@ -512,7 +509,7 @@ const manifestEnvValue = (
  * vacuously. This test asserts the property the proxy actually needs: each of these env vars carries
  * an artifact, and every artifact they carry is recorded as a dependency of the proxy. */
 export async function testLdProxyDependencies() {
-	const host = std.triple.host();
+	const host = bootstrap.toolchainTriple(std.triple.host());
 	const buildToolchain = await bootstrap.sdk();
 	const { ld } = await std.sdk.toolchainComponents({
 		env: await std.env.compose(buildToolchain),
@@ -529,7 +526,7 @@ export async function testLdProxyDependencies() {
 
 	// Each env var must carry an artifact, not a bare id string.
 	const referents = new Set<tg.Object.Id>();
-	for (const name of ldProxyArtifactEnvVars) {
+	for (const name of ldProxyArtifactEnvVars(host)) {
 		const value = manifestEnvValue(manifest, name);
 		tg.assert(value !== undefined, `the linker proxy env should set ${name}`);
 		const artifacts = [];

--- a/packages/std/sdk/proxy.tg.ts
+++ b/packages/std/sdk/proxy.tg.ts
@@ -465,7 +465,6 @@ export async function test() {
 	return true;
 }
 
-/** The names of the linker proxy env vars that each locate an artifact the proxy checks out at run time. Only Mach-O outputs get codesigned, so the proxy leaves `TANGRAM_CODESIGN_PATH` unset elsewhere. */
 const ldProxyArtifactEnvVars = (host: string) => [
 	...(std.triple.os(host) === "darwin" ? ["TANGRAM_CODESIGN_PATH"] : []),
 	"TANGRAM_WRAPPER_EXE_PATH",
@@ -496,18 +495,6 @@ const manifestEnvValue = (
 	return map.value[name];
 };
 
-/** Every artifact the linker proxy needs at run time must be reachable from its object graph.
- *
- * The proxy receives the wrapper executable, `codesign`, and the injection library through its
- * env. Passing any of them as a bare id string smuggles the reference past the
- * object graph: a string component is not an artifact component, so no dependency edge is recorded,
- * so the sandboxed process holds no grant and its runtime checkout is denied ("failed to ensure the
- * artifacts are stored and authorized ... failed to find the artifact").
- *
- * Note that a bare id string is invisible to `manifestDependencies`, which only yields artifact
- * components. Asserting only that every referent is a recorded dependency therefore passes
- * vacuously. This test asserts the property the proxy actually needs: each of these env vars carries
- * an artifact, and every artifact they carry is recorded as a dependency of the proxy. */
 export async function testLdProxyDependencies() {
 	const host = bootstrap.toolchainTriple(std.triple.host());
 	const buildToolchain = await bootstrap.sdk();

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -2682,6 +2682,13 @@ export async function test() {
 		tg.build(testSingleArgObjectNoMutations, {
 			name: "single arg object no mutations",
 		}),
+		tg.build(testConcurrentRelink, { name: "concurrent relink" }),
+		tg.build(testConcurrentRelinkStandalone, {
+			name: "concurrent relink standalone",
+		}),
+		tg.build(testConcurrentRelinkTransient, {
+			name: "concurrent relink transient",
+		}),
 		tg.build(testDependencies, { name: "dependencies" }),
 		tg.build(testDylibPath, { name: "dylib path" }),
 		tg.build(testEnvObjectFromArtifactAuthorization, {
@@ -2808,9 +2815,7 @@ export async function testSingleArgObjectNoMutations() {
 			"Expected _NSGetExecutablePath to point to the wrapper",
 		);
 		tg.assert(
-			text.match(
-				new RegExp(`argv\\[0\\]: .*\\.tangram/store/${wrapperID}`),
-			),
+			text.match(new RegExp(`argv\\[0\\]: .*\\.tangram/store/${wrapperID}`)),
 			"Expected argv[0] to point to the wrapper that was invoked",
 		);
 	}
@@ -3677,4 +3682,177 @@ export async function testLdLibraryPathPreservedThroughNestedWrapping() {
 	const result = string === "hello, world!\n";
 	tg.assert(result, `Expected "hello, world!\\n" but got "${string}"`);
 	return result;
+}
+
+/** The program the concurrent relink tests wrap. */
+const concurrentRelinkSource = tg.directory({
+	"main.c": tg.file(`
+		#include <stdio.h>
+		int main() {
+			printf("hello, world!\\n");
+			return 0;
+		}
+	`),
+});
+
+const relinkWrapper = async (toolchain: std.env.Arg) => {
+	const executable = await std
+		.run(std.shBootstrap`
+		cc ${concurrentRelinkSource}/main.c -o ${tg.output}
+	`)
+		.env(toolchain)
+		.then(tg.File.expect);
+	return await wrap(executable, { buildToolchain: toolchain });
+};
+
+/** Run `wrapper` from 16 concurrent workers, each replacing it with an atomic rename first. */
+const atomicRelink = async (wrapper: tg.File) => {
+	const workers = 16;
+	const iterations = 150;
+	const toolchain = await bootstrap.sdk(std.triple.host());
+
+	const output = await std
+		.build(std.shBootstrap`
+		mkdir -p .libs
+		cp ${wrapper} .libs/lt-prog
+
+		i=1
+		while [ $i -le ${workers.toString()} ]; do
+			(
+				j=0
+				while [ $j -lt ${iterations.toString()} ]; do
+					cp ${wrapper} .libs/$i-lt-prog
+					mv -f .libs/$i-lt-prog .libs/lt-prog
+					./.libs/lt-prog >> $i.log 2>&1
+					j=$((j+1))
+				done
+			) &
+			i=$((i+1))
+		done
+		wait
+
+		cat *.log > ${tg.output}
+	`)
+		.env(toolchain)
+		.then(tg.File.expect);
+
+	const lines = await output.text.then((text) => text.split("\n").slice(0, -1));
+	const failures = lines.filter((line) => line !== "hello, world!");
+	tg.assert(
+		failures.length === 0,
+		`Expected every run to succeed, got ${failures.length} failures: ${failures.slice(0, 3).join(", ")}`,
+	);
+	tg.assert(
+		lines.length === workers * iterations,
+		`Expected ${workers * iterations} runs, got ${lines.length}`,
+	);
+	return true;
+};
+
+/** A libtool wrapper script renames a relinked binary over `.libs/lt-<name>` then execs it, so under `make -j` a wrapper can be replaced between its own exec and its first read of itself. */
+export async function testConcurrentRelink() {
+	const host = std.triple.host();
+	return await atomicRelink(await relinkWrapper(await bootstrap.sdk(host)));
+}
+
+/** The same race against a standalone wrapper, which keeps its manifest elsewhere in the file and execs the program rather than userland-execing itself. */
+export async function testConcurrentRelinkStandalone() {
+	const host = std.triple.host();
+	const sdkArg = await bootstrap.sdk.arg(host);
+	const toolchain = await std.sdk({ ...sdkArg, embedWrapper: false });
+	return await atomicRelink(await relinkWrapper(toolchain));
+}
+
+/** The same race against libtool's fallback, which removes `.libs/lt-<name>` before renaming into place, so the path is briefly absent. Runs the kernel could not exec are expected; a run it did exec must not fail inside the wrapper. */
+export async function testConcurrentRelinkTransient() {
+	const host = std.triple.host();
+	const workers = 8;
+	const iterations = 200;
+
+	const toolchain = await bootstrap.sdk(host);
+	const wrapper = await relinkWrapper(toolchain);
+
+	const output = await std
+		.build(std.shBootstrap`
+		mkdir -p .libs
+		cp ${wrapper} .libs/lt-prog
+
+		i=1
+		while [ $i -le ${workers.toString()} ]; do
+			(
+				j=0
+				while [ $j -lt ${iterations.toString()} ]; do
+					cp ${wrapper} .libs/$i-lt-prog
+					# The bootstrap "rm" still reports ENOENT with "-f" if another worker wins.
+					rm -f .libs/lt-prog || true
+					mv -f .libs/$i-lt-prog .libs/lt-prog
+					# Capture the status, since a failed exec would end the worker under "set -e".
+					if result=$(./.libs/lt-prog 2>&1); then
+						status=0
+					else
+						status=$?
+					fi
+					echo "$status|$result" >> $i.log
+					j=$((j+1))
+				done
+			) &
+			i=$((i+1))
+		done
+		wait
+
+		cat *.log > ${tg.output}
+	`)
+		.env(toolchain)
+		.then(tg.File.expect);
+
+	const results = await output.text.then((text) =>
+		text
+			.split("\n")
+			.filter((line) => line !== "")
+			.map((line) => {
+				const separator = line.indexOf("|");
+				return {
+					status: line.slice(0, separator),
+					text: line.slice(separator + 1),
+				};
+			}),
+	);
+	tg.assert(
+		results.length === workers * iterations,
+		`Expected ${workers * iterations} runs, got ${results.length}`,
+	);
+
+	// The wrapper aborts with 111. The status a shell reports for a failed exec varies, so key on
+	// that rather than on an allowlist of shell statuses.
+	const aborts = results.filter((result) => result.status === "111");
+	tg.assert(
+		aborts.length === 0,
+		`Expected no wrapper failures, got ${aborts.length}: ${aborts
+			.slice(0, 3)
+			.map((abort) => `${abort.status}|${abort.text}`)
+			.join(", ")}`,
+	);
+
+	const successes = results.filter((result) => result.status === "0");
+	tg.assert(successes.length > 0, "Expected at least one run to succeed");
+
+	// Without this the test passes vacuously when the timing never makes the path absent.
+	const absent = results.filter(
+		(result) => result.status !== "0" && result.status !== "111",
+	);
+	tg.assert(
+		absent.length > 0,
+		"Expected at least one run to find the path absent",
+	);
+	const unexpected = successes.filter(
+		(result) => result.text !== "hello, world!",
+	);
+	tg.assert(
+		unexpected.length === 0,
+		`Expected every successful run to print the greeting, got ${unexpected.length} with other output: ${unexpected
+			.slice(0, 3)
+			.map((result) => result.text)
+			.join(", ")}`,
+	);
+	return true;
 }

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -4,6 +4,7 @@ import * as gnu from "./sdk/gnu.tg.ts";
 import * as std from "./tangram.ts";
 import * as injection from "./wrap/injection.tg.ts";
 import * as workspace from "./wrap/workspace.tg.ts";
+import * as wrapperModule from "./wrap/wrapper.tg.ts";
 import inspectProcessSource from "./wrap/test/inspectProcess.c" with { type: "file" };
 
 export { ccProxy, ldProxy, wrapper } from "./wrap/workspace.tg.ts";
@@ -2682,6 +2683,7 @@ export async function test() {
 		tg.build(testSingleArgObjectNoMutations, {
 			name: "single arg object no mutations",
 		}),
+		tg.build(wrapperModule.testStatic, { name: "static executable" }),
 		tg.build(testConcurrentRelink, { name: "concurrent relink" }),
 		tg.build(testConcurrentRelinkStandalone, {
 			name: "concurrent relink standalone",

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -2713,6 +2713,9 @@ export async function test() {
 		tg.build(testManifestDependenciesMergeMutation, {
 			name: "manifest dependencies merge mutation",
 		}),
+		tg.build(testDarwinLargeManifestOverwrite, {
+			name: "Darwin large manifest overwrite",
+		}),
 		tg.build(testManifestMutationPrependRoundTrip, {
 			name: "manifest mutation prepend round trip",
 		}),
@@ -3062,6 +3065,56 @@ export async function testManifestMutationPrependRoundTrip() {
 	tg.assert(
 		roundTrippedMutation.inner.kind === "prepend",
 		"expected a prepend mutation to remain a prepend mutation",
+	);
+
+	return true;
+}
+
+/** Replacing a Mach-O manifest must grow the mapped __LINKEDIT segment with the file data. */
+export async function testDarwinLargeManifestOverwrite() {
+	if (std.triple.os(std.triple.host()) !== "darwin") {
+		return true;
+	}
+
+	const executable = {
+		kind: "content" as const,
+		value: await manifestTemplateFromArg("exit 0"),
+	};
+	const initial = await wrap.Manifest.write(
+		await testWrapperBinary(),
+		{ executable },
+		new Map(),
+	);
+	const values = Array.from(
+		{ length: 32 },
+		(_, index) => `${index}:${"x".repeat(1024)}`,
+	);
+	const rewritten = await wrap.Manifest.write(
+		initial,
+		{
+			executable,
+			args: await Promise.all(
+				values.map((value) => manifestTemplateFromArg(value)),
+			),
+		},
+		new Map(),
+	);
+
+	const output = await tg
+		.build(
+			std.shBootstrap`${rewritten} --tangram-print-manifest > ${tg.output}`,
+		)
+		.then(tg.File.expect);
+	const manifest = tg.encoding.json.decode(await output.text) as wrap.Manifest;
+	tg.assert(
+		manifest.args?.length === values.length &&
+			manifest.args.every((arg, index) => {
+				const component = arg.components[0];
+				return (
+					component?.kind === "string" && component.value === values[index]
+				);
+			}),
+		"large manifest did not round trip through the mapped image",
 	);
 
 	return true;

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -2808,14 +2808,13 @@ export async function testSingleArgObjectNoMutations() {
 		await origExecutable.store();
 		const origExecutableId = origExecutable.id;
 		console.log("origExecutable", origExecutableId);
+		const wrapperStorePath = `.*/store/${wrapperID}`;
 		tg.assert(
-			text.match(
-				new RegExp(`_NSGetExecutablePath: .*\\.tangram/store/${wrapperID}`),
-			),
+			text.match(new RegExp(`_NSGetExecutablePath: ${wrapperStorePath}`)),
 			"Expected _NSGetExecutablePath to point to the wrapper",
 		);
 		tg.assert(
-			text.match(new RegExp(`argv\\[0\\]: .*\\.tangram/store/${wrapperID}`)),
+			text.match(new RegExp(`argv\\[0\\]: ${wrapperStorePath}`)),
 			"Expected argv[0] to point to the wrapper that was invoked",
 		);
 	}
@@ -3836,10 +3835,30 @@ export async function testConcurrentRelinkTransient() {
 	const successes = results.filter((result) => result.status === "0");
 	tg.assert(successes.length > 0, "Expected at least one run to succeed");
 
-	// Without this the test passes vacuously when the timing never makes the path absent.
-	const absent = results.filter(
-		(result) => result.status !== "0" && result.status !== "111",
+	const isAbsentPathFailure = (result: (typeof results)[number]) => {
+		const status = Number(result.status);
+		return (
+			status > 0 &&
+			status < 128 &&
+			/(?:not found|no such file or directory)/i.test(result.text)
+		);
+	};
+	const unexpectedFailures = results.filter(
+		(result) =>
+			result.status !== "0" &&
+			result.status !== "111" &&
+			!isAbsentPathFailure(result),
 	);
+	tg.assert(
+		unexpectedFailures.length === 0,
+		`Expected every non-wrapper failure to be a missing-path exec failure, got ${unexpectedFailures.length} unexpected failures: ${unexpectedFailures
+			.slice(0, 3)
+			.map((failure) => `${failure.status}|${failure.text}`)
+			.join(", ")}`,
+	);
+
+	// Without this the test passes vacuously when the timing never makes the path absent.
+	const absent = results.filter(isAbsentPathFailure);
 	tg.assert(
 		absent.length > 0,
 		"Expected at least one run to find the path absent",

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -2688,6 +2688,9 @@ export async function test() {
 		}),
 		tg.build(wrapperModule.testStatic, { name: "static executable" }),
 		tg.build(wrapperModule.testBssManifest, { name: "BSS manifest" }),
+		tg.build(wrapperModule.testStripPreservesManifest, {
+			name: "strip preserves manifest",
+		}),
 		tg.build(testConcurrentRelink, { name: "concurrent relink" }),
 		tg.build(testConcurrentRelinkStandalone, {
 			name: "concurrent relink standalone",
@@ -3880,8 +3883,7 @@ export async function testConcurrentRelinkTransient() {
 		`Expected ${workers * iterations} runs, got ${results.length}`,
 	);
 
-	// The wrapper aborts with 111. The status a shell reports for a failed exec varies, so key on
-	// that rather than on an allowlist of shell statuses.
+	// The wrapper aborts with 111.
 	const aborts = results.filter((result) => result.status === "111");
 	tg.assert(
 		aborts.length === 0,
@@ -3894,6 +3896,8 @@ export async function testConcurrentRelinkTransient() {
 	const successes = results.filter((result) => result.status === "0");
 	tg.assert(successes.length > 0, "Expected at least one run to succeed");
 
+	// A run the kernel could not exec at all is expected. The status a shell reports for a failed
+	// exec varies, so key on the message rather than on an allowlist of statuses.
 	const isAbsentPathFailure = (result: (typeof results)[number]) => {
 		const status = Number(result.status);
 		return (

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -3076,7 +3076,6 @@ export async function testManifestMutationPrependRoundTrip() {
 	return true;
 }
 
-/** Replacing a Mach-O manifest must grow the mapped __LINKEDIT segment with the file data. */
 export async function testDarwinLargeManifestOverwrite() {
 	if (std.triple.os(std.triple.host()) !== "darwin") {
 		return true;
@@ -3748,7 +3747,6 @@ export async function testLdLibraryPathPreservedThroughNestedWrapping() {
 	return result;
 }
 
-/** The program the concurrent relink tests wrap. */
 const concurrentRelinkSource = tg.directory({
 	"main.c": tg.file(`
 		#include <stdio.h>
@@ -3769,7 +3767,6 @@ const relinkWrapper = async (toolchain: std.env.Arg) => {
 	return await wrap(executable, { buildToolchain: toolchain });
 };
 
-/** Run `wrapper` from 16 concurrent workers, each replacing it with an atomic rename first. */
 const atomicRelink = async (wrapper: tg.File) => {
 	const workers = 16;
 	const iterations = 150;
@@ -3813,13 +3810,11 @@ const atomicRelink = async (wrapper: tg.File) => {
 	return true;
 };
 
-/** A libtool wrapper script renames a relinked binary over `.libs/lt-<name>` then execs it, so under `make -j` a wrapper can be replaced between its own exec and its first read of itself. */
 export async function testConcurrentRelink() {
 	const host = std.triple.host();
 	return await atomicRelink(await relinkWrapper(await bootstrap.sdk(host)));
 }
 
-/** The same race against a standalone wrapper, which keeps its manifest elsewhere in the file and execs the program rather than userland-execing itself. */
 export async function testConcurrentRelinkStandalone() {
 	const host = std.triple.host();
 	const sdkArg = await bootstrap.sdk.arg(host);
@@ -3827,7 +3822,6 @@ export async function testConcurrentRelinkStandalone() {
 	return await atomicRelink(await relinkWrapper(toolchain));
 }
 
-/** The same race against libtool's fallback, which removes `.libs/lt-<name>` before renaming into place, so the path is briefly absent. Runs the kernel could not exec are expected; a run it did exec must not fail inside the wrapper. */
 export async function testConcurrentRelinkTransient() {
 	const host = std.triple.host();
 	const workers = 8;
@@ -3886,7 +3880,6 @@ export async function testConcurrentRelinkTransient() {
 		`Expected ${workers * iterations} runs, got ${results.length}`,
 	);
 
-	// The wrapper aborts with 111.
 	const aborts = results.filter((result) => result.status === "111");
 	tg.assert(
 		aborts.length === 0,
@@ -3899,8 +3892,7 @@ export async function testConcurrentRelinkTransient() {
 	const successes = results.filter((result) => result.status === "0");
 	tg.assert(successes.length > 0, "Expected at least one run to succeed");
 
-	// A run the kernel could not exec at all is expected. The status a shell reports for a failed
-	// exec varies, so key on the message rather than on an allowlist of statuses.
+	// Shell status varies for a missing executable, so also check its message.
 	const isAbsentPathFailure = (result: (typeof results)[number]) => {
 		const status = Number(result.status);
 		return (
@@ -3923,7 +3915,6 @@ export async function testConcurrentRelinkTransient() {
 			.join(", ")}`,
 	);
 
-	// Without this the test passes vacuously when the timing never makes the path absent.
 	const absent = results.filter(isAbsentPathFailure);
 	tg.assert(
 		absent.length > 0,

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -2691,6 +2691,9 @@ export async function test() {
 		tg.build(wrapperModule.testStripPreservesManifest, {
 			name: "strip preserves manifest",
 		}),
+		tg.build(wrapperModule.testEmbedNonuniformWrapper, {
+			name: "embed nonuniform wrapper",
+		}),
 		tg.build(testConcurrentRelink, { name: "concurrent relink" }),
 		tg.build(testConcurrentRelinkStandalone, {
 			name: "concurrent relink standalone",

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -2683,6 +2683,9 @@ export async function test() {
 		tg.build(testSingleArgObjectNoMutations, {
 			name: "single arg object no mutations",
 		}),
+		tg.build(wrapperModule.testWrapperPositionIndependent, {
+			name: "position-independent wrapper",
+		}),
 		tg.build(wrapperModule.testStatic, { name: "static executable" }),
 		tg.build(wrapperModule.testBssManifest, { name: "BSS manifest" }),
 		tg.build(testConcurrentRelink, { name: "concurrent relink" }),

--- a/packages/std/wrap.tg.ts
+++ b/packages/std/wrap.tg.ts
@@ -2684,6 +2684,7 @@ export async function test() {
 			name: "single arg object no mutations",
 		}),
 		tg.build(wrapperModule.testStatic, { name: "static executable" }),
+		tg.build(wrapperModule.testBssManifest, { name: "BSS manifest" }),
 		tg.build(testConcurrentRelink, { name: "concurrent relink" }),
 		tg.build(testConcurrentRelinkStandalone, {
 			name: "concurrent relink standalone",

--- a/packages/std/wrap/workspace.tg.ts
+++ b/packages/std/wrap/workspace.tg.ts
@@ -196,31 +196,6 @@ export async function wrapper(...args: tg.Args<Arg>) {
 		.then(tg.File.expect);
 }
 
-export async function wrapperBinary(...args: tg.Args<Arg>) {
-	const resolved = await tg.Args.apply<
-		Arg,
-		tg.ValueOrMaybeMutationMap<Arg>,
-		Arg
-	>({
-		args,
-		map: async (a) => a,
-		reduce: {},
-	});
-	const { build, host, release = true, source, verbose = false } = resolved;
-
-	if (
-		await shouldUseDefaultWorkspace({ build, host, release, source, verbose })
-	) {
-		return tg.build(defaultWrapperBinary).named("default wrapper");
-	}
-
-	return await tg
-		.build(workspace, ...args)
-		.named("workspace")
-		.then((dir) => dir.get("bin/wrapper.bin"))
-		.then(tg.File.expect);
-}
-
 /** The default workspace built with the default SDK for the detected host. This version uses the default SDK to ensure cache hits when used throughout the codebase. */
 export async function defaultWorkspace() {
 	const host = std.triple.host();
@@ -235,22 +210,9 @@ export async function defaultWrapper() {
 	return workspace.get("bin/wrapper.exe").then(tg.File.expect);
 }
 
-/** The default wrapper binary built with the default SDK for the detected host. This version uses the default SDK to ensure cache hits when used throughout the codebase. */
-export async function defaultWrapperBinary() {
-	const workspace = await tg
-		.build(std.buildDefaultWorkspace)
-		.named("default workspace");
-	return workspace.get("bin/wrapper.bin").then(tg.File.expect);
-}
-
 /** Release helper - builds defaultWrapper with a referent to this file for cache hits. */
 export async function buildDefaultWrapper() {
 	return tg.build(defaultWrapper).named("default wrapper");
-}
-
-/** Release helper - builds defaultWrapperBinary with a referent to this file for cache hits. */
-export async function buildDefaultWrapperBin() {
-	return tg.build(defaultWrapperBinary).named("default wrapper binary");
 }
 
 type ToolchainArg = {

--- a/packages/std/wrap/wrapper.tg.ts
+++ b/packages/std/wrap/wrapper.tg.ts
@@ -119,7 +119,6 @@ export async function build(unresolved: tg.Unresolved<BuildArg>) {
 		...osArgs,
 	];
 	const wrapFlags = ["-static", ...releaseArgs, ...verboseArgs];
-	const objcopy = os === "linux" ? `${prefix}objcopy -O binary` : "cp";
 	let buildPhase = tg`
 		set +x
 
@@ -136,11 +135,6 @@ export async function build(unresolved: tg.Unresolved<BuildArg>) {
 			exit 1
 		fi
 		echo "built wrapper.exe"
-
-
-		# Extract the binary.
-		${objcopy} ${tg.output}/wrapper.exe ${tg.output}/wrapper.bin
-		echo "built wrapper.bin"
 	`;
 
 	let bin = std.phases

--- a/packages/std/wrap/wrapper.tg.ts
+++ b/packages/std/wrap/wrapper.tg.ts
@@ -214,18 +214,37 @@ export async function test() {
 	tg.assert(hostArch);
 
 	// const buildToolchain = await bootstrap.sdk.env(host);
-	const output = await workspace({ host, release: true });
-	if (std.triple.os(host) === "linux") {
-		await Promise.all([
-			tg.build(testWrapperPositionIndependent, {
-				name: "position-independent wrapper",
-			}),
-			tg.build(testStatic, { name: "static executable" }),
-			tg.build(testBssManifest, { name: "BSS manifest" }),
-		]);
-	}
-	return output;
+	return workspace({ host, release: true });
 }
+
+const PT_LOAD = 1;
+const PT_INTERP = 3;
+const ET_EXEC = 2;
+const ET_DYN = 3;
+
+type ProgramHeader = elf.File["programHeaders"][number];
+
+const loadableSegments = (parsed: elf.File) =>
+	parsed.programHeaders.filter(
+		(programHeader) => programHeader.p_type === PT_LOAD,
+	);
+
+const segmentFileEnd = (segment: ProgramHeader) =>
+	Number(segment.p_offset) + Number(segment.p_filesz);
+
+/** The loadable segment whose file contents end last, which is where `wrap` puts the manifest. */
+const lastLoadableSegment = (parsed: elf.File) => {
+	const segments = loadableSegments(parsed);
+	const last = segments.reduce<ProgramHeader | undefined>(
+		(current, segment) =>
+			current === undefined || segmentFileEnd(segment) > segmentFileEnd(current)
+				? segment
+				: current,
+		undefined,
+	);
+	tg.assert(last !== undefined, "expected a loadable segment");
+	return last;
+};
 
 export async function testCompile() {
 	const toolchain = std.bootstrap.sdk();
@@ -257,8 +276,13 @@ export async function testCompile() {
 		.then(tg.File.expect);
 }
 
-/** The Linux wrapper is mapped at an address selected for the wrapped executable, so it must be a
- * position-independent ELF whose entry point is backed by a PT_LOAD. */
+/** `embed` copies the whole wrapper file into one segment of the wrapped executable and maps it at
+ * an address chosen for that executable, indexed by file offset. The wrapper's own segments are not
+ * laid out that way: its writable segment sits one page apart from its offset, so inside a host
+ * binary it lands short of where the wrapper's code would address it. That is only harmless while
+ * the wrapper has no relocations to apply and no memory beyond its file contents, which is what
+ * this checks. If it ever stops holding, `embed` has to build a memory image instead of copying the
+ * file, and map it by address. */
 export async function testWrapperPositionIndependent() {
 	const host = std.triple.host();
 	if (std.triple.os(host) !== "linux") {
@@ -267,18 +291,35 @@ export async function testWrapperPositionIndependent() {
 	const output = await workspace({ host, release: true });
 	const wrapper = await output.get("bin/wrapper.exe").then(tg.File.expect);
 	const parsed = await elf.parse(wrapper);
-	tg.assert(parsed.header.e_type === 3, "expected the wrapper to be ET_DYN");
+	tg.assert(
+		parsed.header.e_type === ET_DYN,
+		"expected the wrapper to be ET_DYN",
+	);
 	const entry = Number(parsed.header.e_entry);
-	const entrySegment = parsed.programHeaders.find(
-		(programHeader) =>
-			programHeader.p_type === 1 &&
-			entry >= Number(programHeader.p_vaddr) &&
-			entry <
-				Number(programHeader.p_vaddr) + Number(programHeader.p_filesz),
+	const segments = loadableSegments(parsed);
+	const entrySegment = segments.find(
+		(segment) =>
+			entry >= Number(segment.p_vaddr) &&
+			entry < Number(segment.p_vaddr) + Number(segment.p_filesz),
 	);
 	tg.assert(
 		entrySegment !== undefined,
 		"expected the wrapper entry point to be in a file-backed PT_LOAD",
+	);
+	for (const segment of segments) {
+		tg.assert(
+			Number(segment.p_filesz) === Number(segment.p_memsz),
+			"expected the wrapper to have no bss",
+		);
+	}
+	const relocations = parsed.sectionHeaders.filter((section) =>
+		[".rel.dyn", ".rel.plt", ".rela.dyn", ".rela.plt"].includes(
+			section.sh_name,
+		),
+	);
+	tg.assert(
+		relocations.every((section) => Number(section.sh_size) === 0),
+		"expected the wrapper to have no relocations",
 	);
 	return true;
 }
@@ -308,14 +349,17 @@ export async function testStatic() {
 		.then(tg.Directory.expect);
 	const executable = await directory.get("main").then(tg.File.expect);
 	const parsed = await elf.parse(executable);
-	tg.assert(parsed.header.e_type === 2, "expected a static non-PIE executable");
 	tg.assert(
-		!parsed.programHeaders.some((programHeader) => programHeader.p_type === 3),
+		parsed.header.e_type === ET_EXEC,
+		"expected a static non-PIE executable",
+	);
+	tg.assert(
+		!parsed.programHeaders.some(
+			(programHeader) => programHeader.p_type === PT_INTERP,
+		),
 		"expected no PT_INTERP",
 	);
-	const loads = parsed.programHeaders.filter(
-		(programHeader) => programHeader.p_type === 1,
-	);
+	const loads = loadableSegments(parsed);
 	for (let index = 1; index < loads.length; index++) {
 		tg.assert(
 			Number(loads[index - 1]!.p_vaddr) <= Number(loads[index]!.p_vaddr),
@@ -331,6 +375,17 @@ export async function testStatic() {
 			Number(segment.p_offset) + Number(segment.p_filesz) >= phend,
 	);
 	tg.assert(stub !== undefined, "expected e_phoff inside the stub PT_LOAD");
+
+	// A kernel before 5.19 reports the program header table at the load address plus e_phoff rather
+	// than at the address of the segment holding it, so the stub has to sit the same distance from
+	// its offset as the rest of the image for both to name the same address.
+	const bias = (segment: ProgramHeader) =>
+		Number(segment.p_vaddr) - Number(segment.p_offset);
+	tg.assert(
+		bias(stub) === bias(loads[0]!),
+		"expected the stub segment at the same address-to-offset distance as the image",
+	);
+
 	const copiedHeaderOffset = phoff - parsed.header.e_ehsize;
 	tg.assert(
 		copiedHeaderOffset === Number(stub.p_offset),
@@ -358,9 +413,11 @@ export async function testStatic() {
 	const stubEnd = Number(stub.p_offset) + Number(stub.p_filesz);
 	tg.assert(
 		Number(wrapperSection.sh_offset) >= Number(stub.p_offset) &&
-			Number(wrapperSection.sh_offset) + Number(wrapperSection.sh_size) <= stubEnd &&
+			Number(wrapperSection.sh_offset) + Number(wrapperSection.sh_size) <=
+				stubEnd &&
 			Number(manifestSection.sh_offset) >= Number(stub.p_offset) &&
-			Number(manifestSection.sh_offset) + Number(manifestSection.sh_size) <= stubEnd,
+			Number(manifestSection.sh_offset) + Number(manifestSection.sh_size) <=
+				stubEnd,
 		"expected the stub to cover the wrapper, manifest, and footer",
 	);
 	const entry = Number(parsed.header.e_entry);
@@ -410,18 +467,7 @@ export async function testBssManifest() {
 		.then(tg.File.expect);
 
 	const original = await elf.parse(executable);
-	const originalLoads = original.programHeaders.filter(
-		(programHeader) => programHeader.p_type === 1,
-	);
-	let bssSegment = originalLoads[0];
-	tg.assert(bssSegment !== undefined, "expected a loadable segment");
-	for (const segment of originalLoads.slice(1)) {
-		const end = Number(segment.p_offset) + Number(segment.p_filesz);
-		const bssEnd = Number(bssSegment.p_offset) + Number(bssSegment.p_filesz);
-		if (end > bssEnd) {
-			bssSegment = segment;
-		}
-	}
+	const bssSegment = lastLoadableSegment(original);
 	tg.assert(
 		Number(bssSegment.p_memsz) > Number(bssSegment.p_filesz),
 		"expected the final PT_LOAD to contain a BSS",
@@ -447,9 +493,7 @@ export async function testBssManifest() {
 		...manifest,
 		args: [
 			{
-				components: [
-					{ kind: "string" as const, value: "x".repeat(8_192) },
-				],
+				components: [{ kind: "string" as const, value: "x".repeat(8_192) }],
 			},
 		],
 	};
@@ -478,9 +522,7 @@ export async function testBssManifest() {
 		Number(parsed.header.e_shoff) % 8 === 0,
 		"expected an aligned section header table",
 	);
-	const loads = parsed.programHeaders.filter(
-		(programHeader) => programHeader.p_type === 1,
-	);
+	const loads = loadableSegments(parsed);
 	const preservedBss = loads.find(
 		(segment) => Number(segment.p_vaddr) === Number(bssSegment.p_vaddr),
 	);
@@ -491,19 +533,25 @@ export async function testBssManifest() {
 			Number(preservedBss.p_memsz) === Number(bssSegment.p_memsz),
 		"original BSS segment changed",
 	);
-	let manifestSegment = loads[0];
-	tg.assert(manifestSegment !== undefined, "expected a loadable segment");
-	for (const segment of loads.slice(1)) {
-		if (
-			Number(segment.p_offset) + Number(segment.p_filesz) >
-			Number(manifestSegment.p_offset) + Number(manifestSegment.p_filesz)
-		) {
-			manifestSegment = segment;
-		}
-	}
+	const manifestSegment = lastLoadableSegment(parsed);
 	tg.assert(
 		Number(manifestSegment.p_filesz) === Number(manifestSegment.p_memsz),
 		"manifest segment unexpectedly contains a BSS",
+	);
+
+	// The relocated program header table has to keep the same address-to-offset distance as the
+	// image, or a kernel before 5.19 reports it somewhere it is not.
+	tg.assert(
+		Number(manifestSegment.p_vaddr) - Number(manifestSegment.p_offset) ===
+			Number(loads[0]!.p_vaddr) - Number(loads[0]!.p_offset),
+		"expected the manifest segment at the same address-to-offset distance as the image",
+	);
+	const phoff = Number(parsed.header.e_phoff);
+	tg.assert(
+		phoff >= Number(manifestSegment.p_offset) &&
+			phoff + parsed.header.e_phnum * parsed.header.e_phentsize <=
+				segmentFileEnd(manifestSegment),
+		"expected the program header table inside the manifest segment",
 	);
 
 	const output = await std
@@ -512,6 +560,47 @@ export async function testBssManifest() {
 	const text = await output.text;
 	tg.assert(
 		text === "bss manifest: ok\n",
+		`unexpected output ${JSON.stringify(text)}`,
+	);
+	return true;
+}
+
+/** The wrapper reads the manifest from a segment, but `strip` repacks a file by section and only
+ * keeps the segments covering allocated ones. Both the embedded and the standalone wrapper must
+ * still run after being stripped. */
+export async function testStripPreservesManifest() {
+	if (std.triple.os(std.triple.host()) !== "linux") {
+		return true;
+	}
+	const toolchain = std.bootstrap.sdk();
+	const source = tg.directory({
+		"main.c": tg.file(`
+			#include <stdio.h>
+			int main() {
+				printf("stripped: ok\\n");
+				return 0;
+			}
+		`),
+	});
+	const embedded = await std
+		.run(std.shBootstrap`gcc ${source}/main.c -o ${tg.output}`)
+		.env(toolchain)
+		.then(tg.File.expect);
+	const standalone = await std.wrap(embedded, { buildToolchain: toolchain });
+	const output = await std
+		.run(std.shBootstrap`
+			cp ${embedded} embedded
+			cp ${standalone} standalone
+			chmod +w embedded standalone
+			strip embedded standalone
+			./embedded > ${tg.output}
+			./standalone >> ${tg.output}
+		`)
+		.env(toolchain, { TGSTRIP_PASSTHROUGH: true })
+		.then(tg.File.expect);
+	const text = await output.text;
+	tg.assert(
+		text === "stripped: ok\nstripped: ok\n",
 		`unexpected output ${JSON.stringify(text)}`,
 	);
 	return true;

--- a/packages/std/wrap/wrapper.tg.ts
+++ b/packages/std/wrap/wrapper.tg.ts
@@ -276,13 +276,10 @@ export async function testCompile() {
 		.then(tg.File.expect);
 }
 
-/** `embed` copies the whole wrapper file into one segment of the wrapped executable and maps it at
- * an address chosen for that executable, indexed by file offset. The wrapper's own segments are not
- * laid out that way: its writable segment sits one page apart from its offset, so inside a host
- * binary it lands short of where the wrapper's code would address it. That is only harmless while
- * the wrapper has no relocations to apply and no memory beyond its file contents, which is what
- * this checks. If it ever stops holding, `embed` has to build a memory image instead of copying the
- * file, and map it by address. */
+/** `embed` lays the wrapper's segments out by address and maps the result at an address chosen for
+ * the wrapped executable, so the distances its code resolved at link time survive. Two things do
+ * not survive: relocations, because nothing applies them, and writes, because the segment carrying
+ * the wrapper is not writable. */
 export async function testWrapperPositionIndependent() {
 	const host = std.triple.host();
 	if (std.triple.os(host) !== "linux") {
@@ -306,20 +303,18 @@ export async function testWrapperPositionIndependent() {
 		entrySegment !== undefined,
 		"expected the wrapper entry point to be in a file-backed PT_LOAD",
 	);
-	for (const segment of segments) {
-		tg.assert(
-			Number(segment.p_filesz) === Number(segment.p_memsz),
-			"expected the wrapper to have no bss",
+	const sized = (names: Array<string>) =>
+		parsed.sectionHeaders.filter(
+			(section) =>
+				names.includes(section.sh_name) && Number(section.sh_size) > 0,
 		);
-	}
-	const relocations = parsed.sectionHeaders.filter((section) =>
-		[".rel.dyn", ".rel.plt", ".rela.dyn", ".rela.plt"].includes(
-			section.sh_name,
-		),
+	tg.assert(
+		sized([".rel.dyn", ".rel.plt", ".rela.dyn", ".rela.plt"]).length === 0,
+		"expected the wrapper to have no relocations",
 	);
 	tg.assert(
-		relocations.every((section) => Number(section.sh_size) === 0),
-		"expected the wrapper to have no relocations",
+		sized([".data", ".bss"]).length === 0,
+		"expected the wrapper to have nothing it would write to",
 	);
 	return true;
 }
@@ -586,7 +581,12 @@ export async function testStripPreservesManifest() {
 		.run(std.shBootstrap`gcc ${source}/main.c -o ${tg.output}`)
 		.env(toolchain)
 		.then(tg.File.expect);
-	const standalone = await std.wrap(embedded, { buildToolchain: toolchain });
+	// `merge` defaults to true, which would rewrite the manifest of the embedded wrapper instead of
+	// producing a standalone one, leaving that layout untested.
+	const standalone = await std.wrap(embedded, {
+		buildToolchain: toolchain,
+		merge: false,
+	});
 	const output = await std
 		.run(std.shBootstrap`
 			cp ${embedded} embedded

--- a/packages/std/wrap/wrapper.tg.ts
+++ b/packages/std/wrap/wrapper.tg.ts
@@ -247,6 +247,34 @@ export async function testCompile() {
 		.then(tg.File.expect);
 }
 
+/** A static executable has no PT_INTERP for the stub segment to reuse, so the wrapper is embedded
+ * alongside a new program header table. */
+export async function testStatic() {
+	const toolchain = std.bootstrap.sdk();
+	const source = tg.directory({
+		"main.c": tg.file(`
+			#include <stdio.h>
+			int main() {
+				printf("hello, world!\\n");
+				return 0;
+			}
+		`),
+	});
+	const output = await std
+		.run(std.shBootstrap`
+		gcc -static ${source}/main.c -o main
+		./main > ${tg.output}
+	`)
+		.env(toolchain)
+		.then(tg.File.expect);
+	const text = await output.text;
+	tg.assert(
+		text === "hello, world!\n",
+		`unexpected output ${JSON.stringify(text)}`,
+	);
+	return true;
+}
+
 export async function testFull() {
 	const toolchain = std.sdk();
 	const source = tg.directory({

--- a/packages/std/wrap/wrapper.tg.ts
+++ b/packages/std/wrap/wrapper.tg.ts
@@ -3,6 +3,7 @@ import * as elf from "../file/elf.tg.ts";
 import * as gnu from "../sdk/gnu.tg.ts";
 import * as llvm from "../sdk/llvm.tg.ts";
 import * as std from "../tangram.ts";
+import * as wrapWorkspace from "./workspace.tg.ts";
 import source from "../packages/wrapper";
 import workspaceSrc from "../" with { type: "directory" };
 import dependencySource from "./test/libdependency.c" with { type: "file" };
@@ -221,8 +222,13 @@ const PT_LOAD = 1;
 const PT_INTERP = 3;
 const ET_EXEC = 2;
 const ET_DYN = 3;
+const SHT_RELA = 4;
+const SHT_REL = 9;
+const SHT_RELR = 19;
+const SHF_WRITE = 0x1;
 
 type ProgramHeader = elf.File["programHeaders"][number];
+type SectionHeader = elf.File["sectionHeaders"][number];
 
 const loadableSegments = (parsed: elf.File) =>
 	parsed.programHeaders.filter(
@@ -231,6 +237,35 @@ const loadableSegments = (parsed: elf.File) =>
 
 const segmentFileEnd = (segment: ProgramHeader) =>
 	Number(segment.p_offset) + Number(segment.p_filesz);
+
+/** How far a segment's address sits from its offset. */
+const segmentBias = (segment: ProgramHeader) =>
+	Number(segment.p_vaddr) - Number(segment.p_offset);
+
+const containingSegment = (parsed: elf.File, address: number, what: string) => {
+	const segment = loadableSegments(parsed).find(
+		(candidate) =>
+			address >= Number(candidate.p_vaddr) &&
+			address < Number(candidate.p_vaddr) + Number(candidate.p_filesz),
+	);
+	tg.assert(segment !== undefined, `expected ${what} in a file-backed PT_LOAD`);
+	return segment;
+};
+
+const sizedSections = (
+	parsed: elf.File,
+	predicate: (section: SectionHeader) => boolean,
+) =>
+	parsed.sectionHeaders.filter(
+		(section) => Number(section.sh_size) > 0 && predicate(section),
+	);
+
+/** Match relocations by section type. Their names vary — `.rela.iplt` and the small-data and TLS
+ * variants are all relocations a list of names would miss. */
+const relocationSections = (parsed: elf.File) =>
+	sizedSections(parsed, (section) =>
+		[SHT_REL, SHT_RELA, SHT_RELR].includes(section.sh_type),
+	);
 
 /** The loadable segment whose file contents end last, which is where `wrap` puts the manifest. */
 const lastLoadableSegment = (parsed: elf.File) => {
@@ -292,29 +327,29 @@ export async function testWrapperPositionIndependent() {
 		parsed.header.e_type === ET_DYN,
 		"expected the wrapper to be ET_DYN",
 	);
-	const entry = Number(parsed.header.e_entry);
-	const segments = loadableSegments(parsed);
-	const entrySegment = segments.find(
-		(segment) =>
-			entry >= Number(segment.p_vaddr) &&
-			entry < Number(segment.p_vaddr) + Number(segment.p_filesz),
+	containingSegment(
+		parsed,
+		Number(parsed.header.e_entry),
+		"the wrapper entry point",
 	);
 	tg.assert(
-		entrySegment !== undefined,
-		"expected the wrapper entry point to be in a file-backed PT_LOAD",
-	);
-	const sized = (names: Array<string>) =>
-		parsed.sectionHeaders.filter(
-			(section) =>
-				names.includes(section.sh_name) && Number(section.sh_size) > 0,
-		);
-	tg.assert(
-		sized([".rel.dyn", ".rel.plt", ".rela.dyn", ".rela.plt"]).length === 0,
+		relocationSections(parsed).length === 0,
 		"expected the wrapper to have no relocations",
 	);
+	// Nothing relocates the wrapper, so its `.dynamic` and its GOT are read but never stored to.
+	// Anything else writable is data the wrapper would write.
+	const exempt = [".dynamic", ".got", ".got.plt"];
+	const writable = sizedSections(
+		parsed,
+		(section) =>
+			(Number(section.sh_flags) & SHF_WRITE) !== 0 &&
+			!exempt.includes(section.sh_name),
+	);
 	tg.assert(
-		sized([".data", ".bss"]).length === 0,
-		"expected the wrapper to have nothing it would write to",
+		writable.length === 0,
+		`expected the wrapper to have nothing it would write to, found ${writable
+			.map((section) => section.sh_name)
+			.join(", ")}`,
 	);
 	return true;
 }
@@ -374,10 +409,8 @@ export async function testStatic() {
 	// A kernel before 5.19 reports the program header table at the load address plus e_phoff rather
 	// than at the address of the segment holding it, so the stub has to sit the same distance from
 	// its offset as the rest of the image for both to name the same address.
-	const bias = (segment: ProgramHeader) =>
-		Number(segment.p_vaddr) - Number(segment.p_offset);
 	tg.assert(
-		bias(stub) === bias(loads[0]!),
+		segmentBias(stub) === segmentBias(loads[0]!),
 		"expected the stub segment at the same address-to-offset distance as the image",
 	);
 
@@ -537,8 +570,7 @@ export async function testBssManifest() {
 	// The relocated program header table has to keep the same address-to-offset distance as the
 	// image, or a kernel before 5.19 reports it somewhere it is not.
 	tg.assert(
-		Number(manifestSegment.p_vaddr) - Number(manifestSegment.p_offset) ===
-			Number(loads[0]!.p_vaddr) - Number(loads[0]!.p_offset),
+		segmentBias(manifestSegment) === segmentBias(loads[0]!),
 		"expected the manifest segment at the same address-to-offset distance as the image",
 	);
 	const phoff = Number(parsed.header.e_phoff);
@@ -601,6 +633,106 @@ export async function testStripPreservesManifest() {
 	const text = await output.text;
 	tg.assert(
 		text === "stripped: ok\nstripped: ok\n",
+		`unexpected output ${JSON.stringify(text)}`,
+	);
+	return true;
+}
+
+/** `embed` maps the wrapper contiguously at one address, but a static PIE's own segments sit at
+ * different distances from their offsets, and its code reaches its data by the distances the linker
+ * resolved. Appending the wrapper's file rather than its memory image moves that data out from
+ * under the code, and nothing in the file reports it: reaching a hidden global compiles to a bare
+ * pc-relative address with no relocation to inspect. This wrapper is that shape, and it exits zero
+ * only if the global still reads back once embedded. */
+export async function testEmbedNonuniformWrapper() {
+	const host = std.triple.host();
+	if (std.triple.os(host) !== "linux") {
+		return true;
+	}
+	const toolchain = std.bootstrap.sdk();
+	const source = tg.directory({
+		"wrapper.c": tg.file(`
+			__attribute__((visibility("hidden"))) volatile int global = 7;
+
+			__attribute__((noreturn)) static void tg_exit(int code) {
+				for (;;) {
+			#if defined(__aarch64__)
+					register long number __asm__("x8") = 93;
+					register long argument __asm__("x0") = code;
+					__asm__ volatile("svc #0" : : "r"(number), "r"(argument) : "memory");
+			#elif defined(__x86_64__)
+					__asm__ volatile("syscall" : : "a"(60), "D"((long)code) : "memory");
+			#else
+			#error "unsupported architecture"
+			#endif
+				}
+			}
+
+			void _start(void) { tg_exit(global == 7 ? 0 : 1); }
+		`),
+		"host.c": tg.file(`int main() { return 0; }`),
+		"manifest.json": tg.file(`{"executable":{"kind":"address","value":0}}`),
+	});
+	const wrapperExe = await std
+		.run(std.shBootstrap`
+			gcc ${source}/wrapper.c -o ${tg.output} \
+				-nolibc -nostdlib -ffreestanding -fPIC -Os -static-pie \
+				-fno-asynchronous-unwind-tables -fno-stack-protector
+		`)
+		.env(toolchain, { TGLD_PASSTHROUGH: true })
+		.then(tg.File.expect);
+
+	const parsed = await elf.parse(wrapperExe);
+	tg.assert(
+		parsed.header.e_type === ET_DYN,
+		"expected a position-independent wrapper",
+	);
+	tg.assert(
+		relocationSections(parsed).length === 0,
+		"expected no relocations to give the layout away",
+	);
+	const data = parsed.sectionHeaders.find(
+		(section) => section.sh_name === ".data" && Number(section.sh_size) > 0,
+	);
+	tg.assert(data !== undefined, "expected an initialized global");
+	const entrySegment = containingSegment(
+		parsed,
+		Number(parsed.header.e_entry),
+		"the entry point",
+	);
+	const dataSegment = containingSegment(
+		parsed,
+		Number(data.sh_addr),
+		"the initialized global",
+	);
+	tg.assert(
+		segmentBias(dataSegment) !== segmentBias(entrySegment),
+		"expected the global and the code at different address-to-offset distances",
+	);
+
+	const wrapped = await std
+		.run(std.shBootstrap`
+			gcc ${source}/host.c -o host
+			${wrapWorkspace.wrap({ host })} embed host \
+				--manifest ${source}/manifest.json \
+				--wrapper-exe ${wrapperExe} \
+				-o ${tg.output}
+		`)
+		.env(toolchain, { TGLD_PASSTHROUGH: true })
+		.then(tg.File.expect);
+
+	// A wrapper reading its global from the wrong address faults rather than returning, so report the
+	// status instead of letting the process take the build down with it.
+	const output = await std
+		.run(std.shBootstrap`
+			cp ${wrapped} wrapped
+			chmod +x wrapped
+			if ./wrapped ; then echo "embedded wrapper: ok" ; else echo "embedded wrapper exited $?" ; fi > ${tg.output}
+		`)
+		.then(tg.File.expect);
+	const text = await output.text;
+	tg.assert(
+		text === "embedded wrapper: ok\n",
 		`unexpected output ${JSON.stringify(text)}`,
 	);
 	return true;

--- a/packages/std/wrap/wrapper.tg.ts
+++ b/packages/std/wrap/wrapper.tg.ts
@@ -238,7 +238,6 @@ const loadableSegments = (parsed: elf.File) =>
 const segmentFileEnd = (segment: ProgramHeader) =>
 	Number(segment.p_offset) + Number(segment.p_filesz);
 
-/** How far a segment's address sits from its offset. */
 const segmentBias = (segment: ProgramHeader) =>
 	Number(segment.p_vaddr) - Number(segment.p_offset);
 
@@ -260,14 +259,11 @@ const sizedSections = (
 		(section) => Number(section.sh_size) > 0 && predicate(section),
 	);
 
-/** Match relocations by section type. Their names vary — `.rela.iplt` and the small-data and TLS
- * variants are all relocations a list of names would miss. */
 const relocationSections = (parsed: elf.File) =>
 	sizedSections(parsed, (section) =>
 		[SHT_REL, SHT_RELA, SHT_RELR].includes(section.sh_type),
 	);
 
-/** The loadable segment whose file contents end last, which is where `wrap` puts the manifest. */
 const lastLoadableSegment = (parsed: elf.File) => {
 	const segments = loadableSegments(parsed);
 	const last = segments.reduce<ProgramHeader | undefined>(
@@ -311,10 +307,6 @@ export async function testCompile() {
 		.then(tg.File.expect);
 }
 
-/** `embed` lays the wrapper's segments out by address and maps the result at an address chosen for
- * the wrapped executable, so the distances its code resolved at link time survive. Two things do
- * not survive: relocations, because nothing applies them, and writes, because the segment carrying
- * the wrapper is not writable. */
 export async function testWrapperPositionIndependent() {
 	const host = std.triple.host();
 	if (std.triple.os(host) !== "linux") {
@@ -336,8 +328,7 @@ export async function testWrapperPositionIndependent() {
 		relocationSections(parsed).length === 0,
 		"expected the wrapper to have no relocations",
 	);
-	// Nothing relocates the wrapper, so its `.dynamic` and its GOT are read but never stored to.
-	// Anything else writable is data the wrapper would write.
+	// The static wrapper does not update its dynamic metadata or GOT.
 	const exempt = [".dynamic", ".got", ".got.plt"];
 	const writable = sizedSections(
 		parsed,
@@ -354,8 +345,6 @@ export async function testWrapperPositionIndependent() {
 	return true;
 }
 
-/** A static executable has no PT_INTERP for the stub segment to reuse, so the wrapper is embedded
- * alongside a new program header table. */
 export async function testStatic() {
 	if (std.triple.os(std.triple.host()) !== "linux") {
 		return true;
@@ -406,9 +395,7 @@ export async function testStatic() {
 	);
 	tg.assert(stub !== undefined, "expected e_phoff inside the stub PT_LOAD");
 
-	// A kernel before 5.19 reports the program header table at the load address plus e_phoff rather
-	// than at the address of the segment holding it, so the stub has to sit the same distance from
-	// its offset as the rest of the image for both to name the same address.
+	// Preserve the load bias used by legacy AT_PHDR calculation.
 	tg.assert(
 		segmentBias(stub) === segmentBias(loads[0]!),
 		"expected the stub segment at the same address-to-offset distance as the image",
@@ -466,8 +453,6 @@ export async function testStatic() {
 	return true;
 }
 
-/** Writing a manifest must preserve an existing BSS rather than extending its PT_LOAD over file
- * data. */
 export async function testBssManifest() {
 	if (std.triple.os(std.triple.host()) !== "linux") {
 		return true;
@@ -567,8 +552,7 @@ export async function testBssManifest() {
 		"manifest segment unexpectedly contains a BSS",
 	);
 
-	// The relocated program header table has to keep the same address-to-offset distance as the
-	// image, or a kernel before 5.19 reports it somewhere it is not.
+	// Preserve the load bias used by legacy AT_PHDR calculation.
 	tg.assert(
 		segmentBias(manifestSegment) === segmentBias(loads[0]!),
 		"expected the manifest segment at the same address-to-offset distance as the image",
@@ -592,9 +576,6 @@ export async function testBssManifest() {
 	return true;
 }
 
-/** The wrapper reads the manifest from a segment, but `strip` repacks a file by section and only
- * keeps the segments covering allocated ones. Both the embedded and the standalone wrapper must
- * still run after being stripped. */
 export async function testStripPreservesManifest() {
 	if (std.triple.os(std.triple.host()) !== "linux") {
 		return true;
@@ -613,8 +594,6 @@ export async function testStripPreservesManifest() {
 		.run(std.shBootstrap`gcc ${source}/main.c -o ${tg.output}`)
 		.env(toolchain)
 		.then(tg.File.expect);
-	// `merge` defaults to true, which would rewrite the manifest of the embedded wrapper instead of
-	// producing a standalone one, leaving that layout untested.
 	const standalone = await std.wrap(embedded, {
 		buildToolchain: toolchain,
 		merge: false,
@@ -638,12 +617,6 @@ export async function testStripPreservesManifest() {
 	return true;
 }
 
-/** `embed` maps the wrapper contiguously at one address, but a static PIE's own segments sit at
- * different distances from their offsets, and its code reaches its data by the distances the linker
- * resolved. Appending the wrapper's file rather than its memory image moves that data out from
- * under the code, and nothing in the file reports it: reaching a hidden global compiles to a bare
- * pc-relative address with no relocation to inspect. This wrapper is that shape, and it exits zero
- * only if the global still reads back once embedded. */
 export async function testEmbedNonuniformWrapper() {
 	const host = std.triple.host();
 	if (std.triple.os(host) !== "linux") {
@@ -721,8 +694,6 @@ export async function testEmbedNonuniformWrapper() {
 		.env(toolchain, { TGLD_PASSTHROUGH: true })
 		.then(tg.File.expect);
 
-	// A wrapper reading its global from the wrong address faults rather than returning, so report the
-	// status instead of letting the process take the build down with it.
 	const output = await std
 		.run(std.shBootstrap`
 			cp ${wrapped} wrapped

--- a/packages/std/wrap/wrapper.tg.ts
+++ b/packages/std/wrap/wrapper.tg.ts
@@ -214,7 +214,11 @@ export async function test() {
 	tg.assert(hostArch);
 
 	// const buildToolchain = await bootstrap.sdk.env(host);
-	return workspace({ host, release: true });
+	const output = await workspace({ host, release: true });
+	if (std.triple.os(host) === "linux") {
+		await tg.build(testStatic, { name: "static executable" });
+	}
+	return output;
 }
 
 export async function testCompile() {
@@ -250,6 +254,9 @@ export async function testCompile() {
 /** A static executable has no PT_INTERP for the stub segment to reuse, so the wrapper is embedded
  * alongside a new program header table. */
 export async function testStatic() {
+	if (std.triple.os(std.triple.host()) !== "linux") {
+		return true;
+	}
 	const toolchain = std.bootstrap.sdk();
 	const source = tg.directory({
 		"main.c": tg.file(`

--- a/packages/std/wrap/wrapper.tg.ts
+++ b/packages/std/wrap/wrapper.tg.ts
@@ -98,7 +98,7 @@ export async function build(unresolved: tg.Unresolved<BuildArg>) {
 			"-nolibc",
 			"-nostdlib",
 			"-fno-tree-loop-distribute-patterns",
-			"-static",
+			"-static-pie",
 		];
 	}
 	if (os === "darwin") {
@@ -119,7 +119,6 @@ export async function build(unresolved: tg.Unresolved<BuildArg>) {
 		...verboseArgs,
 		...osArgs,
 	];
-	const wrapFlags = ["-static", ...releaseArgs, ...verboseArgs];
 	let buildPhase = tg`
 		set +x
 
@@ -218,6 +217,9 @@ export async function test() {
 	const output = await workspace({ host, release: true });
 	if (std.triple.os(host) === "linux") {
 		await Promise.all([
+			tg.build(testWrapperPositionIndependent, {
+				name: "position-independent wrapper",
+			}),
 			tg.build(testStatic, { name: "static executable" }),
 			tg.build(testBssManifest, { name: "BSS manifest" }),
 		]);
@@ -255,6 +257,32 @@ export async function testCompile() {
 		.then(tg.File.expect);
 }
 
+/** The Linux wrapper is mapped at an address selected for the wrapped executable, so it must be a
+ * position-independent ELF whose entry point is backed by a PT_LOAD. */
+export async function testWrapperPositionIndependent() {
+	const host = std.triple.host();
+	if (std.triple.os(host) !== "linux") {
+		return true;
+	}
+	const output = await workspace({ host, release: true });
+	const wrapper = await output.get("bin/wrapper.exe").then(tg.File.expect);
+	const parsed = await elf.parse(wrapper);
+	tg.assert(parsed.header.e_type === 3, "expected the wrapper to be ET_DYN");
+	const entry = Number(parsed.header.e_entry);
+	const entrySegment = parsed.programHeaders.find(
+		(programHeader) =>
+			programHeader.p_type === 1 &&
+			entry >= Number(programHeader.p_vaddr) &&
+			entry <
+				Number(programHeader.p_vaddr) + Number(programHeader.p_filesz),
+	);
+	tg.assert(
+		entrySegment !== undefined,
+		"expected the wrapper entry point to be in a file-backed PT_LOAD",
+	);
+	return true;
+}
+
 /** A static executable has no PT_INTERP for the stub segment to reuse, so the wrapper is embedded
  * alongside a new program header table. */
 export async function testStatic() {
@@ -271,12 +299,79 @@ export async function testStatic() {
 			}
 		`),
 	});
-	const output = await std
+	const directory = await std
 		.run(std.shBootstrap`
-		gcc -static ${source}/main.c -o main
-		./main > ${tg.output}
+		mkdir ${tg.output}
+		gcc -static -no-pie ${source}/main.c -o ${tg.output}/main
 	`)
 		.env(toolchain)
+		.then(tg.Directory.expect);
+	const executable = await directory.get("main").then(tg.File.expect);
+	const parsed = await elf.parse(executable);
+	tg.assert(parsed.header.e_type === 2, "expected a static non-PIE executable");
+	tg.assert(
+		!parsed.programHeaders.some((programHeader) => programHeader.p_type === 3),
+		"expected no PT_INTERP",
+	);
+	const loads = parsed.programHeaders.filter(
+		(programHeader) => programHeader.p_type === 1,
+	);
+	for (let index = 1; index < loads.length; index++) {
+		tg.assert(
+			Number(loads[index - 1]!.p_vaddr) <= Number(loads[index]!.p_vaddr),
+			"expected PT_LOAD entries in ascending p_vaddr order",
+		);
+	}
+
+	const phoff = Number(parsed.header.e_phoff);
+	const phend = phoff + parsed.header.e_phnum * parsed.header.e_phentsize;
+	const stub = loads.find(
+		(segment) =>
+			Number(segment.p_offset) <= phoff &&
+			Number(segment.p_offset) + Number(segment.p_filesz) >= phend,
+	);
+	tg.assert(stub !== undefined, "expected e_phoff inside the stub PT_LOAD");
+	const copiedHeaderOffset = phoff - parsed.header.e_ehsize;
+	tg.assert(
+		copiedHeaderOffset === Number(stub.p_offset),
+		"expected the copied ELF header immediately before the program header table",
+	);
+	const [header, copiedHeader] = await Promise.all([
+		executable.read({ position: 0, length: parsed.header.e_ehsize }),
+		executable.read({
+			position: copiedHeaderOffset,
+			length: parsed.header.e_ehsize,
+		}),
+	]);
+	tg.assert(
+		header.every((byte, index) => byte === copiedHeader[index]),
+		"copied ELF header does not match the patched ELF header",
+	);
+	const wrapperSection = parsed.sectionHeaders.find(
+		(section) => section.sh_name === ".text.tg-wrapper",
+	);
+	const manifestSection = parsed.sectionHeaders.find(
+		(section) => section.sh_name === ".note.tg-manifest",
+	);
+	tg.assert(wrapperSection !== undefined, "expected wrapper section");
+	tg.assert(manifestSection !== undefined, "expected manifest section");
+	const stubEnd = Number(stub.p_offset) + Number(stub.p_filesz);
+	tg.assert(
+		Number(wrapperSection.sh_offset) >= Number(stub.p_offset) &&
+			Number(wrapperSection.sh_offset) + Number(wrapperSection.sh_size) <= stubEnd &&
+			Number(manifestSection.sh_offset) >= Number(stub.p_offset) &&
+			Number(manifestSection.sh_offset) + Number(manifestSection.sh_size) <= stubEnd,
+		"expected the stub to cover the wrapper, manifest, and footer",
+	);
+	const entry = Number(parsed.header.e_entry);
+	tg.assert(
+		entry >= Number(stub.p_vaddr) &&
+			entry < Number(stub.p_vaddr) + Number(stub.p_filesz),
+		"expected the entry point inside the stub PT_LOAD",
+	);
+
+	const output = await std
+		.run(std.shBootstrap`${executable} > ${tg.output}`)
 		.then(tg.File.expect);
 	const text = await output.text;
 	tg.assert(
@@ -348,11 +443,40 @@ export async function testBssManifest() {
 		JSON.stringify(readManifest) === JSON.stringify(manifest),
 		"manifest did not round trip",
 	);
+	const largerManifest = {
+		...manifest,
+		args: [
+			{
+				components: [
+					{ kind: "string" as const, value: "x".repeat(8_192) },
+				],
+			},
+		],
+	};
+	const rewrittenAgain = await std.wrap.Manifest.write(
+		rewritten,
+		largerManifest,
+		new Map(),
+	);
+	const rereadManifest = await std.wrap.Manifest.read(rewrittenAgain);
+	tg.assert(rereadManifest !== undefined, "expected a replacement manifest");
+	tg.assert(
+		JSON.stringify(rereadManifest.executable) ===
+			JSON.stringify(largerManifest.executable) &&
+			rereadManifest.args?.length === 1 &&
+			rereadManifest.args[0]?.components[0]?.kind === "string" &&
+			rereadManifest.args[0].components[0].value.length === 8_192,
+		"larger replacement manifest did not round trip",
+	);
 
-	const parsed = await elf.parse(rewritten);
+	const parsed = await elf.parse(rewrittenAgain);
 	tg.assert(
 		parsed.header.e_phnum === original.header.e_phnum + 1,
 		"expected a new program header",
+	);
+	tg.assert(
+		Number(parsed.header.e_shoff) % 8 === 0,
+		"expected an aligned section header table",
 	);
 	const loads = parsed.programHeaders.filter(
 		(programHeader) => programHeader.p_type === 1,
@@ -383,7 +507,7 @@ export async function testBssManifest() {
 	);
 
 	const output = await std
-		.run(std.shBootstrap`${rewritten} > ${tg.output}`)
+		.run(std.shBootstrap`${rewrittenAgain} > ${tg.output}`)
 		.then(tg.File.expect);
 	const text = await output.text;
 	tg.assert(

--- a/packages/std/wrap/wrapper.tg.ts
+++ b/packages/std/wrap/wrapper.tg.ts
@@ -1,4 +1,5 @@
 import * as bootstrap from "../bootstrap.tg.ts";
+import * as elf from "../file/elf.tg.ts";
 import * as gnu from "../sdk/gnu.tg.ts";
 import * as llvm from "../sdk/llvm.tg.ts";
 import * as std from "../tangram.ts";
@@ -216,7 +217,10 @@ export async function test() {
 	// const buildToolchain = await bootstrap.sdk.env(host);
 	const output = await workspace({ host, release: true });
 	if (std.triple.os(host) === "linux") {
-		await tg.build(testStatic, { name: "static executable" });
+		await Promise.all([
+			tg.build(testStatic, { name: "static executable" }),
+			tg.build(testBssManifest, { name: "BSS manifest" }),
+		]);
 	}
 	return output;
 }
@@ -277,6 +281,113 @@ export async function testStatic() {
 	const text = await output.text;
 	tg.assert(
 		text === "hello, world!\n",
+		`unexpected output ${JSON.stringify(text)}`,
+	);
+	return true;
+}
+
+/** Writing a manifest must preserve an existing BSS rather than extending its PT_LOAD over file
+ * data. */
+export async function testBssManifest() {
+	if (std.triple.os(std.triple.host()) !== "linux") {
+		return true;
+	}
+	const toolchain = std.bootstrap.sdk();
+	const source = tg.directory({
+		"main.c": tg.file(`
+			#include <stdint.h>
+			#include <stdio.h>
+			volatile uint8_t retained_uninitialized_global[65536];
+			int main() {
+				if (retained_uninitialized_global[0] != 0 ||
+					retained_uninitialized_global[65535] != 0) {
+					return 1;
+				}
+				retained_uninitialized_global[0] = 7;
+				printf("bss manifest: ok\\n");
+				return 0;
+			}
+		`),
+	});
+	const executable = await std
+		.run(std.shBootstrap`gcc -static ${source}/main.c -o ${tg.output}`)
+		.env(toolchain, { TGLD_PASSTHROUGH: true })
+		.then(tg.File.expect);
+
+	const original = await elf.parse(executable);
+	const originalLoads = original.programHeaders.filter(
+		(programHeader) => programHeader.p_type === 1,
+	);
+	let bssSegment = originalLoads[0];
+	tg.assert(bssSegment !== undefined, "expected a loadable segment");
+	for (const segment of originalLoads.slice(1)) {
+		const end = Number(segment.p_offset) + Number(segment.p_filesz);
+		const bssEnd = Number(bssSegment.p_offset) + Number(bssSegment.p_filesz);
+		if (end > bssEnd) {
+			bssSegment = segment;
+		}
+	}
+	tg.assert(
+		Number(bssSegment.p_memsz) > Number(bssSegment.p_filesz),
+		"expected the final PT_LOAD to contain a BSS",
+	);
+
+	const manifest = {
+		executable: {
+			kind: "address" as const,
+			value: Number(original.header.e_entry),
+		},
+	};
+	const rewritten = await std.wrap.Manifest.write(
+		executable,
+		manifest,
+		new Map(),
+	);
+	const readManifest = await std.wrap.Manifest.read(rewritten);
+	tg.assert(
+		JSON.stringify(readManifest) === JSON.stringify(manifest),
+		"manifest did not round trip",
+	);
+
+	const parsed = await elf.parse(rewritten);
+	tg.assert(
+		parsed.header.e_phnum === original.header.e_phnum + 1,
+		"expected a new program header",
+	);
+	const loads = parsed.programHeaders.filter(
+		(programHeader) => programHeader.p_type === 1,
+	);
+	const preservedBss = loads.find(
+		(segment) => Number(segment.p_vaddr) === Number(bssSegment.p_vaddr),
+	);
+	tg.assert(preservedBss !== undefined, "original BSS segment is missing");
+	tg.assert(
+		Number(preservedBss.p_offset) === Number(bssSegment.p_offset) &&
+			Number(preservedBss.p_filesz) === Number(bssSegment.p_filesz) &&
+			Number(preservedBss.p_memsz) === Number(bssSegment.p_memsz),
+		"original BSS segment changed",
+	);
+	let manifestSegment = loads[0];
+	tg.assert(manifestSegment !== undefined, "expected a loadable segment");
+	for (const segment of loads.slice(1)) {
+		if (
+			Number(segment.p_offset) + Number(segment.p_filesz) >
+			Number(manifestSegment.p_offset) + Number(manifestSegment.p_filesz)
+		) {
+			manifestSegment = segment;
+		}
+	}
+	tg.assert(
+		Number(manifestSegment.p_filesz) === Number(manifestSegment.p_memsz),
+		"manifest segment unexpectedly contains a BSS",
+	);
+
+	const output = await std
+		.run(std.shBootstrap`${rewritten} > ${tg.output}`)
+		.then(tg.File.expect);
+	const text = await output.text;
+	tg.assert(
+		text === "bss manifest: ok\n",
 		`unexpected output ${JSON.stringify(text)}`,
 	);
 	return true;


### PR DESCRIPTION
The wrapper currently reopens its executable path to read its manifest after the kernel has mapped the process. Concurrent relinking can replace or briefly remove that path, causing the wrapper to read a different file. This change reads the manifest directly from the mapped image on Linux and macOS.

## Changes

- On Linux, locate the footer through `AT_PHDR` and the file-backed ends of the mapped `PT_LOAD` segments. On macOS, locate the mapped `__LINKEDIT` segment from `_mh_execute_header` and its slide.
- Make the ELF writers guarantee that the manifest and footer remain mapped, with the footer at the end of the segment's file contents.
- Preserve load bias for legacy `AT_PHDR` calculation and keep `PT_LOAD` entries ordered by virtual address.
- Give manifests after BSS a separate loadable segment instead of extending `p_filesz` through zero-filled memory.
- For static executables without `PT_INTERP`, place a copied ELF header and relocated program-header table inside the new stub segment so `e_phoff` remains valid.
- Reconstruct an embedded wrapper from its `PT_LOAD` memory image rather than copying its ELF file, preserving references between segments with different load biases.
- Grow Mach-O `__LINKEDIT` file and memory sizes when replacing a manifest while preserving code-signature placement.
- Fix section-string-table growth in `write_manifest`.
- Remove the unused `wrapper.bin` pipeline; the linker proxy now carries the wrapper executable artifact directly and verifies its object-graph dependencies.

## Tests

- Concurrent replacement of embedded and standalone wrappers, including a transient missing executable path.
- Static no-`PT_INTERP` layout and execution checks.
- BSS manifest writes and rewrites.
- Stripped embedded and standalone wrappers.
- Wrapper relocation and nonuniform segment load biases.
- Large Mach-O manifest replacement.
- Linker proxy artifact dependencies.
