### PR TITLE
perf(tgld): reduce redundant library path fetches

### DIFF
--- a/packages/std/packages/tgld/src/main.rs
+++ b/packages/std/packages/tgld/src/main.rs
@@ -496,27 +496,9 @@ async fn create_wrapper(options: &Options) -> tg::Result<()> {
 								},
 								// The library path is not checked out yet, so consult the object graph instead.
 								Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-									let root = directory_cache_ref.intern(&directory);
-									let target = {
-										let _walk = root.walk.lock().await;
-										if let Some(ref subpath) = path {
-											root.directory
-												.get(subpath)
-												.await?
-												.try_unwrap_directory()
-												.ok()
-										} else {
-											Some(root.directory.clone())
-										}
-									};
-									match target {
-										Some(target) => {
-											let target = directory_cache_ref.intern(&target);
-											let _walk = target.walk.lock().await;
-											!target.directory.entries().await?.is_empty()
-										},
-										None => false,
-									}
+									return directory_cache_ref
+										.resolve_nonempty(&directory, path)
+										.await;
 								},
 								Err(error) => {
 									return Err(
@@ -1396,6 +1378,45 @@ impl DirectoryCache {
 		cached.clone()
 	}
 
+	fn insert_resolved(&self, dir_with_subpath: &DirectoryWithSubpath, directory: &tg::Directory) {
+		directory.state().inherit_tokens(&dir_with_subpath.tokens);
+		self.resolved
+			.lock()
+			.unwrap()
+			.insert(dir_with_subpath.clone(), directory.clone());
+	}
+
+	async fn resolve_nonempty(
+		&self,
+		directory: &tg::Directory,
+		path: Option<PathBuf>,
+	) -> tg::Result<Option<DirectoryWithSubpath>> {
+		let root = self.intern(directory);
+		let target = {
+			let _walk = root.walk.lock().await;
+			if let Some(ref path) = path {
+				root.directory.get(path).await?.try_unwrap_directory().ok()
+			} else {
+				Some(root.directory.clone())
+			}
+		};
+		let Some(target) = target else {
+			return Ok(None);
+		};
+		let target = self.intern(&target);
+		let has_entries = {
+			let _walk = target.walk.lock().await;
+			!target.directory.entries().await?.is_empty()
+		};
+		if !has_entries {
+			return Ok(None);
+		}
+		tracing::debug!(?path, "found a directory with entries");
+		let dir_with_subpath = dir_with_subpath_from_directory(&root.directory, path).await?;
+		self.insert_resolved(&dir_with_subpath, &target.directory);
+		Ok(Some(dir_with_subpath))
+	}
+
 	async fn resolve(&self, dir_with_subpath: &DirectoryWithSubpath) -> tg::Result<tg::Directory> {
 		if let Some(directory) = self.resolved.lock().unwrap().get(dir_with_subpath).cloned() {
 			directory.state().inherit_tokens(&dir_with_subpath.tokens);
@@ -1422,11 +1443,7 @@ impl DirectoryCache {
 		} else {
 			outer.directory.clone()
 		};
-		directory.state().inherit_tokens(&dir_with_subpath.tokens);
-		self.resolved
-			.lock()
-			.unwrap()
-			.insert(dir_with_subpath.clone(), directory.clone());
+		self.insert_resolved(dir_with_subpath, &directory);
 
 		Ok(directory)
 	}

--- a/packages/std/packages/tgld/src/main.rs
+++ b/packages/std/packages/tgld/src/main.rs
@@ -1103,7 +1103,6 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 			disallow_missing,
 			filtered_library_paths,
 			needed_libraries,
-			directory_cache,
 		)
 		.await;
 	}
@@ -1117,7 +1116,6 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 				disallow_missing,
 				resolved_library_paths,
 				needed_libraries,
-				directory_cache,
 			)
 			.await;
 		},
@@ -1130,7 +1128,6 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 				disallow_missing,
 				isolated_library_paths,
 				needed_libraries,
-				directory_cache,
 			)
 			.await;
 		},
@@ -1143,7 +1140,6 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 				disallow_missing,
 				combined_library_path,
 				needed_libraries,
-				directory_cache,
 			)
 			.await;
 		},
@@ -1194,14 +1190,18 @@ async fn combine_library_paths<H: BuildHasher + Default>(
 	Ok(combined_library_path)
 }
 
