### PR TITLE
fix(perl): preserve install metadata and configure glibc locales

### DIFF
--- a/packages/perl/patches/perl_no_fix_deps.patch
+++ b/packages/perl/patches/perl_no_fix_deps.patch
@@ -16,23 +16,17 @@
  	    chmod($SO_MODE, "$installarchlib/CORE/$file");
  	} else {
  	    chmod($NON_SO_MODE, "$installarchlib/CORE/$file");
-@@ -556,6 +554,19 @@
+@@ -550,11 +548,10 @@
+ 	unless $opts{silent};
+     print "  creating new version of $xto\n"
+ 	if $Is_VMS and -e $to and !$opts{silent};
+-    unless ($opts{notify} or File::Copy::copy($from, $to)) {
+-	# Might have been that F::C::c can't overwrite the target
++    unless ($opts{notify} or system('cp', '--', $from, $to) == 0) {
+ 	warn "Couldn't copy $from to $to: $!\n"
  	    unless -f $to and (chmod(0666, $to), unlink $to)
- 		   and File::Copy::copy($from, $to);
+-		   and File::Copy::copy($from, $to);
++		   and system('cp', '--', $from, $to) == 0;
      }
-+    # Preserve the Tangram dependencies xattr, which File::Copy drops on macOS.
-+    # Without it the installed copy of a wrapped executable loses its dependency
-+    # edges at check-in, orphaning the interpreter it references so that the
-+    # object cannot be authorized to consumers of the build.
-+    unless ($opts{notify} or $^O ne 'darwin') {
-+	my $attr = 'user.tangram.dependencies';
-+	my $hex = `xattr -px '$attr' "$from" 2>/dev/null`;
-+	if ($? == 0 and $hex =~ /\S/) {
-+	    $hex =~ s/\s+//g;
-+	    system('xattr', '-wx', $attr, $hex, $to) == 0
-+		or warn "Couldn't preserve $attr on $to\n";
-+	}
-+    }
      $packlist->{$xto} = { type => 'file' };
  }
- 

--- a/packages/perl/tangram.ts
+++ b/packages/perl/tangram.ts
@@ -41,7 +41,6 @@ export function deps() {
 export type Arg = std.autotools.Arg & std.deps.Arg<typeof deps>;
 
 export async function build(...args: tg.Args<Arg>) {
-	// Build configure args, including OS-specific flags.
 	const host =
 		(
 			await tg.Args.apply<Arg, tg.ValueOrMaybeMutationMap<Arg>, Arg>({
@@ -51,21 +50,33 @@ export async function build(...args: tg.Args<Arg>) {
 			})
 		).host ?? std.triple.host();
 
-	const configureArgs: Array<tg.Template.Arg> = [
-		"-des",
-		await tg`-Dscriptdir=${tg.output}/bin`,
-		"-Dinstallstyle=lib/perl5",
-		"-Dusethreads",
-		'-Doptimize="-O3 -pipe -fstack-protector -fwrapv -fno-strict-aliasing"',
-	];
-
-	// On Linux non-musl hosts, specify that LC_ALL uses name/value pairs.
+	let pre;
+	// The locale probe needs a non-C locale.
 	if (
 		std.triple.os(host) === "linux" &&
 		std.triple.environment(host) !== "musl"
 	) {
-		configureArgs.push("-Accflags=-DPERL_LC_ALL_USES_NAME_VALUE_PAIRS");
+		const config = tg.file(
+			"d_perl_lc_all_uses_name_value_pairs='define'\n" +
+				"d_perl_lc_all_separator='undef'\n" +
+				"d_perl_lc_all_category_positions_init='undef'\n",
+		);
+		pre = tg`cp ${config} config.over`;
 	}
+
+	const configure = {
+		body: {
+			args: [
+				"-des",
+				tg`-Dscriptdir=${tg.output}/bin`,
+				"-Dinstallstyle=lib/perl5",
+				"-Dusethreads",
+				'-Doptimize="-O3 -pipe -fstack-protector -fwrapv -fno-strict-aliasing"',
+			],
+			command: "bash Configure",
+		},
+		...(pre ? { pre } : {}),
+	};
 
 	const arg = await std.autotools.arg(
 		{
@@ -73,12 +84,7 @@ export async function build(...args: tg.Args<Arg>) {
 			source: source(),
 			buildInTree: true,
 			prefixArg: "-Dprefix=",
-			phases: {
-				configure: {
-					args: configureArgs,
-					command: "bash Configure",
-				},
-			},
+			phases: { configure },
 		},
 		...args,
 	);

--- a/packages/std/autotools/perl.tg.ts
+++ b/packages/std/autotools/perl.tg.ts
@@ -44,21 +44,30 @@ export async function build(arg?: tg.Unresolved<Arg>) {
 
 	const sourceDir = source_ ?? source(os);
 
-	const configure = {
-		args: [
-			"-des",
-			tg`-Dscriptdir=${tg.output}/bin`,
-			"-Dinstallstyle=lib/perl5",
-			"-Dusethreads",
-			'-Doptimize="-O3 -pipe -fstack-protector -fwrapv -fno-strict-aliasing"',
-		],
-		command: "bash Configure",
-	};
-
-	// On Linux non-musl hosts, specify that LC_ALL uses name/value pairs.
+	let pre;
+	// The locale probe needs a non-C locale.
 	if (os === "linux" && std.triple.environment(host) !== "musl") {
-		configure.args.push("-Accflags=-DPERL_LC_ALL_USES_NAME_VALUE_PAIRS");
+		const config = tg.file(
+			"d_perl_lc_all_uses_name_value_pairs='define'\n" +
+				"d_perl_lc_all_separator='undef'\n" +
+				"d_perl_lc_all_category_positions_init='undef'\n",
+		);
+		pre = tg`cp ${config} config.over`;
 	}
+
+	const configure = {
+		body: {
+			args: [
+				"-des",
+				tg`-Dscriptdir=${tg.output}/bin`,
+				"-Dinstallstyle=lib/perl5",
+				"-Dusethreads",
+				'-Doptimize="-O3 -pipe -fstack-protector -fwrapv -fno-strict-aliasing"',
+			],
+			command: "bash Configure",
+		},
+		...(pre ? { pre } : {}),
+	};
 
 	const phases = { configure };
 

--- a/packages/std/autotools/perl_no_fix_deps.patch
+++ b/packages/std/autotools/perl_no_fix_deps.patch
@@ -16,23 +16,17 @@
  	    chmod($SO_MODE, "$installarchlib/CORE/$file");
  	} else {
  	    chmod($NON_SO_MODE, "$installarchlib/CORE/$file");
-@@ -556,6 +554,19 @@
+@@ -550,11 +548,10 @@
+ 	unless $opts{silent};
+     print "  creating new version of $xto\n"
+ 	if $Is_VMS and -e $to and !$opts{silent};
+-    unless ($opts{notify} or File::Copy::copy($from, $to)) {
+-	# Might have been that F::C::c can't overwrite the target
++    unless ($opts{notify} or system('cp', '--', $from, $to) == 0) {
+ 	warn "Couldn't copy $from to $to: $!\n"
  	    unless -f $to and (chmod(0666, $to), unlink $to)
- 		   and File::Copy::copy($from, $to);
+-		   and File::Copy::copy($from, $to);
++		   and system('cp', '--', $from, $to) == 0;
      }
-+    # Preserve the Tangram dependencies xattr, which File::Copy drops on macOS.
-+    # Without it the installed copy of a wrapped executable loses its dependency
-+    # edges at check-in, orphaning the interpreter it references so that the
-+    # object cannot be authorized to consumers of the build.
-+    unless ($opts{notify} or $^O ne 'darwin') {
-+	my $attr = 'user.tangram.dependencies';
-+	my $hex = `xattr -px '$attr' "$from" 2>/dev/null`;
-+	if ($? == 0 and $hex =~ /\S/) {
-+	    $hex =~ s/\s+//g;
-+	    system('xattr', '-wx', $attr, $hex, $to) == 0
-+		or warn "Couldn't preserve $attr on $to\n";
-+	}
-+    }
      $packlist->{$xto} = { type => 'file' };
  }
- 


### PR DESCRIPTION
Perl's installer used `File::Copy`, dropping Tangram metadata. Use std's patched `cp` in both recipes and replace the glibc compiler define with `config.over`. This is still a hack to handle a failing locale probe, but it's at least the right hack now.