-/// Check out a set of library paths into the store. Each referent carries its stored tokens, without
-/// which the server falls back to an index lookup to authorize it.
+/// Check out a set of library paths into the store, returning the path each one was checked out to.
+/// Each referent carries its stored tokens, without which the server falls back to an index lookup
+/// to authorize it.
 async fn cache_library_paths<H: BuildHasher + Default>(
 	library_paths: &HashSet<DirectoryWithSubpath, H>,
-) -> tg::Result<()> {
+) -> tg::Result<Vec<(DirectoryWithSubpath, PathBuf)>> {
 	if library_paths.is_empty() {
-		return Ok(());
+		return Ok(Vec::new());
 	}
+	// The checkout returns one path per artifact in order, so hold the paths in an order the
+	// results can be zipped against.
+	let library_paths = library_paths.iter().cloned().collect_vec();
 	let artifacts = library_paths
 		.iter()
 		.map(|dir_with_subpath| {
@@ -1212,10 +1212,28 @@ async fn cache_library_paths<H: BuildHasher + Default>(
 		})
 		.collect();
 	tracing::debug!("caching libraries");
-	common::checkout_artifacts(artifacts)
+	let paths = common::checkout_artifacts(artifacts)
 		.await
 		.map_err(|error| tg::error!(!error, "failed to cache libraries"))?;
-	Ok(())
+	if paths.len() != library_paths.len() {
+		return Err(tg::error!("expected one checkout path per library path"));
+	}
+
+	// A checkout names the root of a library path, so a subpath is appended to reach the directory
+	// the path refers to.
+	let checkouts = library_paths
+		.into_iter()
+		.zip(paths)
+		.map(|(dir_with_subpath, path)| {
+			let path = match dir_with_subpath.subpath {
+				Some(ref subpath) => path.join(subpath),
+				None => path,
+			};
+			(dir_with_subpath, path)
+		})
+		.collect();
+
+	Ok(checkouts)
 }
 
 /// Produce the set of library paths to be written to the wrapper post-optimization.
@@ -1223,18 +1241,11 @@ async fn finalize_library_paths<H: BuildHasher + Default>(
 	disallow_missing: bool,
 	library_paths: HashSet<DirectoryWithSubpath, H>,
 	needed_libraries: &HashMap<String, Option<DirectoryWithSubpath>, H>,
-	directory_cache: &DirectoryCache,
 ) -> tg::Result<HashSet<DirectoryWithSubpath, H>> {
-	cache_library_paths(&library_paths).await?;
+	let checkouts = cache_library_paths(&library_paths).await?;
 
 	// Warn or error if any required libraries are not included in the set.
-	verify_missing_libraries(
-		disallow_missing,
-		needed_libraries,
-		&library_paths,
-		directory_cache,
-	)
-	.await?;
+	verify_missing_libraries(disallow_missing, needed_libraries, &checkouts).await?;
 	Ok(library_paths)
 }
 
@@ -1242,8 +1253,7 @@ async fn finalize_library_paths<H: BuildHasher + Default>(
 async fn verify_missing_libraries<H: BuildHasher + Default>(
 	disallow_missing: bool,
 	needed_libraries: &HashMap<String, Option<DirectoryWithSubpath>, H>,
-	library_paths: &HashSet<DirectoryWithSubpath, H>,
-	directory_cache: &DirectoryCache,
+	checkouts: &[(DirectoryWithSubpath, PathBuf)],
 ) -> tg::Result<()> {
 	let mut found_libraries = HashSet::default();
 	let basename = |library_name: &str| -> tg::Result<String> {
@@ -1254,12 +1264,19 @@ async fn verify_missing_libraries<H: BuildHasher + Default>(
 		Ok(res.to_owned())
 	};
 
-	// List the entries of each library path once, then match the names in memory instead of
-	// refetching every directory for every needed library.
-	let futures = library_paths.iter().map(|library_path| async move {
-		let directory = directory_cache.resolve(library_path).await?;
-		let entries = directory.entries().await?;
-		Ok::<_, tg::Error>(entries.into_keys().collect_vec())
+	// Every library path was just checked out, so read the names from the store instead of walking
+	// each directory over the network again.
+	let futures = checkouts.iter().map(|(library_path, path)| async move {
+		let mut read_dir = tokio::fs::read_dir(path).await.map_err(
+			|error| tg::error!(!error, directory = %library_path.id, path = %path.display(), "failed to read the checked out library path"),
+		)?;
+		let mut names = Vec::new();
+		while let Some(entry) = read_dir.next_entry().await.map_err(
+			|error| tg::error!(!error, path = %path.display(), "failed to read the library path's entries"),
+		)? {
+			names.push(entry.file_name().to_string_lossy().into_owned());
+		}
+		Ok::<_, tg::Error>(names)
 	});
 	let entries = futures::future::try_join_all(futures).await?;
 
@@ -1290,6 +1307,7 @@ async fn verify_missing_libraries<H: BuildHasher + Default>(
 		.difference(&found_libraries)
 		.collect_vec();
 	if !missing_libs.is_empty() {
+		let library_paths = checkouts.iter().map(|(library_path, _)| library_path).collect_vec();
 		if disallow_missing {
 			return Err(tg::error!(
 				?library_paths,

--- a/packages/std/packages/tgld/src/main.rs
+++ b/packages/std/packages/tgld/src/main.rs
@@ -1099,12 +1099,8 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 	tracing::debug!(?filtered_library_paths, "post-filter");
 
 	if matches!(strategy, LibraryPathStrategy::Filter) {
-		return finalize_library_paths(
-			disallow_missing,
-			filtered_library_paths,
-			needed_libraries,
-		)
-		.await;
+		return finalize_library_paths(disallow_missing, filtered_library_paths, needed_libraries)
+			.await;
 	}
 
 	match strategy {
@@ -1190,19 +1186,15 @@ async fn combine_library_paths<H: BuildHasher + Default>(
 	Ok(combined_library_path)
 }
 
-/// Check out a set of library paths into the store, returning the path each one was checked out to.
-/// Each referent carries its stored tokens, without which the server falls back to an index lookup
-/// to authorize it.
+/// Check out library paths and return their filesystem paths.
 async fn cache_library_paths<H: BuildHasher + Default>(
 	library_paths: &HashSet<DirectoryWithSubpath, H>,
 ) -> tg::Result<Vec<(DirectoryWithSubpath, PathBuf)>> {
 	if library_paths.is_empty() {
 		return Ok(Vec::new());
 	}
-	// The checkout returns one path per artifact in order, so hold the paths in an order the
-	// results can be zipped against.
-	let library_paths = library_paths.iter().cloned().collect_vec();
-	let artifacts = library_paths
+	let ordered_library_paths = library_paths.iter().cloned().collect_vec();
+	let artifacts = ordered_library_paths
 		.iter()
 		.map(|dir_with_subpath| {
 			tg::Referent::with_node_and_tokens(
@@ -1215,13 +1207,11 @@ async fn cache_library_paths<H: BuildHasher + Default>(
 	let paths = common::checkout_artifacts(artifacts)
 		.await
 		.map_err(|error| tg::error!(!error, "failed to cache libraries"))?;
-	if paths.len() != library_paths.len() {
+	if paths.len() != ordered_library_paths.len() {
 		return Err(tg::error!("expected one checkout path per library path"));
 	}
 
-	// A checkout names the root of a library path, so a subpath is appended to reach the directory
-	// the path refers to.
-	let checkouts = library_paths
+	let checkouts = ordered_library_paths
 		.into_iter()
 		.zip(paths)
 		.map(|(dir_with_subpath, path)| {
@@ -1264,8 +1254,7 @@ async fn verify_missing_libraries<H: BuildHasher + Default>(
 		Ok(res.to_owned())
 	};
 
-	// Every library path was just checked out, so read the names from the store instead of walking
-	// each directory over the network again.
+	// Read from the checkouts to avoid loading the directories again.
 	let futures = checkouts.iter().map(|(library_path, path)| async move {
 		let mut read_dir = tokio::fs::read_dir(path).await.map_err(
 			|error| tg::error!(!error, directory = %library_path.id, path = %path.display(), "failed to read the checked out library path"),
@@ -1307,7 +1296,10 @@ async fn verify_missing_libraries<H: BuildHasher + Default>(
 		.difference(&found_libraries)
 		.collect_vec();
 	if !missing_libs.is_empty() {
-		let library_paths = checkouts.iter().map(|(library_path, _)| library_path).collect_vec();
+		let library_paths = checkouts
+			.iter()
+			.map(|(library_path, _)| library_path)
+			.collect_vec();
 		if disallow_missing {
 			return Err(tg::error!(
 				?library_paths,

--- a/packages/std/packages/tgld/src/main.rs
+++ b/packages/std/packages/tgld/src/main.rs
@@ -487,10 +487,36 @@ async fn create_wrapper(options: &Options) -> tg::Result<()> {
 					(Some(artifact), path) => {
 						tracing::debug!(?artifact, ?path, "checking for entries");
 						if let Ok(directory) = artifact.try_unwrap_directory() {
-							let mut entries = match tokio::fs::read_dir(library_path).await {
-								Ok(entries) => entries,
+							let has_entries = match tokio::fs::read_dir(library_path).await {
+								Ok(mut entries) => entries.next_entry().await.map_err(
+									|error| tg::error!(!error, path = %library_path, "failed to read the library path's entries"),
+								)?.is_some(),
 								Err(error) if error.kind() == std::io::ErrorKind::NotADirectory => {
 									return Ok(None);
+								},
+								// The library path is not checked out yet, so consult the object graph instead.
+								Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+									let root = directory_cache_ref.intern(&directory);
+									let target = {
+										let _walk = root.walk.lock().await;
+										if let Some(ref subpath) = path {
+											root.directory
+												.get(subpath)
+												.await?
+												.try_unwrap_directory()
+												.ok()
+										} else {
+											Some(root.directory.clone())
+										}
+									};
+									match target {
+										Some(target) => {
+											let target = directory_cache_ref.intern(&target);
+											let _walk = target.walk.lock().await;
+											!target.directory.entries().await?.is_empty()
+										},
+										None => false,
+									}
 								},
 								Err(error) => {
 									return Err(
@@ -498,16 +524,14 @@ async fn create_wrapper(options: &Options) -> tg::Result<()> {
 									);
 								},
 							};
-							if entries.next_entry().await.map_err(
-								|error| tg::error!(!error, path = %library_path, "failed to read the library path's entries"),
-							)?.is_none() {
-								None
-							} else {
+							if has_entries {
 								tracing::debug!(?path, "found a directory with entries");
 								let root = directory_cache_ref.intern(&directory);
 								let dir_with_subpath =
 									dir_with_subpath_from_directory(&root.directory, path).await?;
 								Some(dir_with_subpath)
+							} else {
+								None
 							}
 						} else {
 							None

--- a/packages/std/packages/tgld/src/main.rs
+++ b/packages/std/packages/tgld/src/main.rs
@@ -5,6 +5,7 @@ use std::{
 	hash::BuildHasher,
 	path::PathBuf,
 	str::FromStr,
+	sync::{Arc, Mutex},
 };
 use tangram_client::prelude::*;
 use tokio::io::AsyncReadExt as _;
@@ -428,8 +429,7 @@ fn read_options() -> tg::Result<Options> {
 
 #[allow(clippy::too_many_lines)]
 async fn create_wrapper(options: &Options) -> tg::Result<()> {
-	// Share the directory handles across every phase of the wrap.
-	let directories = Directories::default();
+	let directory_cache = DirectoryCache::default();
 
 	// Analyze the output file.
 	let AnalyzeOutputFileOutput {
@@ -486,24 +486,33 @@ async fn create_wrapper(options: &Options) -> tg::Result<()> {
 					(Some(artifact), path) => {
 						tracing::debug!(?artifact, ?path, "checking for entries");
 						if let Ok(directory) = artifact.try_unwrap_directory() {
-							let directory = directories.root(&directory);
-							let entries = if let Some(ref subpath) = path {
-								if let Ok(subdirectory) =
-									directory.get(&subpath).await?.try_unwrap_directory()
-								{
-									subdirectory.entries().await?
+							let root = directory_cache.intern(&directory);
+							let target = {
+								let _walk = root.walk.lock().await;
+								root.directory.object().await?;
+								if let Some(ref subpath) = path {
+									root.directory
+										.get(subpath)
+										.await?
+										.try_unwrap_directory()
+										.ok()
 								} else {
-									BTreeMap::default()
+									Some(root.directory.clone())
 								}
+							};
+							let entries = if let Some(target) = target {
+								let target = directory_cache.intern(&target);
+								let _walk = target.walk.lock().await;
+								target.directory.entries().await?
 							} else {
-								directory.entries().await?
+								BTreeMap::default()
 							};
 							if entries.is_empty() {
 								None
 							} else {
 								tracing::debug!(?path, "found a directory with entries");
 								let dir_with_subpath =
-									dir_with_subpath_from_directory(&directory, path).await?;
+									dir_with_subpath_from_directory(&root.directory, path).await?;
 								Some(dir_with_subpath)
 							}
 						} else {
@@ -586,7 +595,7 @@ async fn create_wrapper(options: &Options) -> tg::Result<()> {
 			&output_file,
 			library_paths,
 			&mut needed_libraries,
-			&directories,
+			&directory_cache,
 			options.library_path_strategy,
 			options.max_depth,
 			options.disallow_missing,
@@ -1062,7 +1071,7 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 	file: &tg::File,
 	library_paths: HashSet<DirectoryWithSubpath, H>,
 	needed_libraries: &mut HashMap<String, Option<DirectoryWithSubpath>, H>,
-	directories: &Directories,
+	directory_cache: &DirectoryCache,
 	strategy: LibraryPathStrategy,
 	max_depth: usize,
 	disallow_missing: bool,
@@ -1079,7 +1088,7 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 		file,
 		&library_paths,
 		needed_libraries,
-		directories,
+		directory_cache,
 		max_depth,
 		0,
 	)
@@ -1094,7 +1103,7 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 			disallow_missing,
 			filtered_library_paths,
 			needed_libraries,
-			directories,
+			directory_cache,
 		)
 		.await;
 	}
@@ -1102,39 +1111,39 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 	match strategy {
 		LibraryPathStrategy::Resolve => {
 			let resolved_library_paths: HashSet<DirectoryWithSubpath, H> =
-				resolve_directories(&filtered_library_paths, directories).await?;
+				resolve_directories(&filtered_library_paths, directory_cache).await?;
 			tracing::trace!(?resolved_library_paths, "post-resolve");
 			return finalize_library_paths(
 				disallow_missing,
 				resolved_library_paths,
 				needed_libraries,
-				directories,
+				directory_cache,
 			)
 			.await;
 		},
 		LibraryPathStrategy::Isolate => {
 			let isolated_library_paths =
-				isolate_library_paths(needed_libraries, directories).await?;
+				isolate_library_paths(needed_libraries, directory_cache).await?;
 			tracing::trace!(?isolated_library_paths, "post-isolate");
 
 			return finalize_library_paths(
 				disallow_missing,
 				isolated_library_paths,
 				needed_libraries,
-				directories,
+				directory_cache,
 			)
 			.await;
 		},
 		LibraryPathStrategy::Combine => {
 			let combined_library_path =
-				combine_library_paths(needed_libraries, directories).await?;
+				combine_library_paths(needed_libraries, directory_cache).await?;
 			tracing::trace!(?combined_library_path, "post-combine");
 
 			return finalize_library_paths(
 				disallow_missing,
 				combined_library_path,
 				needed_libraries,
-				directories,
+				directory_cache,
 			)
 			.await;
 		},
@@ -1144,46 +1153,37 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 	}
 }
 
-/// Create an individual library path for every located library.
 async fn isolate_library_paths<H: BuildHasher + Default>(
 	needed_libraries: &HashMap<String, Option<DirectoryWithSubpath>, H>,
-	directories: &Directories,
+	directory_cache: &DirectoryCache,
 ) -> tg::Result<HashSet<DirectoryWithSubpath, H>> {
-	let futures = located_libraries(needed_libraries).map(|(name, dir_with_subpath)| async move {
-		let directory = directories.get(dir_with_subpath).await?;
+	let mut isolated_library_paths = HashSet::default();
+	for (name, dir_with_subpath) in located_libraries(needed_libraries) {
+		let directory = directory_cache.resolve(dir_with_subpath).await?;
 		let Ok(Some(artifact)) = directory.try_get(name).await else {
-			return Ok::<_, tg::Error>(None);
+			continue;
 		};
 		let mut entries = BTreeMap::new();
 		entries.insert(name.clone(), artifact);
 		let directory = tg::Directory::with_entries(entries);
 		let dir_with_subpath = dir_with_subpath_from_directory(&directory, None).await?;
-		Ok(Some(dir_with_subpath))
-	});
-	let isolated_library_paths = futures::future::try_join_all(futures)
-		.await?
-		.into_iter()
-		.flatten()
-		.collect();
+		isolated_library_paths.insert(dir_with_subpath);
+	}
 
 	Ok(isolated_library_paths)
 }
 
-/// Create a single library path combining every located library file.
 async fn combine_library_paths<H: BuildHasher + Default>(
 	needed_libraries: &HashMap<String, Option<DirectoryWithSubpath>, H>,
-	directories: &Directories,
+	directory_cache: &DirectoryCache,
 ) -> tg::Result<HashSet<DirectoryWithSubpath, H>> {
-	let futures = located_libraries(needed_libraries).map(|(name, dir_with_subpath)| async move {
-		let directory = directories.get(dir_with_subpath).await?;
-		let artifact = directory.try_get(name).await.ok().flatten();
-		Ok::<_, tg::Error>(artifact.map(|artifact| (name.clone(), artifact)))
-	});
-	let entries = futures::future::try_join_all(futures)
-		.await?
-		.into_iter()
-		.flatten()
-		.collect::<BTreeMap<_, _>>();
+	let mut entries = BTreeMap::new();
+	for (name, dir_with_subpath) in located_libraries(needed_libraries) {
+		let directory = directory_cache.resolve(dir_with_subpath).await?;
+		if let Ok(Some(artifact)) = directory.try_get(name).await {
+			entries.insert(name.clone(), artifact);
+		}
+	}
 	if entries.is_empty() {
 		return Ok(HashSet::default());
 	}
@@ -1223,7 +1223,7 @@ async fn finalize_library_paths<H: BuildHasher + Default>(
 	disallow_missing: bool,
 	library_paths: HashSet<DirectoryWithSubpath, H>,
 	needed_libraries: &HashMap<String, Option<DirectoryWithSubpath>, H>,
-	directories: &Directories,
+	directory_cache: &DirectoryCache,
 ) -> tg::Result<HashSet<DirectoryWithSubpath, H>> {
 	cache_library_paths(&library_paths).await?;
 
@@ -1232,7 +1232,7 @@ async fn finalize_library_paths<H: BuildHasher + Default>(
 		disallow_missing,
 		needed_libraries,
 		&library_paths,
-		directories,
+		directory_cache,
 	)
 	.await?;
 	Ok(library_paths)
@@ -1243,7 +1243,7 @@ async fn verify_missing_libraries<H: BuildHasher + Default>(
 	disallow_missing: bool,
 	needed_libraries: &HashMap<String, Option<DirectoryWithSubpath>, H>,
 	library_paths: &HashSet<DirectoryWithSubpath, H>,
-	directories: &Directories,
+	directory_cache: &DirectoryCache,
 ) -> tg::Result<()> {
 	let mut found_libraries = HashSet::default();
 	let basename = |library_name: &str| -> tg::Result<String> {
@@ -1257,7 +1257,7 @@ async fn verify_missing_libraries<H: BuildHasher + Default>(
 	// List the entries of each library path once, then match the names in memory instead of
 	// refetching every directory for every needed library.
 	let futures = library_paths.iter().map(|library_path| async move {
-		let directory = directories.get(library_path).await?;
+		let directory = directory_cache.resolve(library_path).await?;
 		let entries = directory.entries().await?;
 		Ok::<_, tg::Error>(entries.into_keys().collect_vec())
 	});
@@ -1308,12 +1308,12 @@ async fn verify_missing_libraries<H: BuildHasher + Default>(
 /// Given a set of directories which may contain subpaths, return structs with the item resolved to the inner directory.
 async fn resolve_directories<H: BuildHasher + Default>(
 	unresolved_paths: &HashSet<DirectoryWithSubpath, H>,
-	directories: &Directories,
+	directory_cache: &DirectoryCache,
 ) -> tg::Result<HashSet<DirectoryWithSubpath, H>> {
 	let resolved_paths =
 		futures::future::try_join_all(unresolved_paths.iter().map(|dir_with_subpath| async {
 			let resolved_dir_with_subpath = if dir_with_subpath.subpath.is_some() {
-				let inner = directories.get(dir_with_subpath).await?;
+				let inner = directory_cache.resolve(dir_with_subpath).await?;
 				dir_with_subpath_from_directory(&inner, None).await?
 			} else {
 				dir_with_subpath.clone()
@@ -1326,49 +1326,66 @@ async fn resolve_directories<H: BuildHasher + Default>(
 	Ok(resolved_paths)
 }
 
-/// The library path directories resolved so far. A handle loads its object on first use and shares
-/// it with every clone, so resolving the same path again refetches the whole walk. Resolution stays
-/// lazy, because the search stops as soon as every library is located and often never reaches most
-/// of the library path.
+/// Reuse handles and serialize cold walks through each directory.
 #[derive(Default)]
-struct Directories {
-	resolved: std::sync::Mutex<HashMap<DirectoryWithSubpath, tg::Directory, Hasher>>,
-	roots: std::sync::Mutex<HashMap<tg::directory::Id, tg::Directory, Hasher>>,
+struct DirectoryCache {
+	directories: Mutex<HashMap<tg::directory::Id, CachedDirectory, Hasher>>,
+	resolved: Mutex<HashMap<DirectoryWithSubpath, tg::Directory, Hasher>>,
 }
 
-impl Directories {
-	/// Get the handle for a directory, so every reference to that id shares one loaded object. A
-	/// library path names the same directory many times over, once per subpath beneath it.
-	fn root(&self, directory: &tg::Directory) -> tg::Directory {
-		let id = directory.id();
-		if let Some(directory) = self.roots.lock().unwrap().get(&id).cloned() {
-			return directory;
-		}
-		self.roots.lock().unwrap().insert(id, directory.clone());
+#[derive(Clone)]
+struct CachedDirectory {
+	directory: tg::Directory,
+	walk: Arc<futures::lock::Mutex<()>>,
+}
 
-		directory.clone()
+impl DirectoryCache {
+	fn intern(&self, directory: &tg::Directory) -> CachedDirectory {
+		let mut directories = self.directories.lock().unwrap();
+		let cached = directories
+			.entry(directory.id())
+			.or_insert_with(|| CachedDirectory {
+				directory: directory.clone(),
+				walk: Arc::new(futures::lock::Mutex::new(())),
+			});
+		cached
+			.directory
+			.state()
+			.inherit_location(directory.state().location().as_ref());
+		cached
+			.directory
+			.state()
+			.inherit_tokens(&directory.state().tokens());
+		cached.clone()
 	}
 
-	/// Resolve a library path to its directory.
-	async fn get(&self, dir_with_subpath: &DirectoryWithSubpath) -> tg::Result<tg::Directory> {
+	async fn resolve(&self, dir_with_subpath: &DirectoryWithSubpath) -> tg::Result<tg::Directory> {
 		if let Some(directory) = self.resolved.lock().unwrap().get(dir_with_subpath).cloned() {
+			directory.state().inherit_tokens(&dir_with_subpath.tokens);
 			return Ok(directory);
 		}
-		let outer = self.root(&{
+		let outer = self.intern(&{
 			let outer = tg::Directory::with_id(dir_with_subpath.id.clone());
 			outer.state().set_tokens(dir_with_subpath.tokens.clone());
 			outer
 		});
+		let _walk = outer.walk.lock().await;
+		if let Some(directory) = self.resolved.lock().unwrap().get(dir_with_subpath).cloned() {
+			directory.state().inherit_tokens(&dir_with_subpath.tokens);
+			return Ok(directory);
+		}
 		let directory = if let Some(ref subpath) = dir_with_subpath.subpath {
-			let Some(inner) = outer.try_get(subpath).await? else {
+			let Some(inner) = outer.directory.try_get(subpath).await? else {
 				return Err(
 					tg::error!(directory = %dir_with_subpath.id, subpath = %subpath.display(), "unable to retrieve subpath from directory"),
 				);
 			};
-			inner.try_unwrap_directory().map_err(|error| tg::error!(!error, outer = %dir_with_subpath.id, subpath = %subpath.display(), "expected a directory"))?
+			let inner = inner.try_unwrap_directory().map_err(|error| tg::error!(!error, outer = %dir_with_subpath.id, subpath = %subpath.display(), "expected a directory"))?;
+			self.intern(&inner).directory
 		} else {
-			outer
+			outer.directory.clone()
 		};
+		directory.state().inherit_tokens(&dir_with_subpath.tokens);
 		self.resolved
 			.lock()
 			.unwrap()
@@ -1383,7 +1400,7 @@ async fn find_transitive_needed_libraries<H: BuildHasher + Default + Send + Sync
 	file: &tg::File,
 	library_paths: &HashSet<DirectoryWithSubpath, H>,
 	all_needed_libraries: &mut HashMap<String, Option<DirectoryWithSubpath>, H>,
-	directories: &Directories,
+	directory_cache: &DirectoryCache,
 	max_depth: usize,
 	depth: usize,
 ) -> tg::Result<()> {
@@ -1415,33 +1432,16 @@ async fn find_transitive_needed_libraries<H: BuildHasher + Default + Send + Sync
 	}
 
 	for dir_with_subpath in library_paths {
-		let directory = directories.get(dir_with_subpath).await?;
+		let directory = directory_cache.resolve(dir_with_subpath).await?;
 		tracing::trace!(?dir_with_subpath, "Checking directory for libraries.");
 
-		// Look for every library still missing in one pass, so a directory is searched concurrently.
 		let names = all_needed_libraries
 			.iter()
 			.filter(|(_, located)| located.is_none())
 			.map(|(name, _)| name.clone())
 			.collect_vec();
 		tracing::debug!(?names, "checking for libraries");
-		let futures = names.iter().map(|library_name| {
-			let directory = &directory;
-			async move {
-				let found = match directory.try_get(library_name).await {
-					Ok(Some(tg::artifact::Handle::File(file))) => Some(file),
-					_ => None,
-				};
-				(library_name.clone(), found)
-			}
-		});
-		let found = futures::future::join_all(futures).await;
-
-		for (library_name, found_library) in found {
-			let Some(found_library) = found_library else {
-				continue;
-			};
-
+		for library_name in names {
 			// A recursion earlier in this pass may already have located the library.
 			if all_needed_libraries
 				.get(&library_name)
@@ -1450,6 +1450,11 @@ async fn find_transitive_needed_libraries<H: BuildHasher + Default + Send + Sync
 			{
 				continue;
 			}
+			let Ok(Some(tg::artifact::Handle::File(found_library))) =
+				directory.try_get(&library_name).await
+			else {
+				continue;
+			};
 			let found_library_id = found_library.id();
 			tracing::trace!(?found_library_id, ?library_name, "Found library file.");
 			*all_needed_libraries
@@ -1459,7 +1464,7 @@ async fn find_transitive_needed_libraries<H: BuildHasher + Default + Send + Sync
 				&found_library,
 				library_paths,
 				all_needed_libraries,
-				directories,
+				directory_cache,
 				max_depth,
 				depth + 1,
 			))
@@ -1473,7 +1478,6 @@ async fn find_transitive_needed_libraries<H: BuildHasher + Default + Send + Sync
 	Ok(())
 }
 
-/// Iterate over the needed libraries that were located in a library path.
 fn located_libraries<H: BuildHasher>(
 	needed_libraries: &HashMap<String, Option<DirectoryWithSubpath>, H>,
 ) -> impl Iterator<Item = (&String, &DirectoryWithSubpath)> {
@@ -1680,25 +1684,6 @@ async fn bytes_from_path(path: impl AsRef<std::path::Path>) -> tg::Result<Vec<u8
 		.map_err(|error| tg::error!(source = error, "failed to read the output file"))?;
 
 	Ok(bytes)
-}
-
-/// Get a [`tg::Directory`] handle from a [`DirectoryWithSubpath`]. If there is a subpath present, returns the inner directory.
-pub async fn directory_from_dir_with_subpath(
-	dir_with_subpath: &DirectoryWithSubpath,
-) -> tg::Result<tg::Directory> {
-	let outer = tg::Directory::with_id(dir_with_subpath.id.clone());
-	outer.state().set_tokens(dir_with_subpath.tokens.clone());
-	let directory = if let Some(ref subpath) = dir_with_subpath.subpath {
-		let Some(inner) = outer.try_get(subpath).await? else {
-			return Err(
-				tg::error!(directory = %dir_with_subpath.id, subpath = %subpath.display(), "unable to retrieve subpath from directory"),
-			);
-		};
-		inner.try_unwrap_directory().map_err(|error| tg::error!(!error, outer = %dir_with_subpath.id, subpath = %subpath.display(), "expected a directory"))?
-	} else {
-		outer
-	};
-	Ok(directory)
 }
 
 /// Get a [`DirectoryWithSubpath`] from a [`tg::Directory`] handle.

--- a/packages/std/packages/tgld/src/main.rs
+++ b/packages/std/packages/tgld/src/main.rs
@@ -475,10 +475,11 @@ async fn create_wrapper(options: &Options) -> tg::Result<()> {
 	.await?;
 
 	// Unrender all library paths to symlinks. If any library path points into the working directory, check in its contents.
+	let directory_cache_ref = &directory_cache;
 	let library_paths = command_line_library_path
 		.into_iter()
 		.chain(
-			futures::future::try_join_all(options.library_paths.iter().map(|library_path| async {
+			futures::future::try_join_all(options.library_paths.iter().map(|library_path| async move {
 				let symlink = common::template_to_symlink(&common::unrender(library_path)?)?;
 				let artifact = symlink.artifact().await?;
 				let path = symlink.path().await?;
@@ -486,31 +487,24 @@ async fn create_wrapper(options: &Options) -> tg::Result<()> {
 					(Some(artifact), path) => {
 						tracing::debug!(?artifact, ?path, "checking for entries");
 						if let Ok(directory) = artifact.try_unwrap_directory() {
-							let root = directory_cache.intern(&directory);
-							let target = {
-								let _walk = root.walk.lock().await;
-								root.directory.object().await?;
-								if let Some(ref subpath) = path {
-									root.directory
-										.get(subpath)
-										.await?
-										.try_unwrap_directory()
-										.ok()
-								} else {
-									Some(root.directory.clone())
-								}
+							let mut entries = match tokio::fs::read_dir(library_path).await {
+								Ok(entries) => entries,
+								Err(error) if error.kind() == std::io::ErrorKind::NotADirectory => {
+									return Ok(None);
+								},
+								Err(error) => {
+									return Err(
+										tg::error!(!error, path = %library_path, "failed to read the library path"),
+									);
+								},
 							};
-							let entries = if let Some(target) = target {
-								let target = directory_cache.intern(&target);
-								let _walk = target.walk.lock().await;
-								target.directory.entries().await?
-							} else {
-								BTreeMap::default()
-							};
-							if entries.is_empty() {
+							if entries.next_entry().await.map_err(
+								|error| tg::error!(!error, path = %library_path, "failed to read the library path's entries"),
+							)?.is_none() {
 								None
 							} else {
 								tracing::debug!(?path, "found a directory with entries");
+								let root = directory_cache_ref.intern(&directory);
 								let dir_with_subpath =
 									dir_with_subpath_from_directory(&root.directory, path).await?;
 								Some(dir_with_subpath)
@@ -1081,12 +1075,12 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 	}
 
 	// Cache the library paths before searching them, so reads do not reassemble blobs.
-	cache_library_paths(&library_paths).await?;
+	let checkouts = cache_library_paths(&library_paths).await?;
 
 	// Find all the transitive needed libraries of the output file we can locate in the library path.
 	find_transitive_needed_libraries(
 		file,
-		&library_paths,
+		&checkouts,
 		needed_libraries,
 		directory_cache,
 		max_depth,
@@ -1194,27 +1188,36 @@ async fn cache_library_paths<H: BuildHasher + Default>(
 		return Ok(Vec::new());
 	}
 	let ordered_library_paths = library_paths.iter().cloned().collect_vec();
-	let artifacts = ordered_library_paths
+	let ordered_roots = ordered_library_paths
 		.iter()
-		.map(|dir_with_subpath| {
-			tg::Referent::with_node_and_tokens(
-				dir_with_subpath.id.clone().into(),
-				dir_with_subpath.tokens.clone(),
-			)
-		})
+		.map(|dir_with_subpath| (dir_with_subpath.id.clone(), dir_with_subpath.tokens.clone()))
+		.collect::<HashSet<_, Hasher>>()
+		.into_iter()
+		.collect_vec();
+	let artifacts = ordered_roots
+		.iter()
+		.map(|(id, tokens)| tg::Referent::with_node_and_tokens(id.clone().into(), tokens.clone()))
 		.collect();
 	tracing::debug!("caching libraries");
 	let paths = common::checkout_artifacts(artifacts)
 		.await
 		.map_err(|error| tg::error!(!error, "failed to cache libraries"))?;
-	if paths.len() != ordered_library_paths.len() {
-		return Err(tg::error!("expected one checkout path per library path"));
+	if paths.len() != ordered_roots.len() {
+		return Err(tg::error!("expected one checkout path per library root"));
 	}
+	let paths: HashMap<_, _, Hasher> = ordered_roots
+		.into_iter()
+		.map(|(id, _)| id)
+		.zip(paths)
+		.collect();
 
 	let checkouts = ordered_library_paths
 		.into_iter()
-		.zip(paths)
-		.map(|(dir_with_subpath, path)| {
+		.map(|dir_with_subpath| {
+			let path = paths
+				.get(&dir_with_subpath.id)
+				.expect("every library root was checked out")
+				.clone();
 			let path = match dir_with_subpath.subpath {
 				Some(ref subpath) => path.join(subpath),
 				None => path,
@@ -1408,7 +1411,7 @@ impl DirectoryCache {
 /// Recursively find all needed libraries for an executable.
 async fn find_transitive_needed_libraries<H: BuildHasher + Default + Send + Sync>(
 	file: &tg::File,
-	library_paths: &HashSet<DirectoryWithSubpath, H>,
+	library_paths: &[(DirectoryWithSubpath, PathBuf)],
 	all_needed_libraries: &mut HashMap<String, Option<DirectoryWithSubpath>, H>,
 	directory_cache: &DirectoryCache,
 	max_depth: usize,
@@ -1441,8 +1444,7 @@ async fn find_transitive_needed_libraries<H: BuildHasher + Default + Send + Sync
 		return Ok(());
 	}
 
-	for dir_with_subpath in library_paths {
-		let directory = directory_cache.resolve(dir_with_subpath).await?;
+	for (dir_with_subpath, path) in library_paths {
 		tracing::trace!(?dir_with_subpath, "Checking directory for libraries.");
 
 		let names = all_needed_libraries
@@ -1451,6 +1453,7 @@ async fn find_transitive_needed_libraries<H: BuildHasher + Default + Send + Sync
 			.map(|(name, _)| name.clone())
 			.collect_vec();
 		tracing::debug!(?names, "checking for libraries");
+		let mut directory = None;
 		for library_name in names {
 			// A recursion earlier in this pass may already have located the library.
 			if all_needed_libraries
@@ -1460,6 +1463,16 @@ async fn find_transitive_needed_libraries<H: BuildHasher + Default + Send + Sync
 			{
 				continue;
 			}
+			if !tokio::fs::try_exists(path.join(&library_name))
+				.await
+				.unwrap_or(false)
+			{
+				continue;
+			}
+			let directory = match &directory {
+				Some(directory) => directory,
+				None => directory.insert(directory_cache.resolve(dir_with_subpath).await?),
+			};
 			let Ok(Some(tg::artifact::Handle::File(found_library))) =
 				directory.try_get(&library_name).await
 			else {

--- a/packages/std/packages/tgld/src/main.rs
+++ b/packages/std/packages/tgld/src/main.rs
@@ -428,6 +428,9 @@ fn read_options() -> tg::Result<Options> {
 
 #[allow(clippy::too_many_lines)]
 async fn create_wrapper(options: &Options) -> tg::Result<()> {
+	// Share the directory handles across every phase of the wrap.
+	let directories = Directories::default();
+
 	// Analyze the output file.
 	let AnalyzeOutputFileOutput {
 		is_executable,
@@ -483,6 +486,7 @@ async fn create_wrapper(options: &Options) -> tg::Result<()> {
 					(Some(artifact), path) => {
 						tracing::debug!(?artifact, ?path, "checking for entries");
 						if let Ok(directory) = artifact.try_unwrap_directory() {
+							let directory = directories.root(&directory);
 							let entries = if let Some(ref subpath) = path {
 								if let Ok(subdirectory) =
 									directory.get(&subpath).await?.try_unwrap_directory()
@@ -582,6 +586,7 @@ async fn create_wrapper(options: &Options) -> tg::Result<()> {
 			&output_file,
 			library_paths,
 			&mut needed_libraries,
+			&directories,
 			options.library_path_strategy,
 			options.max_depth,
 			options.disallow_missing,
@@ -955,8 +960,7 @@ async fn create_library_directory_for_command_line_libraries<H: BuildHasher>(
 				let library_candidate_path_str = library_candidate_path.to_str().ok_or_else(
 					|| tg::error!(path = %library_candidate_path.display(), "unable to convert path to str"),
 				)?;
-				let library_candidate_file = if common::is_store_path(library_candidate_path_str)
-				{
+				let library_candidate_file = if common::is_store_path(library_candidate_path_str) {
 					tracing::trace!("found an artifact, extracting file object");
 					let template = common::unrender(library_candidate_path_str)?;
 					tracing::trace!(?template, "unrendered library candidate path");
@@ -1058,6 +1062,7 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 	file: &tg::File,
 	library_paths: HashSet<DirectoryWithSubpath, H>,
 	needed_libraries: &mut HashMap<String, Option<DirectoryWithSubpath>, H>,
+	directories: &Directories,
 	strategy: LibraryPathStrategy,
 	max_depth: usize,
 	disallow_missing: bool,
@@ -1070,79 +1075,66 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 	cache_library_paths(&library_paths).await?;
 
 	// Find all the transitive needed libraries of the output file we can locate in the library path.
-	find_transitive_needed_libraries(file, &library_paths, needed_libraries, max_depth, 0).await?;
+	find_transitive_needed_libraries(
+		file,
+		&library_paths,
+		needed_libraries,
+		directories,
+		max_depth,
+		0,
+	)
+	.await?;
 	tracing::debug!(?needed_libraries, "post-find");
 
 	let filtered_library_paths = needed_libraries.values().flatten().cloned().collect();
 	tracing::debug!(?filtered_library_paths, "post-filter");
 
 	if matches!(strategy, LibraryPathStrategy::Filter) {
-		return finalize_library_paths(disallow_missing, filtered_library_paths, needed_libraries)
-			.await;
+		return finalize_library_paths(
+			disallow_missing,
+			filtered_library_paths,
+			needed_libraries,
+			directories,
+		)
+		.await;
 	}
 
 	match strategy {
 		LibraryPathStrategy::Resolve => {
 			let resolved_library_paths: HashSet<DirectoryWithSubpath, H> =
-				resolve_directories(&filtered_library_paths).await?;
+				resolve_directories(&filtered_library_paths, directories).await?;
 			tracing::trace!(?resolved_library_paths, "post-resolve");
 			return finalize_library_paths(
 				disallow_missing,
 				resolved_library_paths,
 				needed_libraries,
+				directories,
 			)
 			.await;
 		},
 		LibraryPathStrategy::Isolate => {
-			// Create an individual library path for every found library.
-			let mut isolated_library_paths: HashSet<DirectoryWithSubpath, H> = HashSet::default();
-			for (name, dir_with_subpath) in needed_libraries.iter() {
-				if let Some(dir_with_subpath) = dir_with_subpath {
-					let directory = directory_from_dir_with_subpath(dir_with_subpath).await?;
-					if let Ok(Some(artifact)) = directory.try_get(&name).await {
-						let mut entries = BTreeMap::new();
-						entries.insert(name.clone(), artifact);
-						let dir = tg::Directory::with_entries(entries);
-						let dir_with_subpath = dir_with_subpath_from_directory(&dir, None).await?;
-						isolated_library_paths.insert(dir_with_subpath);
-					}
-				}
-			}
+			let isolated_library_paths =
+				isolate_library_paths(needed_libraries, directories).await?;
 			tracing::trace!(?isolated_library_paths, "post-isolate");
 
 			return finalize_library_paths(
 				disallow_missing,
 				isolated_library_paths,
 				needed_libraries,
+				directories,
 			)
 			.await;
 		},
 		LibraryPathStrategy::Combine => {
-			// Create a directory combining all located library files.
-			let mut entries = BTreeMap::new();
-			for (name, dir_with_subpath) in needed_libraries.iter() {
-				if let Some(dir_with_subpath) = dir_with_subpath {
-					let directory = directory_from_dir_with_subpath(dir_with_subpath).await?;
-					if let Ok(Some(artifact)) = directory.try_get(&name).await {
-						entries.insert(name.clone(), artifact);
-					}
-				}
-			}
-			let dir_id = if entries.is_empty() {
-				None
-			} else {
-				let dir_with_subpath =
-					dir_with_subpath_from_directory(&tg::Directory::with_entries(entries), None)
-						.await?;
-				Some(dir_with_subpath)
-			};
-			tracing::trace!(?dir_id, "post-combine");
-			let combined_library_path = dir_id.into_iter().collect();
+			let combined_library_path =
+				combine_library_paths(needed_libraries, directories).await?;
+			tracing::trace!(?combined_library_path, "post-combine");
 
 			return finalize_library_paths(
 				disallow_missing,
 				combined_library_path,
 				needed_libraries,
+				directories,
 			)
 			.await;
 		},
@@ -1150,6 +1142,56 @@ async fn optimize_library_paths<H: BuildHasher + Default + Send + Sync>(
 			unreachable!("the none and filter cases have already been handled")
 		},
 	}
+}
+
+/// Create an individual library path for every located library.
+async fn isolate_library_paths<H: BuildHasher + Default>(
+	needed_libraries: &HashMap<String, Option<DirectoryWithSubpath>, H>,
+	directories: &Directories,
+) -> tg::Result<HashSet<DirectoryWithSubpath, H>> {
+	let futures = located_libraries(needed_libraries).map(|(name, dir_with_subpath)| async move {
+		let directory = directories.get(dir_with_subpath).await?;
+		let Ok(Some(artifact)) = directory.try_get(name).await else {
+			return Ok::<_, tg::Error>(None);
+		};
+		let mut entries = BTreeMap::new();
+		entries.insert(name.clone(), artifact);
+		let directory = tg::Directory::with_entries(entries);
+		let dir_with_subpath = dir_with_subpath_from_directory(&directory, None).await?;
+		Ok(Some(dir_with_subpath))
+	});
+	let isolated_library_paths = futures::future::try_join_all(futures)
+		.await?
+		.into_iter()
+		.flatten()
+		.collect();
+
+	Ok(isolated_library_paths)
+}
+
+/// Create a single library path combining every located library file.
+async fn combine_library_paths<H: BuildHasher + Default>(
+	needed_libraries: &HashMap<String, Option<DirectoryWithSubpath>, H>,
+	directories: &Directories,
+) -> tg::Result<HashSet<DirectoryWithSubpath, H>> {
+	let futures = located_libraries(needed_libraries).map(|(name, dir_with_subpath)| async move {
+		let directory = directories.get(dir_with_subpath).await?;
+		let artifact = directory.try_get(name).await.ok().flatten();
+		Ok::<_, tg::Error>(artifact.map(|artifact| (name.clone(), artifact)))
+	});
+	let entries = futures::future::try_join_all(futures)
+		.await?
+		.into_iter()
+		.flatten()
+		.collect::<BTreeMap<_, _>>();
+	if entries.is_empty() {
+		return Ok(HashSet::default());
+	}
+	let directory = tg::Directory::with_entries(entries);
+	let dir_with_subpath = dir_with_subpath_from_directory(&directory, None).await?;
+	let combined_library_path = std::iter::once(dir_with_subpath).collect();
+
+	Ok(combined_library_path)
 }
 
 /// Check out a set of library paths into the store. Each referent carries its stored tokens, without
@@ -1181,11 +1223,18 @@ async fn finalize_library_paths<H: BuildHasher + Default>(
 	disallow_missing: bool,
 	library_paths: HashSet<DirectoryWithSubpath, H>,
 	needed_libraries: &HashMap<String, Option<DirectoryWithSubpath>, H>,
+	directories: &Directories,
 ) -> tg::Result<HashSet<DirectoryWithSubpath, H>> {
 	cache_library_paths(&library_paths).await?;
 
 	// Warn or error if any required libraries are not included in the set.
-	verify_missing_libraries(disallow_missing, needed_libraries, &library_paths).await?;
+	verify_missing_libraries(
+		disallow_missing,
+		needed_libraries,
+		&library_paths,
+		directories,
+	)
+	.await?;
 	Ok(library_paths)
 }
 
@@ -1194,6 +1243,7 @@ async fn verify_missing_libraries<H: BuildHasher + Default>(
 	disallow_missing: bool,
 	needed_libraries: &HashMap<String, Option<DirectoryWithSubpath>, H>,
 	library_paths: &HashSet<DirectoryWithSubpath, H>,
+	directories: &Directories,
 ) -> tg::Result<()> {
 	let mut found_libraries = HashSet::default();
 	let basename = |library_name: &str| -> tg::Result<String> {
@@ -1204,16 +1254,22 @@ async fn verify_missing_libraries<H: BuildHasher + Default>(
 		Ok(res.to_owned())
 	};
 
+	// List the entries of each library path once, then match the names in memory instead of
+	// refetching every directory for every needed library.
+	let futures = library_paths.iter().map(|library_path| async move {
+		let directory = directories.get(library_path).await?;
+		let entries = directory.entries().await?;
+		Ok::<_, tg::Error>(entries.into_keys().collect_vec())
+	});
+	let entries = futures::future::try_join_all(futures).await?;
+
 	for library in needed_libraries.keys() {
 		// For this check, we just care about the basename.
 		let library_basename = basename(library)?;
-		for library_path in library_paths {
-			let directory = directory_from_dir_with_subpath(library_path).await?;
-			let directory_id = directory.id();
-			tracing::trace!(?library_basename, %directory_id, "checking for library");
-			for needed_library_name in directory.entries().await?.keys() {
-				if needed_library_name.starts_with(&library_basename) {
-					let found_library_basename = basename(needed_library_name)?;
+		for names in &entries {
+			for name in names {
+				if name.starts_with(&library_basename) {
+					let found_library_basename = basename(name)?;
 					found_libraries.insert(found_library_basename);
 					break;
 				}
@@ -1252,18 +1308,12 @@ async fn verify_missing_libraries<H: BuildHasher + Default>(
 /// Given a set of directories which may contain subpaths, return structs with the item resolved to the inner directory.
 async fn resolve_directories<H: BuildHasher + Default>(
 	unresolved_paths: &HashSet<DirectoryWithSubpath, H>,
+	directories: &Directories,
 ) -> tg::Result<HashSet<DirectoryWithSubpath, H>> {
 	let resolved_paths =
 		futures::future::try_join_all(unresolved_paths.iter().map(|dir_with_subpath| async {
-			let resolved_dir_with_subpath = if let Some(subpath) = &dir_with_subpath.subpath {
-				let directory = tg::Directory::with_id(dir_with_subpath.id.clone());
-				directory.state().set_tokens(dir_with_subpath.tokens.clone());
-				let Some(inner) = directory.try_get(subpath).await? else {
-					return Err(
-						tg::error!(directory = %dir_with_subpath.id, subpath = %subpath.display(), "unable to retrieve subpath from directory"),
-					);
-				};
-				let inner = inner.try_unwrap_directory().map_err(|error| tg::error!(!error, outer =% dir_with_subpath.id, subpath = %subpath.display(), "expected a directory"))?;
+			let resolved_dir_with_subpath = if dir_with_subpath.subpath.is_some() {
+				let inner = directories.get(dir_with_subpath).await?;
 				dir_with_subpath_from_directory(&inner, None).await?
 			} else {
 				dir_with_subpath.clone()
@@ -1276,11 +1326,64 @@ async fn resolve_directories<H: BuildHasher + Default>(
 	Ok(resolved_paths)
 }
 
+/// The library path directories resolved so far. A handle loads its object on first use and shares
+/// it with every clone, so resolving the same path again refetches the whole walk. Resolution stays
+/// lazy, because the search stops as soon as every library is located and often never reaches most
+/// of the library path.
+#[derive(Default)]
+struct Directories {
+	resolved: std::sync::Mutex<HashMap<DirectoryWithSubpath, tg::Directory, Hasher>>,
+	roots: std::sync::Mutex<HashMap<tg::directory::Id, tg::Directory, Hasher>>,
+}
+
+impl Directories {
+	/// Get the handle for a directory, so every reference to that id shares one loaded object. A
+	/// library path names the same directory many times over, once per subpath beneath it.
+	fn root(&self, directory: &tg::Directory) -> tg::Directory {
+		let id = directory.id();
+		if let Some(directory) = self.roots.lock().unwrap().get(&id).cloned() {
+			return directory;
+		}
+		self.roots.lock().unwrap().insert(id, directory.clone());
+
+		directory.clone()
+	}
+
+	/// Resolve a library path to its directory.
+	async fn get(&self, dir_with_subpath: &DirectoryWithSubpath) -> tg::Result<tg::Directory> {
+		if let Some(directory) = self.resolved.lock().unwrap().get(dir_with_subpath).cloned() {
+			return Ok(directory);
+		}
+		let outer = self.root(&{
+			let outer = tg::Directory::with_id(dir_with_subpath.id.clone());
+			outer.state().set_tokens(dir_with_subpath.tokens.clone());
+			outer
+		});
+		let directory = if let Some(ref subpath) = dir_with_subpath.subpath {
+			let Some(inner) = outer.try_get(subpath).await? else {
+				return Err(
+					tg::error!(directory = %dir_with_subpath.id, subpath = %subpath.display(), "unable to retrieve subpath from directory"),
+				);
+			};
+			inner.try_unwrap_directory().map_err(|error| tg::error!(!error, outer = %dir_with_subpath.id, subpath = %subpath.display(), "expected a directory"))?
+		} else {
+			outer
+		};
+		self.resolved
+			.lock()
+			.unwrap()
+			.insert(dir_with_subpath.clone(), directory.clone());
+
+		Ok(directory)
+	}
+}
+
 /// Recursively find all needed libraries for an executable.
 async fn find_transitive_needed_libraries<H: BuildHasher + Default + Send + Sync>(
 	file: &tg::File,
 	library_paths: &HashSet<DirectoryWithSubpath, H>,
 	all_needed_libraries: &mut HashMap<String, Option<DirectoryWithSubpath>, H>,
+	directories: &Directories,
 	max_depth: usize,
 	depth: usize,
 ) -> tg::Result<()> {
@@ -1312,10 +1415,34 @@ async fn find_transitive_needed_libraries<H: BuildHasher + Default + Send + Sync
 	}
 
 	for dir_with_subpath in library_paths {
-		let directory = directory_from_dir_with_subpath(dir_with_subpath).await?;
+		let directory = directories.get(dir_with_subpath).await?;
 		tracing::trace!(?dir_with_subpath, "Checking directory for libraries.");
-		let copy = all_needed_libraries.keys().cloned().collect_vec();
-		for library_name in copy {
+
+		// Look for every library still missing in one pass, so a directory is searched concurrently.
+		let names = all_needed_libraries
+			.iter()
+			.filter(|(_, located)| located.is_none())
+			.map(|(name, _)| name.clone())
+			.collect_vec();
+		tracing::debug!(?names, "checking for libraries");
+		let futures = names.iter().map(|library_name| {
+			let directory = &directory;
+			async move {
+				let found = match directory.try_get(library_name).await {
+					Ok(Some(tg::artifact::Handle::File(file))) => Some(file),
+					_ => None,
+				};
+				(library_name.clone(), found)
+			}
+		});
+		let found = futures::future::join_all(futures).await;
+
+		for (library_name, found_library) in found {
+			let Some(found_library) = found_library else {
+				continue;
+			};
+
+			// A recursion earlier in this pass may already have located the library.
 			if all_needed_libraries
 				.get(&library_name)
 				.unwrap_or(&None)
@@ -1323,31 +1450,40 @@ async fn find_transitive_needed_libraries<H: BuildHasher + Default + Send + Sync
 			{
 				continue;
 			}
-			tracing::info!(?library_name, "checking for library");
-			if let Ok(Some(tg::artifact::Handle::File(found_library))) =
-				directory.try_get(&library_name).await
-			{
-				let found_library_id = found_library.id();
-				tracing::trace!(?found_library_id, ?library_name, "Found library file.");
-				*all_needed_libraries
-					.entry(library_name.clone())
-					.or_insert(None) = Some(dir_with_subpath.clone());
-				Box::pin(find_transitive_needed_libraries(
-					&found_library,
-					library_paths,
-					all_needed_libraries,
-					max_depth,
-					depth + 1,
-				))
-				.await?;
-				if found_all_libraries(all_needed_libraries) {
-					return Ok(());
-				}
+			let found_library_id = found_library.id();
+			tracing::trace!(?found_library_id, ?library_name, "Found library file.");
+			*all_needed_libraries
+				.entry(library_name.clone())
+				.or_insert(None) = Some(dir_with_subpath.clone());
+			Box::pin(find_transitive_needed_libraries(
+				&found_library,
+				library_paths,
+				all_needed_libraries,
+				directories,
+				max_depth,
+				depth + 1,
+			))
+			.await?;
+			if found_all_libraries(all_needed_libraries) {
+				return Ok(());
 			}
 		}
 	}
 
 	Ok(())
+}
+
+/// Iterate over the needed libraries that were located in a library path.
+fn located_libraries<H: BuildHasher>(
+	needed_libraries: &HashMap<String, Option<DirectoryWithSubpath>, H>,
+) -> impl Iterator<Item = (&String, &DirectoryWithSubpath)> {
+	needed_libraries
+		.iter()
+		.filter_map(|(name, dir_with_subpath)| {
+			dir_with_subpath
+				.as_ref()
+				.map(|dir_with_subpath| (name, dir_with_subpath))
+		})
 }
 
 /// Determine if all needed libraries have been found.


### PR DESCRIPTION
## Summary

- Reuse cached directory handles across tgld library-path resolution.
- Search checked-out paths first, falling back to the object graph for unmaterialized paths.

On a warm single-C-link probe, sandbox object requests fell from 84 across 22 distinct entries on main to 26 across 16 at the branch tip: **69% fewer requests.**

The remaining duplicate GETs are concentrated in the lib-symlink target (5 reads total), the GCC sysroot (3), one other directory (2), and the lib symlink itself (2); every other object is fetched once. The 26 total also includes three batched object requests.

## Full build result

`tg build ./packages/std` from an empty store, measured after the merge (`8fb64889`) against the same
tangram server binary used for the pre-merge arms.

| packages | wall | authorize calls | index batches | reads | authz busy |
|---|---|---|---|---|---|
| `0af0931f` (main, without this branch) | 4006 s | 1,584,565 | 1,075,812 | 143.3 M | 1531.1 s (38.2%) |
| `d03b79d0` (this branch, first three commits) | 3317 s | 857,094 | 435,156 | 82.5 M | 1136.8 s (34.2%) |
| `8fb64889` (this branch, merged) | **2943 s** | 600,623 | 191,659 | 32.2 M | 692.1 s (23.5%) |

Against main without the branch: **wall −26.5%, authorize calls −62.1%, index batches −82.2%,
datastore reads −77.5%, authorization busy time −54.8%.**

The last two rows share a server binary exactly (`2b9f9752`), so `d03b79d0 → 8fb64889` isolates the
tail of this branch — the library-path prefilter — at −374 s (−11.3%) and −61.0% reads. That matches
the direction of the probe, which fell from 38 requests to 26 over the same commits.

Two caveats. The first row's run was contended by concurrent work on this machine, so its 4006 s
wall is an overestimate and the −26.5% is a ceiling; the counts are contention-immune and the
reduction in reads and batches is not affected. And all three runs carry the same two local edits
working around an unreachable GNU mirror, verified byte-identical across the arms.

The wall-clock share is smaller than the read reduction because this build is serialization-bound:
median worker concurrency is 2 on 13 cores. Removing authorization reads relieves a cost that was
only partly on the critical path.
